### PR TITLE
docs(maintenance): update Ki release status

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Documentation is organized by reader intent, not by document type.
 
 - New to the project? Start with [`architecture/overview.md`](architecture/overview.md).
 - Setting up a dev environment? See [`contributing/development.md`](contributing/development.md).
+- Maintaining the Ki-Buddy/Ki-Core fork? Read the [`upstream release analysis and target alignment`](contributing/upstream-release-analysis-and-target-alignment.zh-CN.md) and the [`maintainer release handbook`](contributing/maintainer-release-and-maintenance-handbook.zh-CN.md).
 - Writing code? The entry point for code-style, linting, formatting, and commit rules is [`AGENTS.md`](../AGENTS.md) at the repo root.
 - Deploying a server? [`guides/deploy-server.md`](guides/deploy-server.md).
 

--- a/docs/contributing/maintainer-release-and-maintenance-handbook.zh-CN.md
+++ b/docs/contributing/maintainer-release-and-maintenance-handbook.zh-CN.md
@@ -1,0 +1,526 @@
+# Ki-Buddy 与 Ki-Core 仓库管理者发版和维护手册
+
+> 当前管理者：`xlihub`  
+> 最近核对时间：2026-08-05  
+> 适用仓库：`xlihub/Ki-Buddy`、`xlihub/Ki-Core`
+
+本文按实际工作场景说明仓库管理者每天、每次上游更新和每次发版需要处理的事项。读完后，管理者应当能够判断下一步该同步哪个仓库、合并哪个 PR、批准哪个 workflow，以及遇到失败时是否允许重试或必须创建新版本。
+
+流程依据见[上游发版流程分析与 Ki 双仓目标流程](upstream-release-analysis-and-target-alignment.zh-CN.md)。
+
+## 1. 当前过渡状态
+
+2026-08-05 时，目标流程尚未全部实现。当前不得直接按后文的正式发版步骤发布产品。
+
+### Ki-Core 当前状态
+
+- `product/main` 已包含 `0.1.0` 发布元数据，映射 AionCore `v0.1.58`。
+- Release PR #3 已合并。
+- 没有 `ki-core-v0.1.0` tag，也没有公开 Ki-Core Release。
+- [PR #6](https://github.com/xlihub/Ki-Core/pull/6) 是 Release Please 状态错误生成的 `0.2.0` PR，不应合并。
+- 正式发布 workflow 依赖 Candidate run，后续将按确认方案简化。
+- `ki-core-stable` Environment 已配置 `xlihub` 为 required reviewer，允许自审，管理员不能绕过审批。
+
+### Ki-Buddy 当前状态
+
+- 远端 `product/main` 尚未建立独立发版体系。
+- 本地功能分支正在实现 Ki-Core 产物消费。
+- `kiCore.tag` 仍为空，没有可用于正式构建的 Ki-Core Release。
+- 没有 Ki-Buddy 产品 CHANGELOG 和版本映射。
+
+### 过渡期允许的操作
+
+- 查询、同步和比较上游。
+- 修改并验证发布 workflow。
+- 运行手工 Candidate Build 做联调。
+- 创建实现目标流程的普通 PR。
+
+### 过渡期禁止的操作
+
+- 合并 Ki-Core PR #6。
+- 为当前 `0.1.0` 手工创建正式 tag。
+- 把 Candidate Actions artifact 当作 Ki-Buddy 正式依赖。
+- 在 Ki-Buddy 的正式配置中写入不存在的 Ki-Core tag。
+- 为修复失败发布覆盖已有 tag 或 Release 资产。
+
+## 2. 管理者日常检查
+
+不需要持续盯住 Actions。建议在准备同步或发版时进行以下检查。
+
+### 2.1 查看两个上游的最新正式版本
+
+```bash
+gh release view --repo iOfficeAI/AionCore --json tagName,publishedAt,url
+gh release view --repo iOfficeAI/AionUi --json tagName,publishedAt,url
+```
+
+同时查看 Ki 产品当前版本：
+
+```bash
+gh release view --repo xlihub/Ki-Core --json tagName,publishedAt,url
+gh release view --repo xlihub/Ki-Buddy --json tagName,publishedAt,url
+```
+
+仓库没有 Release 时，命令失败属于预期状态，应改用：
+
+```bash
+gh release list --repo xlihub/Ki-Core
+gh release list --repo xlihub/Ki-Buddy
+```
+
+### 2.2 查看待处理 PR
+
+```bash
+gh pr list --repo xlihub/Ki-Core --state open
+gh pr list --repo xlihub/Ki-Buddy --state open
+```
+
+重点识别：
+
+- 上游同步 PR。
+- Release Please 创建的 Ki-Core Release PR。
+- Ki-Buddy 版本准备 PR。
+- 版本号异常跳升的 Release PR。
+
+### 2.3 查看最近失败的 workflow
+
+```bash
+gh run list --repo xlihub/Ki-Core --limit 20
+gh run list --repo xlihub/Ki-Buddy --limit 20
+```
+
+检查具体失败：
+
+```bash
+gh run view <run-id> --repo <owner/repo> --log-failed
+```
+
+先判断失败属于代码、上游同步、版本元数据、平台构建还是权限审批，再决定重试。不得把所有失败都当作临时网络问题。
+
+## 3. 场景：AionCore 发布了新版本
+
+目标：让 Ki-Core 在不修改 AionCore 源码语义的情况下发布一个对应的 Ki-Core 产品版本。
+
+### 3.1 确认上游 Release 完整
+
+```bash
+gh release view <aioncore-tag> \
+  --repo iOfficeAI/AionCore \
+  --json tagName,targetCommitish,assets,url
+```
+
+应确认：
+
+- tag 是正式版本，不是 test tag。
+- 六个平台 archive 存在。
+- `aioncore-checksums.txt` 存在。
+- Release workflow 已完成。
+
+资产仍在上传时不要开始 Ki-Core 正式版本准备。AionCore 上游会先公开 Release，再完成资产上传，通常需要等待十几分钟。
+
+### 3.2 更新 Ki-Core 上游镜像
+
+Ki-Core `main` 只承担上游镜像职责。同步时应记录：
+
+- AionCore tag。
+- tag peeled commit。
+- 上游 `main` 当前 commit。
+
+产品基线应固定在正式 tag，不应把 tag 之后的上游 `main` 提交带入 Ki-Core Release。
+
+### 3.3 创建上游同步 PR
+
+同步 PR 进入 Ki-Core `product/main`，内容应包括：
+
+- 合入指定 AionCore tag。
+- 更新当前上游 tag 和 peeled commit。
+- 为下一 Ki-Core 版本准备映射记录。
+- 更新 `CHANGELOG.ki-core.md` 的上游同步说明。
+
+短期没有 Ki-Core 源码二次开发时，PR 相对 AionCore tag 不应出现 Rust 源码、API、协议或数据库迁移差异。
+
+### 3.4 审查和合并同步 PR
+
+合并前确认：
+
+- CI 成功。
+- 映射 tag 与 commit 能在上游远端验证。
+- `CHANGELOG.md` 保持上游内容。
+- `CHANGELOG.ki-core.md` 只记录 Ki-Core 产品内容和本次上游同步。
+- 没有修改 AionCore workspace version 来代替 Ki-Core 产品版本。
+
+合并后，Release Please 应创建或更新 Ki-Core Release PR。
+
+## 4. 场景：准备 Ki-Core 正式版本
+
+本节描述目标流程。过渡期应先完成流程简化。
+
+### 4.1 检查 Release PR 版本
+
+Release PR 应满足：
+
+- base 为 `product/main`。
+- 版本符合 Ki-Core 自己的 SemVer。
+- 纯 AionCore 同步通常增加 patch。
+- CHANGELOG 同时能看到 Ki-Core 变化和同步的 AionCore tag。
+- 映射表中没有重复 Ki-Core 版本或 tag。
+
+若纯同步从 `0.1.0` 跳到 `0.2.0`，不要合并。先检查：
+
+- 上一 Ki-Core Release tag 是否真实存在。
+- Release Please manifest 是否与已发布版本一致。
+- Release PR 合并提交是否进入了创建 tag/Release 的发布分支。
+- Release Please 是否仍在使用只创建 PR、跳过 Release 的配置。
+
+### 4.2 合并 Release PR
+
+合并 Release PR 表示管理者接受：
+
+- 本次 Ki-Core 产品版本。
+- 本次 AionCore 映射。
+- 本次 Ki-Core CHANGELOG。
+- 随后创建正式 tag 和 GitHub Release。
+
+合并后检查 Release Please run，确认它进入发布 job，没有继续生成下一版本 PR。
+
+### 4.3 批准正式发布
+
+当 `ki-core-stable` Environment 请求审批时，`xlihub` 需要核对：
+
+- 请求来自 Ki-Core 正式发布 workflow。
+- commit 是刚合并的 `product/main` Release commit。
+- tag 与 Release PR 版本一致。
+- 映射指向已验证的 AionCore tag。
+
+确认后批准。当前 Environment 允许 `xlihub` 审批自己的部署请求，符合单维护者阶段的实际情况。
+
+### 4.4 检查发布结果
+
+```bash
+gh release view <ki-core-tag> \
+  --repo xlihub/Ki-Core \
+  --json tagName,targetCommitish,isDraft,isPrerelease,assets,url
+```
+
+应看到：
+
+- tag 指向 Release commit。
+- 六个平台 archive 全部存在。
+- checksums 存在。
+- Release Notes 与 `CHANGELOG.ki-core.md` 一致。
+- 映射能追溯到 AionCore tag 和 peeled commit。
+
+只有上述检查通过后，Ki-Buddy 才能更新正式 pin。
+
+## 5. 场景：Ki-Core 构建失败
+
+### 5.1 tag 或 Release 尚未创建
+
+- 查看失败 job 日志。
+- 修复代码或 workflow，走普通 PR。
+- 重新合并新的 Release PR或重新触发批准后的发布入口。
+- 不提前手工创建 tag。
+
+### 5.2 Release 已创建但资产不完整
+
+AionCore 上游允许公开 Release 先于资产上传。Ki-Core 目标流程采用同一状态机后，也可能出现短暂的不完整 Release。
+
+处理原则：
+
+- 构建仍在进行时等待完成。
+- 明确的临时 runner 失败可以重跑同一个 workflow。
+- 不得用不同 commit 重建同一个 tag。
+- 已公开 Release 若最终无法完成，应标记问题并创建新的 Ki-Core patch 版本。
+- 不覆盖已经发布的同名资产。
+
+### 5.3 单个平台持续失败
+
+- 不允许 Ki-Buddy 固定该 Ki-Core 版本。
+- 检查是否为上游同平台也存在的问题。
+- 检查 Rust target、runner、GLIBC baseline 和 archive 命名。
+- 修复后发布新的 patch；不要修改已公开 tag 指向。
+
+## 6. 场景：Ki-Core 发布后准备 Ki-Buddy 版本
+
+目标：把一个完整 Ki-Core Release、AionUi 上游变化和 Ki-Buddy 定制变化放入同一个 Ki-Buddy 产品版本。
+
+### 6.1 确认 Ki-Core 可消费
+
+```bash
+gh release view <ki-core-tag> \
+  --repo xlihub/Ki-Core \
+  --json tagName,targetCommitish,assets,url
+```
+
+确认六个平台资产和 checksums 完整。还应从 Ki-Core 映射确认它对应的 AionCore tag。
+
+### 6.2 确认 AionUi 上游同步范围
+
+Ki-Buddy 的版本准备 PR应明确：
+
+- 上一个已同步的 AionUi tag 或 commit。
+- 本次同步到的 AionUi tag 或 commit。
+- 上游 CHANGELOG 对应范围。
+- 需要人工解决的定制代码冲突。
+
+Ki-Buddy 不要求等待 AionUi 发布一个正好对应最新 AionCore 的版本。上游真实流程本身允许 AionUi 与 AionCore 不同时发布。
+
+### 6.3 汇总 Ki-Buddy 定制变化
+
+从上一个 Ki-Buddy tag 到当前 `product/main`，收集用户可见的 `feat`、`fix`、`perf` 和必要文档变化。不要把普通依赖整理、workflow 调试和纯格式提交写成产品功能。
+
+### 6.4 创建 Ki-Buddy 版本准备 PR
+
+版本准备 PR应同时更新：
+
+- Ki-Buddy 自身版本。
+- 固定的 Ki-Core tag。
+- Ki-Buddy 与 AionUi、Ki-Core、AionCore 的映射。
+- `CHANGELOG.ki-buddy.md`。
+
+`CHANGELOG.ki-buddy.md` 的单个版本条目使用以下结构：
+
+```markdown
+## Ki-Buddy X.Y.Z
+
+### Ki-Buddy 定制变化
+
+### AionUi 上游更新
+
+### Ki-Core 更新
+
+- Ki-Core: ki-core-vA.B.C
+- AionCore: vD.E.F
+```
+
+上游 `CHANGELOG.md` 不应改写为 Ki-Buddy 内容。
+
+## 7. 场景：发布 Ki-Buddy
+
+本节描述目标流程，当前尚未建立对应正式 workflow。
+
+### 7.1 合并版本准备 PR
+
+合并前确认：
+
+- Ki-Buddy CI 成功。
+- 正式构建固定的是 Ki-Core Release tag，不是 Candidate run。
+- 所有 checksums 与 Ki-Core Release 一致。
+- `bun.lock` 仅包含当前依赖变化，没有无关的大范围重写。
+- Ki-Buddy CHANGELOG 同时包含定制、AionUi 上游和 Ki-Core 三类变化。
+
+### 7.2 创建正式 tag
+
+版本准备 PR 合并后，由 `xlihub` 从合并后的 `product/main` 创建正式 tag。建议采用 `ki-buddy-vX.Y.Z`，避免产品 tag 与上游 AionUi `vX.Y.Z` 混淆。
+
+创建前再次确认远端没有同名 tag。已经存在的 tag 不得移动。
+
+### 7.3 观察构建
+
+正式 tag 应触发：
+
+- 代码质量检查。
+- 六平台桌面构建。
+- 固定 Ki-Core Release 下载与 checksum 验证。
+- Draft Release 创建。
+
+Candidate run 只用于版本准备前联调，不得传入正式构建。
+
+### 7.4 审批和发布 Draft
+
+管理者检查：
+
+- 六个平台安装包齐全。
+- updater metadata 中的版本与 tag 规则一致。
+- Release Notes 来自 `CHANGELOG.ki-buddy.md`。
+- Ki-Core 和 AionCore 映射写明。
+- Draft 没有混入 Actions 临时产物。
+
+检查通过后再公开 Release。单维护者阶段由 `xlihub` 触发并批准发布。
+
+## 8. 场景：只发布 Ki-Buddy 定制修复
+
+Ki-Buddy 可以在 Ki-Core 没有新版本时独立发布，与 AionUi 的 `--skip-core` 能力一致。
+
+版本准备时：
+
+- Ki-Core pin 保持不变。
+- 映射记录继续指向同一个 Ki-Core/AionCore 组合。
+- CHANGELOG 的 Ki-Core 部分写明“本版本未更新 Ki-Core”。
+- Ki-Buddy patch 版本按自身修复语义增加。
+
+不得为了让版本看起来同步而创建一个内容完全相同的 Ki-Core Release。
+
+## 9. 场景：Ki-Core 未来开始源码二次开发
+
+Ki-Core 自有源码变化只进入 `product/main`，并使用普通 PR：
+
+- `feat`：产品能力变化。
+- `fix`：Ki-Core 自有修复。
+- `refactor`：无用户行为变化的内部调整。
+
+发版时：
+
+- `CHANGELOG.ki-core.md` 分别列出 Ki-Core 自有变化和 AionCore 上游同步。
+- 映射仍然记录 AionCore 基线，不因 Ki-Core 有 overlay 而失效。
+- 上游同步 PR需要处理 overlay 冲突并运行完整测试。
+- 不再使用“相对上游 tag 不允许任何 Rust 源码差异”的短期规则，改为维护允许的 overlay 和兼容性测试。
+
+该变化不要求删除 `product/main`、独立版本或映射表，现有产品结构可以继续使用。
+
+## 10. 场景：上游同步发生冲突
+
+### Ki-Core
+
+短期没有源码二次开发时，冲突通常来自发布配置或文档：
+
+- 保留 AionCore 的 Rust、Cargo 和 migration 变化。
+- 保留 Ki-Core 的产品版本、映射和发布 workflow。
+- 上游 `CHANGELOG.md` 采用上游版本。
+- Ki-Core 内容继续写入 `CHANGELOG.ki-core.md`。
+
+### Ki-Buddy
+
+Ki-Buddy 已进行定制开发，冲突需要按用户行为处理：
+
+- 先理解 AionUi 上游改动的目的。
+- 再决定定制行为继续保留、适配上游，还是被上游能力替代。
+- 冲突解决 PR必须运行受影响测试。
+- CHANGELOG 分别记录上游变化和 Ki-Buddy 行为变化。
+
+不得用整文件覆盖快速消除冲突，这会丢失上游更新或产品定制。
+
+## 11. 场景：发现错误版本 PR
+
+典型表现：
+
+- 纯 patch 同步产生 minor。
+- Release PR 刚合并又出现下一版本 PR。
+- CHANGELOG 重复包含已经发布的提交。
+- 映射仍指向旧 AionCore tag。
+
+处理步骤：
+
+1. 不合并错误 PR。
+2. 检查上一产品 tag 和 Release 是否存在。
+3. 检查 Release Please manifest。
+4. 检查上一 Release PR 合并后是否执行了创建 tag/Release 的 job。
+5. 修复 workflow 状态机并通过普通 PR 合并。
+6. 关闭错误 Release PR。
+7. 重新运行 Release Please，让它基于正确的已发布状态生成版本。
+
+不要直接编辑错误 PR 把版本号改小。Release Please 的已发布状态仍然错误，下一次还会重复发生。
+
+## 12. 场景：需要回退产品
+
+### Ki-Buddy 回退 Ki-Core
+
+如果新 Ki-Core Release 存在问题：
+
+- 创建 Ki-Buddy patch PR，把 pin 改回上一完整 Ki-Core Release。
+- 更新 Ki-Buddy 映射和 CHANGELOG。
+- 重新发布新的 Ki-Buddy patch。
+- 不移动旧 Ki-Buddy tag。
+
+### Ki-Core 回退 AionCore
+
+如果需要重新采用旧 AionCore 基线：
+
+- 创建新的 Ki-Core patch 或 minor，按产品兼容性决定。
+- 新映射记录指向旧 AionCore tag。
+- CHANGELOG 说明回退原因和影响。
+- 发布新的 Ki-Core tag。
+- 不修改已经发布的映射记录。
+
+## 13. 场景：需要重跑 workflow
+
+允许重跑：
+
+- 网络下载失败。
+- GitHub runner 临时故障。
+- 同一 commit、同一 tag、同一 workflow 的可重复构建。
+- Draft Release 尚未公开，且重跑不会覆盖不可变资产。
+
+不允许直接重跑并覆盖：
+
+- 代码或 lockfile 已变化。
+- tag 已指向不同 commit。
+- 已公开资产内容需要变化。
+- checksums 与原资产不一致。
+
+后一类情况必须创建新 patch 版本。
+
+## 14. 定期维护
+
+建议每月或发布流程发生变化后执行。
+
+### GitHub 设置
+
+- 确认 `main` 和 `product/main` ruleset 仍生效。
+- 确认 `ki-core-v*` tag 禁止更新和删除。
+- 确认正式发布 Environment 的 reviewer 仍为当前仓库 owner。
+- 单维护者阶段保持 `prevent self-review` 关闭。
+- 增加维护者后重新评估是否要求独立审批人。
+- 检查 repository variables 是否仍启用正确的 fork automation。
+
+### Actions
+
+- 检查 action major version 更新。
+- 检查 runner image、Rust、Node、Bun 和 Electron 版本变化。
+- 检查六平台最近是否都有成功构建。
+- 检查 Release workflow 是否出现长期等待或大量重复运行。
+- 不因单次耗时就删除 PR required checks；调整前先区分 PR 验证、main push 验证和正式构建的职责。
+
+### 版本与映射
+
+- 检查每个公开 Ki-Core tag 都有唯一映射。
+- 检查每个公开 Ki-Buddy tag 都能追溯到 AionUi、Ki-Core 和 AionCore。
+- 检查产品 CHANGELOG 与 Release Notes 一致。
+- 检查上游 CHANGELOG 没有被产品内容改写。
+
+### 资产
+
+- 随机抽查 Release checksums。
+- 检查 archive 内 executable 名称。
+- 检查 updater metadata 与产品 tag 版本一致。
+- 检查旧 Release 资产没有被替换。
+
+## 15. 每次发版的管理者检查表
+
+### Ki-Core
+
+- [ ] AionCore 正式 Release 资产完整。
+- [ ] Ki-Core `main` 已更新上游引用。
+- [ ] `product/main` 固定在明确的 AionCore tag。
+- [ ] 映射 tag 与 peeled commit 正确。
+- [ ] Release PR 版本符合 Ki-Core SemVer。
+- [ ] 双 CHANGELOG 职责没有混用。
+- [ ] CI 成功。
+- [ ] `xlihub` 批准正确的 Release commit。
+- [ ] 六平台资产和 checksums 完整。
+- [ ] Ki-Core Release 验证后再通知 Ki-Buddy 更新 pin。
+
+### Ki-Buddy
+
+- [ ] AionUi 上游同步范围明确。
+- [ ] Ki-Buddy 定制变化已汇总。
+- [ ] 固定的是完整 Ki-Core Release tag。
+- [ ] Ki-Core 与 AionCore 映射正确。
+- [ ] `CHANGELOG.ki-buddy.md` 包含三类变化。
+- [ ] `bun.lock` 没有无关的大范围变化。
+- [ ] CI 和六平台构建成功。
+- [ ] updater metadata 与正式 tag 一致。
+- [ ] Draft Release 资产和说明检查完成。
+- [ ] 由 `xlihub` 公开发布。
+
+## 16. 权限与职责边界
+
+当前只有一个维护者，因此：
+
+- `xlihub` 可以触发并批准发布。
+- 发布审批允许 self-review。
+- 自动化可以创建 PR、tag 和 Release，但不能自行决定是否接受上游版本。
+- 自动化不能覆盖已公开 tag 和资产。
+- 版本号、上游映射、CHANGELOG 和公开 Release 的最终责任属于 `xlihub`。
+
+未来增加维护者后，优先调整审批规则，不需要重新设计双仓分支和版本模型。

--- a/docs/contributing/maintainer-release-and-maintenance-handbook.zh-CN.md
+++ b/docs/contributing/maintainer-release-and-maintenance-handbook.zh-CN.md
@@ -1,24 +1,24 @@
 # Ki-Buddy 与 Ki-Core 仓库管理者发版和维护手册
 
-> 当前管理者：`xlihub`  
-> 最近核对时间：2026-08-05  
+> 当前管理者：`xlihub`
+> 最近核对时间：2026-08-06
 > 适用仓库：`xlihub/Ki-Buddy`、`xlihub/Ki-Core`
 
 本文按实际工作场景说明仓库管理者每天、每次上游更新和每次发版需要处理的事项。读完后，管理者应当能够判断下一步该同步哪个仓库、合并哪个 PR、批准哪个 workflow，以及遇到失败时是否允许重试或必须创建新版本。
 
 流程依据见[上游发版流程分析与 Ki 双仓目标流程](upstream-release-analysis-and-target-alignment.zh-CN.md)。
 
-## 1. 当前过渡状态
+## 1. 首次迁移状态
 
-2026-08-05 时，目标流程尚未全部实现。当前不得直接按后文的正式发版步骤发布产品。
+2026-08-06 时，远端仍未完成第一次 Ki-Core 正式发布。发布流程改造合并前，不得直接按后文的常规发版步骤发布产品。
 
 ### Ki-Core 当前状态
 
-- `product/main` 已包含 `0.1.0` 发布元数据，映射 AionCore `v0.1.58`。
+- 第一次正式发布的目标是 `Ki-Core 0.1.0 ↔ AionCore v0.1.59`。
 - Release PR #3 已合并。
 - 没有 `ki-core-v0.1.0` tag，也没有公开 Ki-Core Release。
 - [PR #6](https://github.com/xlihub/Ki-Core/pull/6) 是 Release Please 状态错误生成的 `0.2.0` PR，不应合并。
-- 正式发布 workflow 依赖 Candidate run，后续将按确认方案简化。
+- 发布流程改造将 Candidate 从正式发布前置条件中移除，并增加 `release-current` 手动入口处理第一次发布。
 - `ki-core-stable` Environment 已配置 `xlihub` 为 required reviewer，允许自审，管理员不能绕过审批。
 
 ### Ki-Buddy 当前状态
@@ -28,14 +28,14 @@
 - `kiCore.tag` 仍为空，没有可用于正式构建的 Ki-Core Release。
 - 没有 Ki-Buddy 产品 CHANGELOG 和版本映射。
 
-### 过渡期允许的操作
+### 首次发布前允许的操作
 
 - 查询、同步和比较上游。
 - 修改并验证发布 workflow。
 - 运行手工 Candidate Build 做联调。
 - 创建实现目标流程的普通 PR。
 
-### 过渡期禁止的操作
+### 首次发布前禁止的操作
 
 - 合并 Ki-Core PR #6。
 - 为当前 `0.1.0` 手工创建正式 tag。
@@ -134,8 +134,9 @@ Ki-Core `main` 只承担上游镜像职责。同步时应记录：
 
 - 合入指定 AionCore tag。
 - 更新当前上游 tag 和 peeled commit。
-- 为下一 Ki-Core 版本准备映射记录。
-- 更新 `CHANGELOG.ki-core.md` 的上游同步说明。
+- 保持 Ki-Core 产品发布配置不被上游文件覆盖。
+
+纯上游同步应使用能够产生 patch 版本的 Conventional Commit，例如 `fix(upstream): sync AionCore vX.Y.Z`。该提交会由 Release Please 写入下一版 `CHANGELOG.ki-core.md`，并在 Release PR 分支自动增加版本映射。不要使用不会触发版本变化的 `chore(upstream)` 作为常规同步提交标题。
 
 短期没有 Ki-Core 源码二次开发时，PR 相对 AionCore tag 不应出现 Rust 源码、API、协议或数据库迁移差异。
 
@@ -153,7 +154,7 @@ Ki-Core `main` 只承担上游镜像职责。同步时应记录：
 
 ## 4. 场景：准备 Ki-Core 正式版本
 
-本节描述目标流程。过渡期应先完成流程简化。
+本节描述流程改造合并后的常规流程。
 
 ### 4.1 检查 Release PR 版本
 
@@ -181,11 +182,13 @@ Release PR 应满足：
 - 本次 Ki-Core CHANGELOG。
 - 随后创建正式 tag 和 GitHub Release。
 
-合并后检查 Release Please run，确认它进入发布 job，没有继续生成下一版本 PR。
+保留 Release Please 生成的 `chore(product/main): release ...` 标题。使用 GitHub 默认 merge commit 或 squash merge 都可以，但不要把该标题从最终提交信息中删除。
+
+合并后检查 Release Please run，确认它进入 `Create Ki-Core Release` job，没有继续生成下一版本 PR。
 
 ### 4.3 批准正式发布
 
-当 `ki-core-stable` Environment 请求审批时，`xlihub` 需要核对：
+当 Release Please 的 `Create Ki-Core Release` job 请求 `ki-core-stable` Environment 审批时，`xlihub` 需要核对：
 
 - 请求来自 Ki-Core 正式发布 workflow。
 - commit 是刚合并的 `product/main` Release commit。
@@ -194,7 +197,19 @@ Release PR 应满足：
 
 确认后批准。当前 Environment 允许 `xlihub` 审批自己的部署请求，符合单维护者阶段的实际情况。
 
-### 4.4 检查发布结果
+### 4.4 第一次发布 `0.1.0`
+
+流程改造 PR 合并并通过 CI 后，第一次发布不再创建新的 Release PR：
+
+1. 关闭错误的 PR #6，不合并。
+2. 在 Actions 中打开 `Release Please`。
+3. 选择 `Run workflow`，分支选择 `product/main`，`operation` 选择 `release-current`。
+4. 在 `ki-core-stable` Environment 审批 `Create Ki-Core Release` job。
+5. Release Please 创建 `ki-core-v0.1.0` 和公开 Release，并显式启动 `Ki-Core Stable Release` 构建。
+
+不得用 `git tag` 或 GitHub Release 页面代替该入口。
+
+### 4.5 检查发布结果
 
 ```bash
 gh release view <ki-core-tag> \
@@ -231,7 +246,7 @@ AionCore 上游允许公开 Release 先于资产上传。Ki-Core 目标流程采
 - 明确的临时 runner 失败可以重跑同一个 workflow。
 - 不得用不同 commit 重建同一个 tag。
 - 已公开 Release 若最终无法完成，应标记问题并创建新的 Ki-Core patch 版本。
-- 不覆盖已经发布的同名资产。
+- 只允许对同一 tag、同一 commit 重跑 `Ki-Core Stable Release`。workflow 会按上游方式覆盖同名资产并重新生成 checksums；不得手工上传来源不同的文件。
 
 ### 5.3 单个平台持续失败
 
@@ -407,7 +422,7 @@ Ki-Buddy 已进行定制开发，冲突需要按用户行为处理：
 4. 检查上一 Release PR 合并后是否执行了创建 tag/Release 的 job。
 5. 修复 workflow 状态机并通过普通 PR 合并。
 6. 关闭错误 Release PR。
-7. 重新运行 Release Please，让它基于正确的已发布状态生成版本。
+7. 首次发布使用 `release-current`；后续再运行 `update-pr`，让 Release Please 基于正确的已发布状态生成版本。
 
 不要直接编辑错误 PR 把版本号改小。Release Please 的已发布状态仍然错误，下一次还会重复发生。
 
@@ -439,13 +454,13 @@ Ki-Buddy 已进行定制开发，冲突需要按用户行为处理：
 - 网络下载失败。
 - GitHub runner 临时故障。
 - 同一 commit、同一 tag、同一 workflow 的可重复构建。
-- Draft Release 尚未公开，且重跑不会覆盖不可变资产。
+- 同一 tag 和 commit 的正式资产构建，允许由 `Ki-Core Stable Release` 使用 `--clobber` 重建整套资产和 checksums。
 
 不允许直接重跑并覆盖：
 
 - 代码或 lockfile 已变化。
 - tag 已指向不同 commit。
-- 已公开资产内容需要变化。
+- 需要使用不同 commit 或人工替换部分公开资产。
 - checksums 与原资产不一致。
 
 后一类情况必须创建新 patch 版本。

--- a/docs/contributing/maintainer-release-and-maintenance-handbook.zh-CN.md
+++ b/docs/contributing/maintainer-release-and-maintenance-handbook.zh-CN.md
@@ -8,40 +8,51 @@
 
 流程依据见[上游发版流程分析与 Ki 双仓目标流程](upstream-release-analysis-and-target-alignment.zh-CN.md)。
 
-## 1. 首次迁移状态
+## 1. 首次迁移结果与当前状态
 
-2026-08-06 时，远端仍未完成第一次 Ki-Core 正式发布。发布流程改造合并前，不得直接按后文的常规发版步骤发布产品。
+Ki-Core 第一次正式发布已于 2026-08-06 完成。后续 Ki-Core 版本直接按第 3 至第 5 节的常规流程操作，不再重复首次发布恢复步骤。
 
 ### Ki-Core 当前状态
 
-- 第一次正式发布的目标是 `Ki-Core 0.1.0 ↔ AionCore v0.1.59`。
-- Release PR #3 已合并。
-- 没有 `ki-core-v0.1.0` tag，也没有公开 Ki-Core Release。
-- [PR #6](https://github.com/xlihub/Ki-Core/pull/6) 是 Release Please 状态错误生成的 `0.2.0` PR，不应合并。
-- 发布流程改造将 Candidate 从正式发布前置条件中移除，并增加 `release-current` 手动入口处理第一次发布。
-- `ki-core-stable` Environment 已配置 `xlihub` 为 required reviewer，允许自审，管理员不能绕过审批。
+- [Ki-Core 0.1.0](https://github.com/xlihub/Ki-Core/releases/tag/ki-core-v0.1.0) 已公开发布，对应 AionCore `v0.1.59`。
+- AionCore peeled commit 为 `815e61ed9bbe942339347dc1e69ddce176cded76`。
+- 最终 Release PR 是 [PR #9](https://github.com/xlihub/Ki-Core/pull/9)，合并提交和 tag 目标均为 `209e6844d39bac0762c61e198c1ba3a007f9dd2e`。
+- [Release Please run](https://github.com/xlihub/Ki-Core/actions/runs/31068696569) 与 [Ki-Core Stable Release run](https://github.com/xlihub/Ki-Core/actions/runs/31068791622) 均成功。
+- Release 包含六个平台 archive 和 `ki-core-checksums.txt`，不是 Draft 或 Prerelease。
+- PR #9 已标记为 `autorelease: tagged`。
+- `ki-core-stable` Environment 由 `xlihub` 审批，单维护者阶段允许审批自己的发布请求。
+
+### 首次发布故障记录
+
+首次发布恢复过程出现过三类状态：
+
+1. [PR #3](https://github.com/xlihub/Ki-Core/pull/3) 的正文被改写为普通中文 PR 描述，Release Please 无法解析版本区块。
+2. [PR #8](https://github.com/xlihub/Ki-Core/pull/8) 保留了可解析正文，但分支 `release/ki-core-0.1.0-recovery` 不符合 Release Please 分支协议。
+3. [PR #9](https://github.com/xlihub/Ki-Core/pull/9) 使用 `release-ki-core-v0.1.0`、可解析正文和 `autorelease: pending`，合并后成功创建 tag 与 Release。
+
+旧 PR #3、#6 和 #8 的 `autorelease: pending` 已移除。不要重新添加这些标签，也不要重新运行它们的发布流程。
 
 ### Ki-Buddy 当前状态
 
 - 远端 `product/main` 尚未建立独立发版体系。
 - 本地功能分支正在实现 Ki-Core 产物消费。
-- `kiCore.tag` 仍为空，没有可用于正式构建的 Ki-Core Release。
+- `ki-core-v0.1.0` 已可用于正式 pin，但 Ki-Buddy 配置仍未写入 tag、commit 和六个平台 checksum。
 - 没有 Ki-Buddy 产品 CHANGELOG 和版本映射。
+- xlihub/Ki-Buddy 当前没有公开 Release。
 
-### 首次发布前允许的操作
+### 当前允许的后续操作
 
-- 查询、同步和比较上游。
-- 修改并验证发布 workflow。
-- 运行手工 Candidate Build 做联调。
-- 创建实现目标流程的普通 PR。
+- 对齐 Ki-Buddy 的 AionUi 正式上游基线。
+- 在 Ki-Buddy 正式配置中固定 `ki-core-v0.1.0` 并验证六个平台 checksum。
+- 保留 Candidate Build 供未来 Ki-Core 未发布版本联调。
+- 建立 Ki-Buddy 独立版本、映射、产品 CHANGELOG 和正式发布 workflow。
 
-### 首次发布前禁止的操作
+### 仍然禁止的操作
 
-- 合并 Ki-Core PR #6。
-- 为当前 `0.1.0` 手工创建正式 tag。
 - 把 Candidate Actions artifact 当作 Ki-Buddy 正式依赖。
-- 在 Ki-Buddy 的正式配置中写入不存在的 Ki-Core tag。
-- 为修复失败发布覆盖已有 tag 或 Release 资产。
+- 移动或重建 `ki-core-v0.1.0`。
+- 覆盖来源不同的公开 Release 资产。
+- 复用旧 PR 的 pending 标签或把普通功能分支伪装成 Release PR。
 
 ## 2. 管理者日常检查
 
@@ -184,6 +195,13 @@ Release PR 应满足：
 
 保留 Release Please 生成的 `chore(product/main): release ...` 标题。使用 GitHub 默认 merge commit 或 squash merge 都可以，但不要把该标题从最终提交信息中删除。
 
+Release PR 还必须保留以下机器协议：
+
+- 常规流程使用 Release Please 创建的 `release-please--branches--product/main--components--ki-core` 分支。
+- 恢复既有版本时使用 `release-ki-core-vX.Y.Z`，不能使用普通 `release/*`、`fix/*` 或 `feat/*` 分支。
+- 正文保留两个 `---` 分隔符和 `## [X.Y.Z]` 版本标题；标题、说明和 footer 可以使用中文。
+- 合并前保留 `autorelease: pending` 标签。
+
 合并后检查 Release Please run，确认它进入 `Create Ki-Core Release` job，没有继续生成下一版本 PR。
 
 ### 4.3 批准正式发布
@@ -197,17 +215,16 @@ Release PR 应满足：
 
 确认后批准。当前 Environment 允许 `xlihub` 审批自己的部署请求，符合单维护者阶段的实际情况。
 
-### 4.4 第一次发布 `0.1.0`
+### 4.4 首次发布 `0.1.0` 的历史记录
 
-流程改造 PR 合并并通过 CI 后，第一次发布不再创建新的 Release PR：
+本节只用于解释历史 Actions，不是后续版本操作步骤。
 
-1. 关闭错误的 PR #6，不合并。
-2. 在 Actions 中打开 `Release Please`。
-3. 选择 `Run workflow`，分支选择 `product/main`，`operation` 选择 `release-current`。
-4. 在 `ki-core-stable` Environment 审批 `Create Ki-Core Release` job。
-5. Release Please 创建 `ki-core-v0.1.0` 和公开 Release，并显式启动 `Ki-Core Stable Release` 构建。
+1. 手工运行 `release-current` 时，Release Please 找到 PR #3，但其正文已失去机器可解析结构，因此没有创建 Release。
+2. PR #8 使用正确标题和正文，但普通恢复分支名不符合 Release Please 协议，仍未创建 Release。
+3. PR #9 使用 `release-ki-core-v0.1.0`、可解析正文和 pending 标签；合并并批准后创建 `ki-core-v0.1.0`。
+4. 稳定版 workflow 从 tag 构建六个平台，生成 checksums 并完成资产上传。
 
-不得用 `git tag` 或 GitHub Release 页面代替该入口。
+后续版本应由普通提交触发 Release Please 自动创建或更新 Release PR。`release-current` 只能重新处理已经具备正确标题、正文、分支名和标签的合并 PR，不能修复错误的 Release PR 元数据。
 
 ### 4.5 检查发布结果
 
@@ -420,11 +437,12 @@ Ki-Buddy 已进行定制开发，冲突需要按用户行为处理：
 2. 检查上一产品 tag 和 Release 是否存在。
 3. 检查 Release Please manifest。
 4. 检查上一 Release PR 合并后是否执行了创建 tag/Release 的 job。
-5. 修复 workflow 状态机并通过普通 PR 合并。
-6. 关闭错误 Release PR。
-7. 首次发布使用 `release-current`；后续再运行 `update-pr`，让 Release Please 基于正确的已发布状态生成版本。
+5. 检查 Release PR 的标题、正文、分支名和 pending 标签是否都符合机器协议。
+6. 修复 workflow 状态机并通过普通 PR 合并。
+7. 关闭错误 Release PR并移除其过期 pending 标签。
+8. 通过普通 `product/main` push 或手工 `update-pr`，让 Release Please 基于正确的已发布状态重新生成版本。
 
-不要直接编辑错误 PR 把版本号改小。Release Please 的已发布状态仍然错误，下一次还会重复发生。
+不要直接编辑错误 PR 把版本号改小，也不要认为 `release-current` 能忽略错误的正文或分支名。Release Please 的已发布状态或 PR 身份仍然错误时，下一次还会重复发生。
 
 ## 12. 场景：需要回退产品
 

--- a/docs/contributing/upstream-release-analysis-and-target-alignment.zh-CN.md
+++ b/docs/contributing/upstream-release-analysis-and-target-alignment.zh-CN.md
@@ -1,0 +1,325 @@
+# 上游发版流程分析与 Ki 双仓目标流程
+
+> 最近核对时间：2026-08-05  
+> 适用仓库：`xlihub/Ki-Buddy`、`xlihub/Ki-Core`  
+> 上游仓库：`iOfficeAI/AionUi`、`iOfficeAI/AionCore`
+
+本文面向后续参与双仓维护的开发者。读完后，读者应当能够判断一项发版相关改动属于上游同步、Ki 产品版本管理，还是不必要的发布基础设施，并能按本文描述实现后续流程。
+
+本文同时记录两类信息：
+
+- **已观察现状**：来自 GitHub workflow、Release、PR、Actions 运行记录和仓库设置。
+- **已确认目标**：Ki-Core 与 Ki-Buddy 后续采用的流程方向，目前仍有部分尚未实现。
+
+不得把“已确认目标”视为当前已经可用的自动化。实际操作前应同时查看[仓库管理者发版与维护手册](maintainer-release-and-maintenance-handbook.zh-CN.md)中的“当前过渡状态”。
+
+## 1. 仓库职责与分支模型
+
+| 仓库     | `main` 的职责                          | `product/main` 的职责                                     | 产品版本        |
+| -------- | -------------------------------------- | --------------------------------------------------------- | --------------- |
+| Ki-Core  | 跟踪 AionCore 上游，不承载 Ki 产品提交 | 固定到选定的 AionCore 正式 tag，并保存 Ki-Core 产品层变更 | 独立于 AionCore |
+| Ki-Buddy | 跟踪 AionUi 上游，不承载 Ki 产品提交   | 承载 Ki-Buddy 定制开发、上游同步和发布配置                | 独立于 AionUi   |
+
+`product/main` 必须长期保留。即使 Ki-Core 当前没有源码二次开发，其 tag、二进制名称、版本历史和发布记录也已经属于 Ki-Core 产品，不能与 AionCore 混用。
+
+“跟踪上游”是分支职责，不代表远端分支始终自动保持最新。2026-08-05 核对时，两个 Ki 仓库的 `main` 均落后于各自上游当前 `main`，仍需要后续同步。
+
+## 2. AionCore 上游实际流程
+
+AionCore 使用 Release Please 管理版本、tag、CHANGELOG 和 GitHub Release。
+
+相关入口：
+
+- [Release Please workflow](https://github.com/iOfficeAI/AionCore/blob/main/.github/workflows/release-please.yml)
+- [Release workflow](https://github.com/iOfficeAI/AionCore/blob/main/.github/workflows/release.yml)
+- [Release Please 配置](https://github.com/iOfficeAI/AionCore/blob/main/release-please-config.json)
+- [AionCore Releases](https://github.com/iOfficeAI/AionCore/releases)
+
+### 2.1 普通提交进入 `main`
+
+功能和修复提交遵循 Conventional Commits。每次 `main` push 都触发 Release Please：
+
+1. 普通提交进入 `main`。
+2. Release Please 创建或更新 Release PR。
+3. Release PR 更新 workspace version、manifest 和 `CHANGELOG.md`。
+4. workflow 还会更新 `Cargo.lock` 并提交到 Release PR 分支。
+
+Release PR 会持续汇集未发布的 `feat`、`fix`、`perf`、`refactor` 和文档变化。维护者通过合并时机决定发版时间。
+
+### 2.2 合并 Release PR
+
+Release PR 合并提交使用 `chore(main): release X.Y.Z`。Release Please workflow 根据提交标题进入发布分支：
+
+1. 禁止继续创建 Release PR。
+2. 创建 `vX.Y.Z` tag。
+3. 创建公开 GitHub Release。
+4. 显式 dispatch Release workflow。
+
+显式 dispatch 很重要。由默认 `GITHUB_TOKEN` 创建的 tag 或 Release 不会继续触发新的 workflow，不能依赖 tag 事件自然传播。
+
+### 2.3 构建和产物
+
+Release workflow 从正式 tag 构建六个平台：
+
+- macOS x64、arm64
+- Linux x64、arm64
+- Windows x64、arm64
+
+发布资产包含六个平台 archive 和 `aioncore-checksums.txt`。
+
+### 2.4 最近一次实际记录
+
+[AionCore PR #775](https://github.com/iOfficeAI/AionCore/pull/775) 于 2026-08-05 合并并发布 `v0.1.59`：
+
+- [Release Please run](https://github.com/iOfficeAI/AionCore/actions/runs/30982619932) 创建 tag 和 Release。
+- [Release build run](https://github.com/iOfficeAI/AionCore/actions/runs/30982630958) 构建并上传资产。
+- [v0.1.59 Release](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.59) 最终包含六个平台资产和 checksums。
+
+维护者的主要发版动作是合并 Release PR。AionCore 没有发布 Environment，也没有 Draft Release 审批阶段。
+
+公开 Release 会先于构建资产出现。`v0.1.59` 的 Release 创建后约 13 分钟，六个平台资产才上传完成。这是上游接受的流程特征，不应误认为发布和资产上传是一个原子操作。
+
+## 3. AionUi 上游实际流程
+
+AionUi 没有使用 Release Please。它采用“版本准备 PR、手工正式 tag、Draft Release、人工发布”的方式。
+
+相关入口：
+
+- [Build and Release workflow](https://github.com/iOfficeAI/AionUi/blob/main/.github/workflows/build-and-release.yml)
+- [Reusable Build workflow](https://github.com/iOfficeAI/AionUi/blob/main/.github/workflows/_build-reusable.yml)
+- [Distribute Release Assets workflow](https://github.com/iOfficeAI/AionUi/blob/main/.github/workflows/release-distribute.yml)
+- [AionUi Releases](https://github.com/iOfficeAI/AionUi/releases)
+
+### 3.1 版本准备 PR
+
+AionUi 仓库的版本维护说明规定：
+
+1. 查询最新或指定的 AionCore Release。
+2. 检查六个平台 archive 和 checksums 是否存在。
+3. 更新 AionUi 自身版本和 `aioncoreVersion`。
+4. 生成 `CHANGELOG.md`。
+5. 运行质量检查和测试。
+6. 创建版本准备 PR并合并。
+
+AionUi 的 `CHANGELOG.md` 在一个版本条目中包含：
+
+- `Desktop`：AionUi 自身变化。
+- `Core`：所固定 AionCore 版本的变化。
+
+版本准备流程允许 `--skip-core`。因此 AionUi 可以只发布前端变化，不要求每个 UI 版本都升级 AionCore。
+
+### 3.2 正式 tag 和构建
+
+Build and Release workflow 监听 `dev` push 和所有 tag push：
+
+- `dev` push 会在构建成功后生成开发 tag。
+- 正式 tag 不由 workflow 创建，需要维护者在版本 PR 合并后推送。
+- 正式 tag 触发代码质量检查、六平台桌面构建和 Web CLI 打包。
+- 构建完成后创建 Draft Release。
+
+正式发布 job 使用 `release` Environment。2026-08-05 核对时，该 Environment 要求指定维护者审批；`dev-release` 没有审批规则。
+
+### 3.3 Draft 发布与分发
+
+构建完成后，维护者检查 Draft Release、Release Notes 和资产，然后手工发布。Release 发布事件再触发外部分发 workflow。
+
+[AionUi PR #3852](https://github.com/iOfficeAI/AionUi/pull/3852) 和 [v2.1.47-final 构建](https://github.com/iOfficeAI/AionUi/actions/runs/30910954643) 展示了这条路径：
+
+- PR 将 AionUi 更新到 `2.1.47`，并固定 AionCore `v0.1.58`。
+- PR 合并后推送 `v2.1.47-final`。
+- workflow 完成六平台构建并创建 Draft Release。
+- [v2.1.47-final Release](https://github.com/iOfficeAI/AionUi/releases/tag/v2.1.47-final) 在第二天由维护者发布。
+
+该版本的[外部分发任务](https://github.com/iOfficeAI/AionUi/actions/runs/30986701877)失败：tag 版本为 `2.1.47-final`，而 updater metadata 版本为 `2.1.47`。这说明上游流程也需要结合 Ki 产品语义审查，不能直接复制所有细节。
+
+## 4. AionUi 与 AionCore 的实际发布关系
+
+上游采用明确版本固定，没有实现跨仓库原子发布。
+
+| AionCore  | 对应 AionUi             | 关系                                           |
+| --------- | ----------------------- | ---------------------------------------------- |
+| `v0.1.56` | `v2.1.45`               | AionUi 版本准备时固定最新 Core 正式版本        |
+| `v0.1.57` | `v2.1.46`               | 同日完成对应更新                               |
+| `v0.1.58` | `v2.1.47-final`         | AionUi CHANGELOG 同时包含 Desktop 和 Core 变化 |
+| `v0.1.59` | 暂无对应 AionUi Release | 两仓并非同时完成发布                           |
+
+“AionUi 跟随 AionCore”的实际含义是：
+
+- 正式构建固定一个已发布的 AionCore tag。
+- 版本准备时确认所需资产存在。
+- AionUi CHANGELOG 记录 Core 更新内容。
+- AionUi 可以在不更新 Core 的情况下独立发布。
+- 手工构建可以使用 AionCore Actions run 做联调，正式构建仍使用固定 Release。
+
+## 5. Ki 双仓当前状态
+
+### 5.1 Ki-Core
+
+已具备：
+
+- `main` 与 `product/main` 双分支模型。
+- Ki-Core 独立版本文件、tag 命名和 Release Please 配置。
+- Ki-Core 与 AionCore 的映射文件。
+- 上游 `CHANGELOG.md` 和 `CHANGELOG.ki-core.md`。
+- 六平台 Candidate Build 与正式构建定义。
+- `ki-core-stable` Environment，审批人为 `xlihub`，允许审批自己的发布请求。
+- `ki-core-v*` tag 禁止更新和删除。
+
+当前事实：
+
+- `product/main` 的首个产品版本为 `0.1.0`，映射 AionCore `v0.1.58`。
+- Release PR #3 已合并，但还没有 `ki-core-v0.1.0` tag 或公开 Ki-Core Release。
+- Release Please 随后创建了错误的 [PR #6](https://github.com/xlihub/Ki-Core/pull/6)：`0.2.0`。
+- 正式发布 workflow 尚未完成一次远端真实发版。
+- `main` 还没有跟上 AionCore 当前 `main`。
+
+PR #6 的出现来自 Release Please 状态机偏离上游：当前流程只创建 Release PR，没有在 Release PR 合并时创建 tag/Release。Release Please 因而继续把之前的 `feat(release)` 提交当作未发布内容。
+
+### 5.2 Ki-Buddy
+
+远端 `product/main` 当前主要包含 fork workflow 防护，还没有 Ki-Buddy 独立发版体系。
+
+本地功能分支正在实现 Ki-Core 消费验证，包含：
+
+- 正式 Release、Candidate Build 和本地开发三类来源策略。
+- checksums、manifest、provenance 和 archive 安全检查。
+- Ki-Core 来源诊断和测试。
+
+当前缺失：
+
+- 一个真实可固定的 Ki-Core Release tag。
+- Ki-Buddy 独立版本文件与 tag 规范。
+- `CHANGELOG.ki-buddy.md`。
+- Ki-Buddy、AionUi、Ki-Core、AionCore 的发布映射。
+- Ki-Buddy 正式发布 workflow。
+
+## 6. 已确认的 Ki-Core 目标流程
+
+Ki-Core 短期继续保持与 AionCore 正式版本相同的发布节奏，同时管理自己的版本号。
+
+```text
+AionCore 发布正式 tag
+  → 创建 Ki-Core 上游同步 PR
+  → product/main 固定到该 AionCore tag
+  → Release Please 创建或更新 Ki-Core Release PR
+  → xlihub 合并并批准发布
+  → 创建 ki-core-vX.Y.Z
+  → 六平台构建与 checksums
+  → 发布 Ki-Core GitHub Release
+```
+
+### 6.1 版本规则
+
+- 每个被接受的 AionCore 正式版本对应一个 Ki-Core 正式版本。
+- Ki-Core 与 AionCore 的数字不需要相同。
+- 纯上游同步默认作为 Ki-Core patch，例如：
+  `Ki-Core 0.1.1 ↔ AionCore 0.1.59`。
+- 未来 Ki-Core 自有 `feat`、`fix` 继续参与 Ki-Core SemVer 计算。
+- AionCore 的 Cargo workspace version、API 和协议版本不改写为 Ki-Core 版本。
+
+### 6.2 映射规则
+
+映射记录只保存已经确定的事实：
+
+- Ki-Core version
+- Ki-Core tag
+- AionCore tag
+- AionCore peeled commit
+- 发布日期
+
+映射是 append-only。已经发布的记录不得修改。`prepared`、`candidate-built` 等过程状态不写入长期映射，以免失败后留下错误状态。
+
+### 6.3 CHANGELOG 规则
+
+- `CHANGELOG.md`：保持 AionCore 上游内容，随上游源码同步。
+- `CHANGELOG.ki-core.md`：记录 Ki-Core 自身变化，以及本次同步的 AionCore tag 和 compare 链接。
+
+### 6.4 构建规则
+
+- 正式发布从 Ki-Core tag 直接构建六个平台。
+- 保留手工 Candidate Build，供 Ki-Buddy 联调使用。
+- Candidate Build 不再作为正式发布的必填输入，也不要求正式发布重复证明一次 Candidate Build 身份。
+- 正式资产至少包含六个平台 archive 和 checksums。
+- 当前阶段不要求复杂的发布状态历史和多次远端资产回读。
+
+### 6.5 Release Please 对齐
+
+Ki-Core Release Please 应与 AionCore 保持同一状态机：
+
+- 普通 `product/main` push：创建或更新 Release PR。
+- Release PR 合并：创建 tag/Release并显式 dispatch构建。
+- Release merge commit 不得再生成下一版本 PR。
+- `xlihub` 的发布审批保留在正式发布入口。
+
+## 7. 已确认的 Ki-Buddy 目标流程
+
+Ki-Buddy 短期会进行二次开发，因此需要同时管理上游变化、定制变化和 Ki-Core 更新。
+
+```text
+同步 AionUi 上游
+  + Ki-Buddy 定制提交进入 product/main
+  + Ki-Core 发布正式版本
+  → 创建 Ki-Buddy 版本准备 PR
+  → 更新 Ki-Buddy 版本和固定 Ki-Core tag
+  → 生成 Ki-Buddy 产品 CHANGELOG
+  → xlihub 合并
+  → 推送正式 tag
+  → 六平台构建与 Draft Release
+  → xlihub 检查并发布
+```
+
+### 7.1 Core 消费规则
+
+- Ki-Buddy 正式构建只消费 `xlihub/Ki-Core` 的固定正式 tag。
+- 正式构建不得使用 `latest` 或 Candidate Build。
+- 手工构建允许使用一个明确的 Ki-Core Actions run 做联调。
+- 正式下载保留 checksum 验证和 archive 安全解压。
+- Candidate provenance 可以服务联调，但不进入正式发布的强依赖链。
+
+### 7.2 CHANGELOG 规则
+
+- `CHANGELOG.md`：保持 AionUi 上游内容。
+- `CHANGELOG.ki-buddy.md`：每个版本包含三类信息：
+  - Ki-Buddy 定制开发变化。
+  - 本次同步的 AionUi 上游变化。
+  - Ki-Core 更新，以及该 Ki-Core 对应的 AionCore 版本。
+
+### 7.3 发布节奏
+
+Ki-Core 正式 Release 发布后，自动化可以创建或更新 Ki-Buddy 版本准备 PR。自动化不得直接发布 Ki-Buddy。
+
+这样可以让 Ki-Buddy及时跟进 Ki-Core，也给 `xlihub` 留出合并同期定制开发、同步 AionUi 和编辑 Release Notes 的时间。
+
+## 8. 设计取舍
+
+| 能力                                  | 决定 | 理由                                           |
+| ------------------------------------- | ---- | ---------------------------------------------- |
+| 双仓 `main` + `product/main`          | 保留 | 区分上游镜像与产品历史                         |
+| Ki-Core 独立 SemVer、tag、映射        | 保留 | 二进制和发布属于 Ki-Core 产品                  |
+| 两份 CHANGELOG                        | 保留 | 上游内容与 Ki 产品内容职责不同                 |
+| 六平台构建与 checksums                | 保留 | 与上游平台支持一致，供 Ki-Buddy 固定消费       |
+| 正式构建固定 Ki-Core tag              | 保留 | 保证 Ki-Buddy 构建可重复                       |
+| archive 安全解压                      | 保留 | 下载外部 archive 时属于必要安全边界            |
+| Candidate 作为正式发布前置            | 移除 | 增加一次六平台构建，不能证明正式构建二进制相同 |
+| 复杂状态历史                          | 移除 | 过程失败容易留下失真的长期状态                 |
+| 多阶段 Draft 查找、回读和原子发布脚本 | 简化 | 当前需求没有要求自建完整发布事务               |
+| Ki-Buddy 三状态来源策略               | 简化 | 正式、手工联调、本地开发可以用更直接的入口表达 |
+
+## 9. 实施顺序
+
+1. 关闭错误的 Ki-Core PR #6，不创建 `0.2.0`。
+2. 让 Ki-Core Release Please 与 AionCore 状态机一致。
+3. 移除正式发布对 Candidate run 的依赖。
+4. 简化 Ki-Core 映射和验证器，继续保留双 CHANGELOG。
+5. 同步 AionCore 最新正式 tag，决定首个公开 Ki-Core 版本的映射。
+6. 完成首个 Ki-Core Release。
+7. 调整 Ki-Buddy Core 消费实现，固定真实 Ki-Core tag。
+8. 建立 Ki-Buddy 独立版本、映射、产品 CHANGELOG 和正式发布 workflow。
+
+## 10. 不在当前范围内
+
+- Ki-Core Rust 源码、API、协议和数据库迁移的二次开发。
+- 自动合并上游同步 PR。
+- 自动公开发布 Ki-Core 或 Ki-Buddy。
+- 覆盖、移动或删除已经公开的产品 tag。
+- 为了同步上游而重写整个 AionUi/AionCore workflow 体系。

--- a/docs/contributing/upstream-release-analysis-and-target-alignment.zh-CN.md
+++ b/docs/contributing/upstream-release-analysis-and-target-alignment.zh-CN.md
@@ -1,6 +1,6 @@
 # 上游发版流程分析与 Ki 双仓目标流程
 
-> 最近核对时间：2026-08-05
+> 最近核对时间：2026-08-06
 > 适用仓库：`xlihub/Ki-Buddy`、`xlihub/Ki-Core`
 > 上游仓库：`iOfficeAI/AionUi`、`iOfficeAI/AionCore`
 
@@ -9,9 +9,9 @@
 本文同时记录两类信息：
 
 - **已观察现状**：来自 GitHub workflow、Release、PR、Actions 运行记录和仓库设置。
-- **已确认目标**：Ki-Core 与 Ki-Buddy 后续采用的流程方向，目前仍有部分尚未实现。
+- **已确认目标**：Ki-Core 与 Ki-Buddy 采用的流程方向。Ki-Core 首次发布已经验证，Ki-Buddy 部分仍在实施。
 
-不得把“已确认目标”视为当前已经可用的自动化。实际操作前应同时查看[仓库管理者发版与维护手册](maintainer-release-and-maintenance-handbook.zh-CN.md)中的“当前过渡状态”。
+不得把尚未实施的 Ki-Buddy 目标视为当前已经可用的自动化。实际操作前应同时查看[仓库管理者发版与维护手册](maintainer-release-and-maintenance-handbook.zh-CN.md)中的当前状态。
 
 ## 1. 仓库职责与分支模型
 
@@ -167,13 +167,15 @@ Build and Release workflow 监听 `dev` push 和所有 tag push：
 
 当前事实：
 
-- 第一次正式发布目标为 `Ki-Core 0.1.0 ↔ AionCore v0.1.59`；流程改造合并前，远端元数据仍可能显示旧的 `v0.1.58` 基线。
-- Release PR #3 已合并，但还没有 `ki-core-v0.1.0` tag 或公开 Ki-Core Release。
-- Release Please 随后创建了错误的 [PR #6](https://github.com/xlihub/Ki-Core/pull/6)：`0.2.0`。
-- 正式发布 workflow 尚未完成一次远端真实发版。
-- `main` 还没有跟上 AionCore 当前 `main`。
+- [Ki-Core 0.1.0](https://github.com/xlihub/Ki-Core/releases/tag/ki-core-v0.1.0) 已于 2026-08-06 公开发布，对应 AionCore `v0.1.59`，peeled commit 为 `815e61ed9bbe942339347dc1e69ddce176cded76`。
+- 最终 Release PR 是 [PR #9](https://github.com/xlihub/Ki-Core/pull/9)，发布分支为 `release-ki-core-v0.1.0`，合并提交和 tag 目标均为 `209e6844d39bac0762c61e198c1ba3a007f9dd2e`。
+- [Release Please run](https://github.com/xlihub/Ki-Core/actions/runs/31068696569) 创建 tag 和公开 Release，并显式启动稳定版构建。
+- [Ki-Core Stable Release run](https://github.com/xlihub/Ki-Core/actions/runs/31068791622) 完成六个平台构建、Linux GLIBC 基线检查、checksums 生成和资产上传。
+- Release 最终包含六个平台 archive 和 `ki-core-checksums.txt`，不是 Draft 或 Prerelease。
+- PR #9 已从 `autorelease: pending` 转为 `autorelease: tagged`；PR #3、#6 和 #8 的过期 pending 标签已移除。
+- `main` 的上游镜像仍需要按日常维护流程持续更新，不影响已发布 `product/main` 的 AionCore `v0.1.59` 基线。
 
-PR #6 的出现来自 Release Please 状态机偏离上游：当前流程只创建 Release PR，没有在 Release PR 合并时创建 tag/Release。Release Please 因而继续把之前的 `feat(release)` 提交当作未发布内容。
+首次发布暴露了两个 Release Please 机器协议要求：Release PR 正文必须保留可解析的版本区块，发布分支也必须使用 Release Please 支持的命名。普通恢复分支即使标题和正文正确，仍不会被识别为 Release PR。
 
 ### 5.2 Ki-Buddy
 
@@ -187,13 +189,13 @@ PR #6 的出现来自 Release Please 状态机偏离上游：当前流程只创�
 
 当前缺失：
 
-- 一个真实可固定的 Ki-Core Release tag。
+- 将正式构建固定到已经存在的 `ki-core-v0.1.0`，并写入六个平台 checksum。
 - Ki-Buddy 独立版本文件与 tag 规范。
 - `CHANGELOG.ki-buddy.md`。
 - Ki-Buddy、AionUi、Ki-Core、AionCore 的发布映射。
 - Ki-Buddy 正式发布 workflow。
 
-## 6. 已确认的 Ki-Core 目标流程
+## 6. 已验证的 Ki-Core 目标流程
 
 Ki-Core 短期继续保持与 AionCore 正式版本相同的发布节奏，同时管理自己的版本号。
 
@@ -242,7 +244,7 @@ AionCore 发布正式 tag
 
 ### 6.5 Release Please 对齐
 
-Ki-Core Release Please 应与 AionCore 保持同一状态机：
+Ki-Core Release Please 已与 AionCore 保持同一状态机：
 
 - 普通 `product/main` push：创建或更新 Release PR。
 - Release PR 合并：创建 tag/Release，并显式 dispatch 构建。
@@ -250,6 +252,14 @@ Ki-Core Release Please 应与 AionCore 保持同一状态机：
 - `xlihub` 的发布审批保留在正式发布入口。
 
 Ki-Core 同时支持 GitHub 默认 merge commit 和 squash merge。发布判断检查完整提交信息是否包含 Release Please 的 `chore(product/main): release ...` 标题，因此合并时不得删除该标题。
+
+Release PR 的标题、正文、标签和分支名共同构成机器协议：
+
+- 常规流程使用 Release Please 自动创建的 `release-please--branches--product/main--components--ki-core` 分支。
+- 恢复既有版本时允许使用 `release-ki-core-vX.Y.Z`。
+- 任意 `feat/*`、`fix/*` 或普通 `release/*` 分支不能代替上述发布分支。
+- 正文必须保留两个 `---` 分隔符和 `## [X.Y.Z]` 版本标题。
+- 合并前必须保留 `autorelease: pending`；成功创建 tag 后应由 Release Please 改为 `autorelease: tagged`。
 
 ## 7. 已确认的 Ki-Buddy 目标流程
 
@@ -305,16 +315,22 @@ Ki-Core 正式 Release 发布后，自动化可以创建或更新 Ki-Buddy 版�
 | 多阶段 Draft 查找、回读和原子发布脚本 | 简化 | 当前需求没有要求自建完整发布事务               |
 | Ki-Buddy 三状态来源策略               | 简化 | 正式、手工联调、本地开发可以用更直接的入口表达 |
 
-## 9. 实施顺序
+## 9. 实施状态与后续顺序
 
-1. 关闭错误的 Ki-Core PR #6，不创建 `0.2.0`。
-2. 让 Ki-Core Release Please 与 AionCore 状态机一致。
-3. 移除正式发布对 Candidate run 的依赖。
-4. 简化 Ki-Core 映射和验证器，继续保留双 CHANGELOG。
-5. 同步 AionCore 最新正式 tag，决定首个公开 Ki-Core 版本的映射。
-6. 完成首个 Ki-Core Release。
-7. 调整 Ki-Buddy Core 消费实现，固定真实 Ki-Core tag。
-8. 建立 Ki-Buddy 独立版本、映射、产品 CHANGELOG 和正式发布 workflow。
+Ki-Core 部分已经完成：
+
+1. 错误的 Ki-Core PR #6 已关闭，没有创建 `0.2.0`。
+2. Release Please 已与 AionCore 状态机对齐。
+3. 正式发布已移除 Candidate run 前置依赖。
+4. Ki-Core 映射、验证器和双 CHANGELOG 已采用简化方案。
+5. 首个映射确定为 `Ki-Core 0.1.0 ↔ AionCore v0.1.59`。
+6. `ki-core-v0.1.0`、六个平台资产和 checksums 已完成发布验证。
+
+下一阶段按以下顺序实施：
+
+1. 对齐 Ki-Buddy 的 AionUi 正式上游基线。
+2. 调整 Ki-Buddy Core 消费实现，固定真实 `ki-core-v0.1.0` 和六个平台 checksum。
+3. 建立 Ki-Buddy 独立版本、映射、产品 CHANGELOG 和正式发布 workflow。
 
 ## 10. 不在当前范围内
 

--- a/docs/contributing/upstream-release-analysis-and-target-alignment.zh-CN.md
+++ b/docs/contributing/upstream-release-analysis-and-target-alignment.zh-CN.md
@@ -1,7 +1,7 @@
 # 上游发版流程分析与 Ki 双仓目标流程
 
-> 最近核对时间：2026-08-05  
-> 适用仓库：`xlihub/Ki-Buddy`、`xlihub/Ki-Core`  
+> 最近核对时间：2026-08-05
+> 适用仓库：`xlihub/Ki-Buddy`、`xlihub/Ki-Core`
 > 上游仓库：`iOfficeAI/AionUi`、`iOfficeAI/AionCore`
 
 本文面向后续参与双仓维护的开发者。读完后，读者应当能够判断一项发版相关改动属于上游同步、Ki 产品版本管理，还是不必要的发布基础设施，并能按本文描述实现后续流程。

--- a/docs/contributing/upstream-release-analysis-and-target-alignment.zh-CN.md
+++ b/docs/contributing/upstream-release-analysis-and-target-alignment.zh-CN.md
@@ -167,7 +167,7 @@ Build and Release workflow 监听 `dev` push 和所有 tag push：
 
 当前事实：
 
-- `product/main` 的首个产品版本为 `0.1.0`，映射 AionCore `v0.1.58`。
+- 第一次正式发布目标为 `Ki-Core 0.1.0 ↔ AionCore v0.1.59`；流程改造合并前，远端元数据仍可能显示旧的 `v0.1.58` 基线。
 - Release PR #3 已合并，但还没有 `ki-core-v0.1.0` tag 或公开 Ki-Core Release。
 - Release Please 随后创建了错误的 [PR #6](https://github.com/xlihub/Ki-Core/pull/6)：`0.2.0`。
 - 正式发布 workflow 尚未完成一次远端真实发版。
@@ -203,9 +203,8 @@ AionCore 发布正式 tag
   → product/main 固定到该 AionCore tag
   → Release Please 创建或更新 Ki-Core Release PR
   → xlihub 合并并批准发布
-  → 创建 ki-core-vX.Y.Z
-  → 六平台构建与 checksums
-  → 发布 Ki-Core GitHub Release
+  → 创建 ki-core-vX.Y.Z 和公开 GitHub Release
+  → 六平台构建并上传 archive 与 checksums
 ```
 
 ### 6.1 版本规则
@@ -213,7 +212,7 @@ AionCore 发布正式 tag
 - 每个被接受的 AionCore 正式版本对应一个 Ki-Core 正式版本。
 - Ki-Core 与 AionCore 的数字不需要相同。
 - 纯上游同步默认作为 Ki-Core patch，例如：
-  `Ki-Core 0.1.1 ↔ AionCore 0.1.59`。
+  `Ki-Core 0.1.1 ↔ AionCore v0.1.60`（仅作版本关系示例）。
 - 未来 Ki-Core 自有 `feat`、`fix` 继续参与 Ki-Core SemVer 计算。
 - AionCore 的 Cargo workspace version、API 和协议版本不改写为 Ki-Core 版本。
 
@@ -225,9 +224,8 @@ AionCore 发布正式 tag
 - Ki-Core tag
 - AionCore tag
 - AionCore peeled commit
-- 发布日期
 
-映射是 append-only。已经发布的记录不得修改。`prepared`、`candidate-built` 等过程状态不写入长期映射，以免失败后留下错误状态。
+已经发布的映射是 append-only，不得修改。当前尚未发布的版本允许在正式 tag 创建前修正映射。`prepared`、`candidate-built` 等过程状态不写入长期映射，以免失败后留下错误状态。
 
 ### 6.3 CHANGELOG 规则
 
@@ -247,9 +245,11 @@ AionCore 发布正式 tag
 Ki-Core Release Please 应与 AionCore 保持同一状态机：
 
 - 普通 `product/main` push：创建或更新 Release PR。
-- Release PR 合并：创建 tag/Release并显式 dispatch构建。
+- Release PR 合并：创建 tag/Release，并显式 dispatch 构建。
 - Release merge commit 不得再生成下一版本 PR。
 - `xlihub` 的发布审批保留在正式发布入口。
+
+Ki-Core 同时支持 GitHub 默认 merge commit 和 squash merge。发布判断检查完整提交信息是否包含 Release Please 的 `chore(product/main): release ...` 标题，因此合并时不得删除该标题。
 
 ## 7. 已确认的 Ki-Buddy 目标流程
 

--- a/docs/plans/2026-08-05-001-feat-ki-core-independent-release-plan.md
+++ b/docs/plans/2026-08-05-001-feat-ki-core-independent-release-plan.md
@@ -1,0 +1,432 @@
+---
+title: Ki-Core Independent Release and Ki-Buddy Integration - Plan
+type: feat
+date: 2026-08-05
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+status: superseded
+---
+
+# Ki-Core Independent Release and Ki-Buddy Integration - Plan
+
+> **已废弃（2026-08-06）**  
+> 本计划保留为历史记录，不再作为实施或发版依据。Candidate Build 前置、复杂发布状态和多阶段资产发布要求已经被后续对齐方案替代。当前有效方案见[上游发版流程分析与 Ki 双仓目标流程](../contributing/upstream-release-analysis-and-target-alignment.zh-CN.md)，实际操作见[仓库管理者发版和维护手册](../contributing/maintainer-release-and-maintenance-handbook.zh-CN.md)。
+
+## Goal Capsule
+
+- **Objective:** 建立 Ki-Core 独立产品版本、上游版本映射、候选构建和稳定发布机制，并让 Ki-Buddy 固定、校验和记录该 Ki-Core 发布。
+- **Repositories:** Ki-Core 负责上游基线、产品版本和二进制发布；Ki-Buddy 负责版本固定、下载校验和桌面产品打包。
+- **Authority:** 本文中的 session-settled 决策优先于实现偏好；Product Contract 规定产品行为；Planning Contract 规定实现机制；两个仓库各自的贡献规范继续生效。
+- **Execution profile:** 双仓代码改造加一次受控的 GitHub 稳定发布。Ki-Core 发布成功后才允许合并 Ki-Buddy 的稳定版本固定。
+- **Stop conditions:** 上游 tag 与 commit 不一致、产品分支出现非允许的上游源码差异、六平台任一构建失败、release manifest 或 checksum 不一致、目标 tag/release 已公开存在，或发布审批与凭证未配置。
+- **Tail ownership:** Ki-Core 发布流程拥有 tag、release 和资产完整性；Ki-Buddy 正式构建只消费不可变发布，不修改或替换 Ki-Core 资产。候选联调可按 R13 消费经过身份验证的 Ki-Core Actions artifact。
+
+---
+
+## Product Contract
+
+### Summary
+
+Ki-Core 作为独立产品维护自己的 SemVer、`ki-core-v*` tag、release archive、checksum 和发布历史。AionCore 的 Cargo workspace version、Rust 源码、API、协议和数据库迁移继续保持上游语义。Ki-Buddy 正式构建只依赖 Ki-Core 的产品发布，并从 Ki-Core 提供的机器可读 manifest 获得 AionCore 来源信息；候选联调按 R13 使用经过身份验证的 Ki-Core Actions artifact。
+
+首阶段的主要使用方是 Ki-Buddy 的正式构建、发布维护者和开发者。公开 GitHub Release 是 Ki-Core 向 Ki-Buddy 提供二进制的分发渠道，不构成独立面向终端用户的 CLI 或 API 支持承诺。Ki-Core 在本计划中承诺的兼容面仅包括 tag 语法、六个平台与资产命名、archive 内部 executable 名称、release manifest/checksum schema 和 provenance 字段；AionCore 自身 CLI、API 与协议兼容性继续由上游定义。
+
+### Problem Frame
+
+现有 Ki-Core release-please 配置会修改 `Cargo.toml` 和 `Cargo.lock`，并使用 AionCore 的裸 `v*` tag 与资产名称。现有 Ki-Buddy 下载器又把仓库、tag、archive 和 Actions artifact 全部绑定到 `iOfficeAI/AionCore`，且稳定 release 下载没有 checksum 验证。这些行为会把 Ki-Core 产品版本与 AionCore 源码版本混合，也无法证明某个 Ki-Buddy 包含的 Core 二进制来自哪个 Ki-Core 发布和哪个 AionCore 上游提交。
+
+### Requirements
+
+**Branch and upstream alignment**
+
+- R1. Ki-Core 和 Ki-Buddy 的 `main` 保持各自上游 `main` 的精确镜像，不承载产品配置或二次开发提交。
+- R2. 两个产品仓库继续以 `product/main` 为默认分支；Ki-Core 的稳定发布基线只推进到经过确认的 AionCore 稳定 tag，不包含该 tag 之后的 upstream/main 提交。
+- R3. Ki-Core 在当前阶段不得修改 Rust 源码、Cargo workspace version、API、协议或数据库迁移；CI 必须通过允许文件列表证明 release commit 相对映射的上游 commit 只含产品发布层差异。
+
+**Product version and provenance**
+
+- R4. Ki-Core 使用独立 SemVer。首个稳定产品版本为 `0.1.0`，tag 为 `ki-core-v0.1.0`；AionCore 的 `CARGO_PKG_VERSION` 继续报告上游版本。`1.0.0` 之前，推进 AionCore 稳定基线或不兼容地修改 Ki-Core 发布契约时增加 minor，同一上游基线上的兼容发布基础设施、metadata 或资产修正增加 patch。`1.0.0` 起，破坏 Ki-Core 发布契约时增加 major，兼容地增加产品能力或推进上游稳定基线时增加 minor，同一基线上的兼容修正增加 patch。changelog 必须分别列出 Ki-Core 发布层变化和 AionCore 上游变化。
+- R5. Ki-Core 维护 append-only 映射表，记录每个 Ki-Core 版本对应的 AionCore tag 与 peeled commit。允许多个 Ki-Core patch 版本对应同一个 AionCore commit，已发布记录不得改写，弃用信息通过新增状态记录表达。
+- R6. 每个 Ki-Core release 必须提供机器可读的 `ki-core-release.json`，包含 Ki-Core version/tag/release commit、AionCore tag/peeled commit、内部 executable 名称，以及 Canonical Platform Set 中六个平台的 target triple、资产名和 SHA-256。
+
+**Artifacts and publication**
+
+- R7. 每个稳定 Ki-Core release 必须包含六个平台 archive、`ki-core-release.json` 和 `ki-core-checksums.txt`。archive 使用 Ki-Core 命名，archive 内部继续使用 `aioncore` 或 `aioncore.exe`。
+- R8. 发布状态必须依次经过 metadata prepared、candidate built、six targets verified、draft release populated、stable published。任一验证失败时不得出现公开的稳定 release。
+- R9. 自动化与非管理员身份不得覆盖、移动或删除已公开的 tag 和资产。`ki-core-v*` tag ruleset 禁止更新和删除；发布 job 在 tag、release 或资产已存在时失败，不使用 `--clobber`。仓库管理员仍是 GitHub 无法消除的信任边界；管理员紧急操作必须留下审计记录，日常修复只能创建新的 Ki-Core patch 版本。
+- R10. 稳定发布必须使用受保护的 GitHub environment 和独立 required reviewer，开启 prevent self-review，只接受已验证的 `product/main` commit，并使用单一 concurrency group 防止同时创建两个 Ki-Core release。workflow 的默认权限为只读，`contents: write` 仅授予完成审批后的 publication job。
+
+**Ki-Buddy consumption**
+
+- R11. Ki-Buddy 的正式构建必须固定完整的 Ki-Core tag，并只从 `xlihub/Ki-Core` 的不可变 GitHub Release 下载；正式构建禁止 `latest`、Actions artifact 和本地 binary fallback。
+- R12. Ki-Buddy 必须先验证 checksum 文件和 release manifest，再验证目标 archive，并在解压前因缺失、重复、格式错误或 hash 不符而失败。解压前还必须枚举 archive entries，拒绝绝对路径、`..` 路径跳转、symbolic link、hard link、规范化后重复路径和契约外内容；只允许解压到新建临时目录，并验证最终路径仍位于该目录内。
+- R13. Ki-Buddy 的候选联调可以使用 Ki-Core Actions artifact，但必须验证 repository、workflow、successful conclusion、head SHA 和 artifact name，不能只信任 run ID。
+- R14. Ki-Buddy 的 bundle manifest 和安装诊断必须同时记录 Ki-Core 产品版本/tag/release commit与 AionCore 上游版本/tag/commit；AionCore 来源从 Ki-Core release manifest 读取，不人工复制。
+- R15. 首个 `ki-core-v0.1.0` 稳定 release 完整发布后，Ki-Buddy 才更新正式 pin，并完成所有支持平台的打包验证。本计划不创建首个 Ki-Buddy 稳定 release。
+
+### Canonical Platform Set
+
+六个平台在 workflow matrix、资产名称、`ki-core-release.json`、`ki-core-checksums.txt` 和 Ki-Buddy pin 中使用同一组 platform key 与 target triple：
+
+| Platform key    | Target triple               | Archive                                               | Inner executable |
+| --------------- | --------------------------- | ----------------------------------------------------- | ---------------- |
+| `macos-x64`     | `x86_64-apple-darwin`       | `ki-core-v{version}-x86_64-apple-darwin.tar.gz`       | `aioncore`       |
+| `macos-arm64`   | `aarch64-apple-darwin`      | `ki-core-v{version}-aarch64-apple-darwin.tar.gz`      | `aioncore`       |
+| `linux-x64`     | `x86_64-unknown-linux-gnu`  | `ki-core-v{version}-x86_64-unknown-linux-gnu.tar.gz`  | `aioncore`       |
+| `linux-arm64`   | `aarch64-unknown-linux-gnu` | `ki-core-v{version}-aarch64-unknown-linux-gnu.tar.gz` | `aioncore`       |
+| `windows-x64`   | `x86_64-pc-windows-msvc`    | `ki-core-v{version}-x86_64-pc-windows-msvc.zip`       | `aioncore.exe`   |
+| `windows-arm64` | `aarch64-pc-windows-msvc`   | `ki-core-v{version}-aarch64-pc-windows-msvc.zip`      | `aioncore.exe`   |
+
+`{version}` 是不带 `ki-core-v` 前缀的 Ki-Core SemVer。新增、删除、重命名 platform key，或改变 archive/executable 契约，均按 R4 视为 Ki-Core 产品契约变化。
+
+### Key Flows
+
+- F1. Upstream baseline update
+  - **Trigger:** AionCore 发布新的稳定 tag，或首个 Ki-Core release 开始准备。
+  - **Actors:** Ki-Core maintainer、GitHub Actions。
+  - **Steps:** 更新 Ki-Core `main` 镜像；解引用目标稳定 tag；将该 tag 合入 `product/main`；更新上游元数据；验证产品差异允许列表。
+  - **Outcome:** 候选来源固定为一个可验证的 AionCore tag 和 commit。
+  - **Covered by:** R1, R2, R3, R5
+- F2. Candidate verification
+  - **Trigger:** Ki-Core release PR 已合并，并冻结合并后的 `product/main` commit。
+  - **Actors:** Ki-Core maintainer、六平台 build jobs、Ki-Buddy candidate build。
+  - **Steps:** 从冻结 commit 构建六平台；校验 archive 结构与平台规则；生成候选 manifest/checksum；Ki-Buddy 在尚未合并的集成分支上通过已验证的 run identity 完成候选打包。
+  - **Outcome:** 发布 commit、资产契约和 Ki-Buddy 消费路径均通过验证，但没有公开稳定 release。
+  - **Covered by:** R6, R7, R8, R13
+- F3. Stable Ki-Core publication
+  - **Trigger:** release PR 已合并、候选验证通过且发布审批完成。
+  - **Actors:** Release Please、Ki-Core release workflow、release approver。
+  - **Steps:** 从受批准的 `product/main` SHA 构建；创建 Ki-Core draft release/tag；上传缺失资产；验证 manifest 和 checksum；公开 draft。
+  - **Outcome:** GitHub 上存在一个完整且不可覆盖的 Ki-Core stable release。
+  - **Covered by:** R4, R6, R7, R8, R9, R10
+- F4. Stable Ki-Buddy consumption
+  - **Trigger:** Ki-Core stable release 验证完成。
+  - **Actors:** Ki-Buddy maintainer、Ki-Buddy build jobs。
+  - **Steps:** 在已通过候选验证的 Ki-Buddy 集成分支上写入正式 Ki-Core tag 和各平台 checksum；启用正式 `release-pinned` 路径；下载并逐层验证 checksum、manifest 和目标 archive；准备 managed resources；写入 bundle manifest；完成平台打包后再合并该分支。
+  - **Outcome:** Ki-Buddy 构建可复现地消费指定 Ki-Core 和对应 AionCore 来源，且正式 pin 只在 release 实际存在后进入产品分支。
+  - **Covered by:** R11, R12, R14, R15
+
+### Acceptance Examples
+
+- AE1. Given Ki-Core 映射到 AionCore tag `vX.Y.Z` 的 peeled commit `A`, when CI 比较 Ki-Core release commit `K`, then `A..K` 只包含产品发布层允许文件，Rust/API/协议/迁移路径无差异。Covers R2, R3, R5.
+- AE2. Given 六个平台中任一构建失败, when release workflow 结束, then 不存在公开 stable release，Ki-Buddy 正式 pin 不变。Covers R8, R15.
+- AE3. Given `ki-core-vP.Q.R` 已公开, when workflow 再次处理同一 tag 或同名资产, then 发布失败且不覆盖任何内容。Covers R9.
+- AE4. Given Ki-Buddy 固定 `ki-core-vP.Q.R`, when manifest/checksum 缺失或 archive hash 不符, then 构建在解压前失败，并且不使用 `latest`、AionCore 上游或本地 binary。Covers R11, R12.
+- AE5. Given 有效 Ki-Core Actions run, when Ki-Buddy 候选构建提供 run ID 与 head SHA, then downloader 仅在 repository、workflow、conclusion、SHA 和平台 artifact 全部匹配时接受该候选。Covers R13.
+- AE6. Given 稳定 Ki-Core release 完整, when Ki-Buddy 构建任一支持平台, then archive 内找到 `aioncore` 或 `aioncore.exe`，bundle manifest 同时记录 Ki-Core 与 AionCore 来源。Covers R7, R14.
+- AE7. Given 已公开 Ki-Core 版本发现问题, when 产品恢复服务, then Ki-Buddy 回退到前一 pin 或升级到新的 patch 版本；旧 tag、资产和映射记录保持不变。Covers R5, R9.
+- AE8. Given archive 包含绝对路径、父目录跳转、link、规范化后重复路径或契约外文件, when Ki-Buddy 验证该 archive, then 构建在解压前失败，临时目录外没有文件变化。Covers R12.
+- AE9. Given 发布请求缺少 environment approval、由请求者自审，或指定的 commit 不是已验证的 `product/main` commit, when publication job 尝试开始, then job 不获得 `contents: write` 且不会创建或修改 tag/release。Covers R9, R10.
+- AE10. Given Ki-Core `0.x` 推进到新的 AionCore stable baseline, when Release Please 计算下一版本, then 增加 minor；同一 baseline 上的兼容发布层修正只增加 patch，并在 changelog 中分开描述产品层与上游变化。Covers R4.
+
+### Scope Boundaries
+
+**Included**
+
+- 两仓上游基线同步到首发所需版本。
+- Ki-Core 独立 release metadata、tag、changelog、映射、候选构建、稳定发布和 GitHub 审批配置。
+- Ki-Buddy 的 Ki-Core pin、下载来源、checksum、provenance、候选联调和全平台打包验证。
+- 首个 Ki-Core stable release 与 Ki-Buddy 消费验证。
+
+**Excluded**
+
+- Ki-Core Rust 源码、API、协议、数据库迁移和 `CARGO_PKG_VERSION` 的产品化修改。
+- 将内部 executable、`prepare-aioncore.js`、`bundled-aioncore/` 或 `AIONUI_BACKEND_*` 全面改名。
+- 自动选择并发布刚出现的上游 tag。候选创建后，上游更新由维护者决定是否另建候选。
+- Ki-Buddy 的首个 stable tag/release，以及 AionUi/Ki-Buddy 的品牌、UI 或运行时功能二次开发。
+- 强制删除、重建或覆盖任何已公开的 stable release。
+
+### Dependencies and Sources
+
+- 当前首发基线已核实为 AionCore `v0.1.58`，peeled commit `134daddccf129d1642e08e709522f835fb734572`；上游 AionUi `2.1.47` 同样固定 `v0.1.58`。执行开始时必须再次查询上游 stable release；若已更新，则按 R2 重新准备候选。
+- Release Please v17.6.0 的 `simple` strategy 支持独立 `version-file`；component、`include-component-in-tag` 和 `tag-separator` 可生成 `ki-core-vX.Y.Z`。[Simple strategy](https://github.com/googleapis/release-please/blob/v17.6.0/src/strategies/simple.ts), [tag naming](https://github.com/googleapis/release-please/blob/v17.6.0/src/util/tag-name.ts)
+- Manifest 模式支持 `bootstrap-sha`、独立版本状态与 draft GitHub Release；draft 可在资产验证后发布。[Manifest releaser](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md)
+- `release-please-action@v5` 使用默认 `GITHUB_TOKEN` 创建的资源不会触发新的 workflow，因此稳定发布使用显式 workflow dispatch，而不依赖 release/tag 事件链。[Release Please Action](https://github.com/googleapis/release-please-action#other-actions-on-release-please-prs)
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Keep `product/main` as the default product branch.** (session-settled: user-directed — chosen over defaulting to mirror-only `main`: Ki-Core 需要独立产品版本和发布生命周期。) `main` 只镜像上游；`product/main` 只在稳定 tag 边界吸收 AionCore 更新，并保留产品发布层提交。Governs R1, R2.
+- KTD2. **Separate Ki-Core product SemVer from Cargo workspace version.** (session-settled: user-directed — chosen over reusing AionCore version semantics: Ki-Core 的 tag、二进制和发布历史属于自身产品。) Release Please 使用 `ki-core-version.txt` 和 `.release-please-manifest.json`；删除 Cargo updater 与 `cargo update --workspace`。`0.x` 阶段以 minor 表示上游稳定基线推进或不兼容发布契约变化，以 patch 表示同一基线上的兼容修正；`1.0.0` 后按 R4 的产品契约语义使用 major、minor 和 patch。Governs R3, R4.
+- KTD3. **Use a dedicated Ki-Core tag namespace and bootstrap at 0.1.0.** Release Please 使用 component `ki-core`、`include-component-in-tag: true`、`tag-separator: -` 和独立 changelog。首次 release PR 使用 `bootstrap-sha` 限定 changelog，并一次性指定 `0.1.0`；成功后移除 bootstrap 配置。Governs R4.
+- KTD4. **Prove source parity with an allowlisted overlay.** `ki-core-upstream.json` 保存当前 AionCore tag 与 peeled commit；验证器拒绝上游 tag/commit 不一致、Cargo/Rust/API/protocol/migration 差异，以及未列入产品文件集合的变化。Governs R2, R3, R5.
+- KTD5. **Keep an append-only checked-in mapping plus a release manifest.** `ki-core-versions.json` 是产品版本历史；release workflow 从映射和构建结果生成 `ki-core-release.json`。同一 AionCore commit 可以对应多个 Ki-Core patch。Ki-Buddy 不读取映射表；AionCore provenance 只取自已验证的 release manifest，同时按 R12 和 KTD9 校验 checksum 文件及 checked-in platform checksum。Governs R5, R6, R14.
+- KTD6. **Publish through a protected draft promotion.** 持续运行的 Release Please workflow 只生成 release PR。候选全部成功后，受保护的稳定发布 workflow 才调用 release-please release step 创建 draft tag/release，上传并验证全部资产，再将 draft 公开。`ki-core-v*` tag ruleset 禁止更新和删除；workflow 默认只读，只有通过独立审批且不能自审的 publication job 拥有 `contents: write`。草稿可恢复缺失上传；公开 release 禁止 `--clobber`，错误通过新 patch 修正。仓库管理员作为剩余信任边界写入运维文档。Governs R8, R9, R10.
+- KTD7. **Separate candidate and stable trust policies.** Candidate 来源必须携带 Ki-Core repo、workflow run、head SHA 和成功状态；stable 来源必须是完整 tag、manifest 和 checksum。Ki-Buddy 正式 workflow 只使用 `release-pinned`；开发 workflow 可以显式使用本地来源；candidate workflow 只使用经过 repository、workflow、conclusion、head SHA 和 artifact name 验证的 Actions 来源。Governs R11, R12, R13.
+- KTD8. **Keep the runtime binary contract unchanged for the first release.** (session-settled: user-approved — chosen over renaming the executable immediately: archive 和产品版本先独立，避免扩大安装器、web CLI 与 runtime resolver 的变更面。) Archive 名改为 Ki-Core，内部仍是 `aioncore[.exe]`，相关运行时目录与环境变量保持兼容。Governs R7.
+- KTD9. **Make Ki-Core the only provenance authority consumed by Ki-Buddy.** Ki-Buddy 的 product pin 固定 release tag 和各平台 checksum；AionCore tag/commit 由已验证的 Ki-Core manifest 注入 bundle manifest，避免双仓手工维护同一来源字段。Governs R11, R12, R14.
+- KTD10. **Use staged cross-repository delivery.** (session-settled: user-approved — chosen over independently publishing both repositories: Ki-Buddy 必须等待可下载的 Ki-Core stable release。) 顺序为：完成两仓发布基础设施；合并 Ki-Core release PR；冻结合并后的 `product/main` SHA；在未合并的 Ki-Buddy 集成分支上完成 candidate integration；发布 Ki-Core stable release；在同一 Ki-Buddy 分支写入正式 tag/checksum 并启用 `release-pinned`；完成正式 package verification 后才合并 Ki-Buddy PR。Governs R15.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  U["iOfficeAI/AionCore upstream/main"] --> M["Ki-Core main mirror"]
+  T["AionCore stable tag + peeled commit"] --> P["Ki-Core product/main product overlay"]
+  M -. "tracks newer upstream commits independently" .-> T
+  P --> C["Six-platform candidate build"]
+  C --> G{"All contracts pass?"}
+  G -->|no| X["Stop without public release"]
+  G -->|yes| D["ki-core-v* draft release"]
+  D --> V["Manifest + checksum + asset verification"]
+  V --> S["Immutable stable Ki-Core release"]
+  S --> B["Ki-Buddy pinned download"]
+  B --> K["Verified bundled-aioncore manifest"]
+```
+
+```mermaid
+sequenceDiagram
+  participant M as Maintainer
+  participant KC as Ki-Core Actions
+  participant GH as GitHub Release
+  participant KB as Ki-Buddy Actions
+  M->>KC: Merge release PR and freeze product/main SHA
+  KC->>KC: Validate allowlist and build six candidates
+  KC-->>M: Candidate manifest, checksums, run identity
+  M->>KB: Prepare unmerged integration branch
+  M->>KB: Run candidate build with run ID + frozen head SHA
+  KB->>KC: Verify run/workflow/repo and fetch artifact
+  KB-->>M: Candidate integration result
+  M->>KC: Approve stable publication
+  KC->>GH: Create draft tag/release after builds pass
+  KC->>GH: Upload and verify all assets
+  KC->>GH: Publish draft
+  M->>KB: Update same branch with stable tag + checksums
+  KB->>GH: Fetch checksum, manifest, archive
+  KB->>KB: Verify and package
+  M->>KB: Merge integration PR after all targets pass
+```
+
+### Branch and Release State Rules
+
+- Ki-Core `main` may advance to upstream/main independently. Ki-Core `product/main` only absorbs an upstream stable tag after its tag and peeled commit have been recorded.
+- Upstream sync PRs into `product/main` use a merge commit so upstream ancestry remains visible. The current product ruleset must add `merge` to the allowed methods; feature and product metadata PRs continue to use squash or rebase.
+- Candidate creation occurs after the release PR merge and freezes the resulting `product/main` SHA together with the AionCore tag/commit. A newer upstream tag or later product commit does not change that candidate. The maintainer either finishes it or starts a new candidate and repeats verification.
+- One release concurrency group serializes candidate-to-publication work. A protected release environment requires an independent reviewer, prevents self-review, and accepts only the verified `product/main` SHA. Repository and workflow permissions stay read-only except for the approved publication job.
+- A `ki-core-v*` tag ruleset blocks update and deletion for automation and non-admin actors. Repository administrators remain an explicit operational trust boundary; emergency changes require audit evidence and cannot be represented as a normal release retry.
+- A draft may accept a retry only when tag, release SHA, metadata and existing asset hashes match. A published release rejects every mutation attempt.
+
+### System-Wide Impact
+
+- **Version semantics:** Ki-Core product version becomes distinct from AionCore runtime version. `Cargo.toml`, `Cargo.lock` and runtime `CARGO_PKG_VERSION` stay under upstream control.
+- **Artifact contract:** Ki-Core changes public tag/archive/manual artifact names. Ki-Buddy download and test paths must change in the same delivery sequence.
+- **Build reproducibility:** Ki-Buddy stable builds lose the `latest` and local fallback paths. Missing product pin or provenance becomes a build error.
+- **Diagnostics:** Bundle diagnostics gain product and upstream fields. Existing `manifest.version` remains available during migration, with its meaning documented as Ki-Core product SemVer.
+- **Permissions:** Candidate cross-repo download needs a fine-grained read-only token unless live verification proves public Actions artifacts are readable with the existing token. Stable consumption needs no cross-repo write credential.
+- **Observability:** Workflow summaries, release manifest, checksum failures and existing build errors provide sufficient visibility. No application runtime logging change is needed because the behavior occurs during build and release.
+- **Data and protocol:** No runtime database, API, protocol or user data migration occurs.
+
+### Risks and Mitigations
+
+| Risk                                                 | Consequence                                                   | Mitigation                                                                                                                                                                                                                                                 |
+| ---------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Release Please publishes before asset validation     | Public release is incomplete                                  | Run release creation only after candidate jobs succeed, create as draft, and publish after full verification.                                                                                                                                              |
+| Product branch contains untagged upstream source     | Mapping misrepresents the binary                              | Freeze a stable tag and enforce the product overlay allowlist against its peeled commit.                                                                                                                                                                   |
+| Release PR includes old upstream history             | Incorrect version or noisy changelog                          | Use one-time `bootstrap-sha` and explicit `0.1.0`, then remove bootstrap configuration after the first release.                                                                                                                                            |
+| Stable assets are replaced                           | Existing Ki-Buddy builds become non-reproducible              | Remove `--clobber`, reject existing tag/assets, and issue a patch version for corrections.                                                                                                                                                                 |
+| Publication bypasses the intended source or approver | Unverified code becomes a stable product release              | Require an independent protected-environment reviewer, prevent self-review, accept only the verified `product/main` SHA, and grant `contents: write` only to the publication job.                                                                          |
+| Actions artifact run ID points elsewhere             | Candidate validation consumes the wrong binary                | Require repo, workflow, conclusion, head SHA and artifact-name checks.                                                                                                                                                                                     |
+| Candidate is built from a pre-merge PR SHA           | Candidate evidence does not cover the eventual release commit | Merge the release PR first, freeze the merged `product/main` SHA, and use that SHA for both candidate integration and stable publication.                                                                                                                  |
+| Archive entries escape the extraction directory      | A build writes or links files outside managed resources       | Enumerate and normalize entries before extraction; reject unsafe paths and links, then verify all outputs remain inside a new temporary directory.                                                                                                         |
+| Cross-repo Actions token is unavailable              | Candidate integration cannot prove the required run identity  | Configure a read-only fine-grained token, or verify that the existing token can read public Ki-Core Actions artifacts. If neither path works, block candidate integration. Local bundles remain development inputs and do not count as candidate evidence. |
+| Upstream publishes during candidate verification     | Pressure to change a frozen source                            | Keep the candidate immutable and require a maintainer decision to restart against the newer tag.                                                                                                                                                           |
+| Ki-Buddy integration fails after Core release        | Cross-repo delivery is partially complete                     | Keep the valid Ki-Core release, repair or revert the Buddy pin, and never mutate Core assets.                                                                                                                                                              |
+
+---
+
+## Implementation Units
+
+### U1. Align branches and define the Ki-Core product metadata contract
+
+- **Goal:** Establish the exact upstream baseline, independent product version files, append-only mapping and source-parity validation.
+- **Requirements:** R1, R2, R3, R4, R5
+- **Dependencies:** None
+- **Files:**
+  - Ki-Core: `ki-core-version.txt` (create)
+  - Ki-Core: `ki-core-upstream.json` (create)
+  - Ki-Core: `ki-core-versions.json` (create)
+  - Ki-Core: `scripts/ki-core-release/validate-release-metadata.sh` (create)
+  - Ki-Core: `scripts/ki-core-release/update-release-map.sh` (create)
+  - Ki-Core: `scripts/ki-core-release/validate-release-metadata.test.sh` (create)
+  - Ki-Core: `Justfile`
+  - GitHub: Ki-Core and Ki-Buddy `Protect product branch` rulesets
+- **Approach:** Sync both `main` branches to upstream. Merge the selected AionCore stable tag into Ki-Core `product/main`. Add `merge` to product rulesets for upstream sync PRs. Store the peeled upstream commit separately from product version history. Make the validator compare the release tree with the mapped commit and accept only product release metadata, scripts, documentation and workflows.
+- **Test scenarios:**
+  - Valid stable tag, peeled commit and allowlisted product overlay pass.
+  - Tag/commit mismatch fails.
+  - A change under Cargo workspace, Rust crates, API types, protocol or migrations fails.
+  - Duplicate Ki-Core version or rewritten historic mapping fails.
+  - A new patch version pointing to an existing AionCore commit passes.
+- **Verification:** `just check` includes the Ki-Core metadata validator, and the first mapping entry identifies one exact AionCore stable tag/commit with no source-layer difference.
+
+### U2. Convert Release Please to Ki-Core product semantics
+
+- **Goal:** Generate Ki-Core release PRs and configure the `ki-core-v*` tag namespace without modifying AionCore version files. This unit does not create a tag or GitHub Release.
+- **Requirements:** R3, R4, R5, R10
+- **Dependencies:** U1
+- **Files:**
+  - Ki-Core: `release-please-config.json`
+  - Ki-Core: `.release-please-manifest.json`
+  - Ki-Core: `CHANGELOG.ki-core.md` (create)
+  - Ki-Core: `.github/workflows/release-please.yml`
+  - Ki-Core: `ki-core-version.txt`
+  - Ki-Core: `ki-core-versions.json`
+- **Approach:** Keep the `simple` strategy, set component `ki-core`, enable component tag naming, use `ki-core-version.txt`, and use the Ki-Core changelog. Remove the Cargo extra-file updater and Cargo.lock update job. Limit the first changelog with `bootstrap-sha`; request `0.1.0` once, then remove bootstrap-only configuration. Release PR generation skips GitHub Release creation; publication belongs to U3.
+- **Release PR mapping step:** After Release Please opens or updates its trusted PR, a metadata job checks out that PR's exact head branch, runs `scripts/ki-core-release/update-release-map.sh` with the proposed Ki-Core version and frozen AionCore tag/peeled commit, runs the U1 validator, and commits the mapping update to the same PR branch. If authentication, validation or push fails, the PR remains unready and publication is blocked.
+- **Test scenarios:**
+  - A representative conventional commit proposes the expected Ki-Core version and tag namespace.
+  - The release PR contains a mapping entry whose Ki-Core version matches the proposal and whose AionCore tag/peeled commit match `ki-core-upstream.json`; `Cargo.toml` and `Cargo.lock` remain unchanged.
+  - A missing or stale mapping update prevents the release PR from passing validation.
+  - A second simulated release derives from the Ki-Core tag history and does not reuse an upstream `v*` tag.
+- **Verification:** The generated release PR targets `product/main`, contains a `ki-core-v0.1.0` proposal for the bootstrap, and passes the U1 validator.
+
+### U3. Implement candidate builds and the protected Ki-Core publication workflow
+
+- **Goal:** Implement six-platform candidate generation, asset verification and the protected stable-publication capability. This unit does not publish the first stable version; U7 performs that operation after Ki-Buddy candidate integration succeeds.
+- **Requirements:** R6, R7, R8, R9, R10
+- **Dependencies:** U1, U2
+- **Files:**
+  - Ki-Core: `.github/workflows/build-manual.yml`
+  - Ki-Core: `.github/workflows/release.yml`
+  - Ki-Core: `scripts/ki-core-release/build-release-manifest.sh` (create)
+  - Ki-Core: `scripts/ki-core-release/verify-release-assets.sh` (create)
+  - Ki-Core: `scripts/ki-core-release/verify-release-assets.test.sh` (create)
+  - GitHub: Ki-Core protected release environment, repository variable and workflow permissions
+- **Approach:** Rename manual and stable artifacts to the Canonical Platform Set while retaining the inner executable. Candidate artifacts carry source identity, manifest and checksums. The stable workflow accepts the merged and frozen `product/main` SHA, validates mapping and tag syntax, builds all targets, creates a draft only after builds succeed, uploads without `--clobber`, verifies the complete asset set, then publishes. A resumed draft must match the same tag and SHA. Repository configuration protects `ki-core-v*` from update/delete, requires an independent protected-environment reviewer with self-review disabled, and keeps `contents: write` out of every job except approved publication.
+- **Test scenarios:**
+  - Strict parser accepts `ki-core-v0.1.0` and rejects bare `v0.1.0`, malformed SemVer and metadata mismatch.
+  - Six archive names are unique and each archive contains the expected executable.
+  - Linux GLIBC checks remain required.
+  - One failed target leaves no public stable release.
+  - Missing, duplicate or mismatched checksum/manifest entries stop publication.
+  - Existing public tag or asset stops the workflow; matching draft metadata permits upload of missing assets only.
+  - A request without approval, with self-approval, from the wrong ref, or for a SHA other than the verified `product/main` commit cannot reach the write-capable publication step.
+  - A non-bypass actor cannot move or delete an existing `ki-core-v*` tag; workflow reruns cannot overwrite a published asset.
+- **Verification:** A manual all-platform candidate run produces six valid artifacts. A dry publication against a temporary draft demonstrates that promotion occurs only after the complete manifest/checksum contract passes.
+
+### U4. Move Ki-Buddy version resolution and downloads to Ki-Core
+
+- **Goal:** Make Ki-Buddy consume a fixed Ki-Core product release and verify it before extraction.
+- **Requirements:** R11, R12, R13
+- **Dependencies:** U3 candidate contract
+- **Files:**
+  - Ki-Buddy: `package.json`
+  - Ki-Buddy: `scripts/resolveAioncoreVersion.js`
+  - Ki-Buddy: `scripts/prepareAioncore.js`
+  - Ki-Buddy: `scripts/build-with-builder.js`
+  - Ki-Buddy: `scripts/pack-web-cli.js`
+  - Ki-Buddy: `packages/shared-scripts/src/prepare-aioncore.js`
+  - Ki-Buddy: `tests/unit/assets/prepareAioncoreRelease.test.ts` (create)
+  - Ki-Buddy: `tests/unit/assets/prepareAioncoreActionsArtifact.test.ts`
+- **Approach:** Implement the resolver and downloader on one Ki-Buddy integration branch that remains unmerged through candidate validation and Core publication. Before stable publication, this branch consumes only the verified Actions candidate and does not claim a stable tag/checksum. After publication, update the same branch with the full Ki-Core tag and pinned platform checksums, then enable the official `release-pinned` paths. Keep runtime AionCore names from KTD8. Accept the Ki-Core tag verbatim, resolve the Canonical Platform Set archive/artifact names, verify release checksum and manifest, enumerate and validate archive entries, and extract only into a new temporary directory whose normalized outputs remain inside it.
+- **Test scenarios:**
+  - All six platforms resolve the expected `xlihub/Ki-Core` release URL and asset name.
+  - Missing pin and `latest` fail under `release-pinned` policy.
+  - Valid checksum and manifest permit extraction; missing, duplicate, malformed or mismatched values fail before extraction and remove temporary files.
+  - Absolute paths, `..` traversal, symbolic links, hard links, normalized duplicate paths and unexpected archive contents fail before extraction without writing outside the temporary directory.
+  - Candidate run with wrong repo, workflow, conclusion, head SHA or artifact name fails.
+  - Existing local bundle and local binary development tests remain valid outside `release-pinned` policy.
+- **Verification:** Focused asset tests prove stable and candidate trust paths, while existing managed-resource contract tests remain green.
+
+### U5. Carry Ki-Core and AionCore provenance through the bundle
+
+- **Goal:** Preserve verified release identity in packaged resources and diagnostics.
+- **Requirements:** R6, R12, R14
+- **Dependencies:** U4
+- **Files:**
+  - Ki-Buddy: `packages/shared-scripts/src/prepare-aioncore.js`
+  - Ki-Buddy: `packages/desktop/src/process/startup/backendInstallDiagnostics.ts`
+  - Ki-Buddy: `tests/unit/assets/prepareAioncoreRelease.test.ts`
+  - Ki-Buddy: `tests/unit/assets/prepareAioncoreLocalBundle.test.ts`
+  - Ki-Buddy: `tests/unit/bootstrap/backendInstallDiagnostics.test.ts`
+  - Ki-Buddy: `tests/unit/bootstrap/buildWithBuilder.test.ts`
+- **Approach:** Extend the bundle manifest with schema version, Ki-Core product identity, AionCore upstream identity and source details. Preserve a documented compatibility `version` field during migration. Stable downloads copy provenance from the verified release manifest; candidate and local sources record their non-stable identity without presenting it as a stable product release.
+- **Test scenarios:**
+  - Stable bundle manifest contains matching Ki-Core and AionCore fields from the release manifest.
+  - Candidate manifest records run ID, head SHA and artifact identity.
+  - Local bundle and local binary manifest cannot claim stable provenance.
+  - Diagnostics expose all provenance fields and report malformed manifest data without crashing startup.
+- **Verification:** Bundle manifest tests compare exact provenance values, and backend diagnostics tests show the same values available for support reports.
+
+### U6. Wire candidate and stable policies into Ki-Buddy workflows
+
+- **Goal:** Ensure manual integration can consume a verified candidate while every official package consumes the stable pin.
+- **Requirements:** R11, R13, R15
+- **Dependencies:** U3, U4, U5
+- **Files:**
+  - Ki-Buddy: `.github/workflows/_build-reusable.yml`
+  - Ki-Buddy: `.github/workflows/build-manual.yml`
+  - Ki-Buddy: `.github/workflows/pack-web-cli.yml`
+  - Ki-Buddy: `.github/workflows/build-and-release.yml`
+  - Ki-Buddy: `.github/workflows/README.md`
+  - GitHub: optional Ki-Core Actions read token for Ki-Buddy candidate builds
+- **Approach:** Rename manual inputs to Ki-Core semantics and require run ID plus the merged, frozen `product/main` SHA for candidate builds. Keep the Ki-Buddy integration branch unmerged while it uses candidate policy. After the Ki-Core stable release exists, write its tag/checksums to that same branch and set `release-pinned` on ordinary PR, web CLI and stable package workflows. Keep candidate credentials read-only and absent from untrusted fork contexts. Document which workflows may select each source policy.
+- **Test scenarios:**
+  - Official workflow configuration has no run ID/local source and requires the package pin.
+  - Manual candidate workflow passes both run ID and head SHA.
+  - Missing candidate credential fails with an actionable error; it does not affect stable release consumption.
+  - Fork PR workflows cannot access the candidate token.
+- **Verification:** One Ki-Buddy manual build consumes a verified Ki-Core candidate; ordinary build paths resolve only the checked-in stable configuration.
+
+### U7. Publish `ki-core-v0.1.0` and verify Ki-Buddy consumption
+
+- **Goal:** Execute the first stable release and prove the complete cross-repository path.
+- **Requirements:** R4, R6, R7, R8, R9, R10, R15
+- **Dependencies:** U1, U2, U3, U4, U5, U6
+- **Files:**
+  - Ki-Core: `ki-core-upstream.json`
+  - Ki-Core: `ki-core-versions.json`
+  - Ki-Buddy: `package.json`
+  - GitHub: Ki-Core draft/stable release and Ki-Buddy verification runs
+- **Approach:** Re-query the latest stable AionCore release. Use `v0.1.58 / 134daddc...` when it remains current; otherwise update the candidate and repeat all gates. Merge the Ki-Core release PR and freeze the resulting `product/main` SHA. Build all candidates from that SHA and run Ki-Buddy candidate integration from the unmerged integration branch. Only after candidate integration succeeds, approve publication of the same frozen SHA. Verify the public release, update the same Ki-Buddy branch to the immutable tag and checksums, enable its `release-pinned` workflows, and complete all Ki-Buddy platform builds before the pin PR becomes ready or merges. Do not create a Ki-Buddy stable release.
+- **Test scenarios:**
+  - Public release contains six archives, manifest and checksum file with matching hashes.
+  - Release tag points to the approved Ki-Core commit and its mapping points to the frozen AionCore commit.
+  - Candidate run, protected publication and public release all identify the same merged `product/main` commit.
+  - Ki-Buddy builds each supported target from the public release and records matching provenance.
+  - A forced checksum mismatch proves the official build stops and does not use another source.
+- **Verification:** GitHub release inspection, downloaded checksum verification and Ki-Buddy all-platform build results satisfy every scenario before the Ki-Buddy pin PR is considered complete.
+
+---
+
+## Verification Contract
+
+| Gate                     | Repository      | Applies to                              | Command or evidence                                                                                                                                                                                                                                                                   | Required outcome                                                                                                                                                                          |
+| ------------------------ | --------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Core release metadata    | Ki-Core         | U1-U3, U7                               | `just migration-check`, Ki-Core release metadata validator                                                                                                                                                                                                                            | Upstream mapping is exact; product overlay contains no disallowed source change.                                                                                                          |
+| Release PR mapping       | Ki-Core         | U2, U7                                  | Release PR diff plus metadata-job result                                                                                                                                                                                                                                              | Proposed Ki-Core version, AionCore tag and peeled commit are recorded and validated on the release PR branch before merge.                                                                |
+| Core formatting and lint | Ki-Core         | U1-U3                                   | `just fmt-check`, `just lint`                                                                                                                                                                                                                                                         | Formatting and Clippy pass without changing AionCore product versions.                                                                                                                    |
+| Core tests               | Ki-Core         | U1-U3                                   | `just test` plus release-script tests                                                                                                                                                                                                                                                 | Workspace tests and release contract scenarios pass.                                                                                                                                      |
+| Core full gate           | Ki-Core         | Before each PR is ready                 | `just check`                                                                                                                                                                                                                                                                          | Migration, lint, format and tests all pass.                                                                                                                                               |
+| Buddy focused tests      | Ki-Buddy        | U4-U6                                   | `bunx vitest run tests/unit/assets/prepareAioncoreRelease.test.ts tests/unit/assets/prepareAioncoreActionsArtifact.test.ts tests/unit/assets/prepareAioncoreLocalBundle.test.ts tests/unit/bootstrap/backendInstallDiagnostics.test.ts tests/unit/bootstrap/buildWithBuilder.test.ts` | Stable, candidate, local and diagnostic paths satisfy their source policies.                                                                                                              |
+| Buddy static checks      | Ki-Buddy        | U4-U6                                   | `bun run lint`, `bun run format:check`, `bunx tsc --noEmit`                                                                                                                                                                                                                           | No lint, formatting or TypeScript errors.                                                                                                                                                 |
+| Buddy full tests         | Ki-Buddy        | Before each PR is ready                 | `bun run test`, `bun run test:coverage`                                                                                                                                                                                                                                               | All tests pass and project coverage remains at least 80%.                                                                                                                                 |
+| Archive safety           | Ki-Buddy        | U4                                      | Focused malicious-archive fixtures                                                                                                                                                                                                                                                    | Unsafe paths, links, duplicates and unexpected contents fail before extraction; no output escapes the new temporary directory.                                                            |
+| GitHub release controls  | Ki-Core         | U3, U7                                  | Environment/ruleset API inspection plus negative workflow attempts                                                                                                                                                                                                                    | Independent approval, no self-review, exact product SHA, tag update/delete protection and publication-only write permission are all enforced; administrator trust boundary is documented. |
+| Candidate matrix         | Both            | U3, U6                                  | Ki-Core manual all-platform run plus Ki-Buddy candidate build                                                                                                                                                                                                                         | Six Core candidates come from the merged frozen `product/main` SHA; Buddy accepts only that exact run identity.                                                                           |
+| Stable release           | Both            | U7                                      | Public GitHub release inspection, independent checksum verification, Ki-Buddy all-platform build                                                                                                                                                                                      | Immutable `ki-core-v0.1.0` is complete and every Buddy target consumes it.                                                                                                                |
+| Push gate                | Each repository | Only when push is explicitly authorized | `just push` in that repository                                                                                                                                                                                                                                                        | Repository-specific pre-push checks pass before GitHub mutation.                                                                                                                          |
+
+No renderer text or locale file is expected to change. If implementation touches renderer or i18n paths, it must also run `bun run i18n:types` and `node scripts/check-i18n.js`.
+
+---
+
+## Definition of Done
+
+- D1. Both `main` branches match their upstream mirrors, and both `product/main` branches remain the default product branches.
+- D2. Ki-Core product version files, changelog and tag namespace are independent from `Cargo.toml`, `Cargo.lock` and AionCore `v*` tags.
+- D3. Ki-Core CI rejects any release commit with Rust/API/protocol/database or other non-allowlisted differences from the mapped AionCore commit.
+- D4. The Ki-Core release PR contains an append-only `0.1.0` mapping to one verified AionCore stable tag and peeled commit; the mapping validator passes before merge.
+- D5. The public `ki-core-v0.1.0` release contains six non-overwritable platform archives, `ki-core-release.json` and `ki-core-checksums.txt`; all names, hashes and executable contents agree.
+- D6. A failed candidate or draft never produces an incomplete public stable release. A workflow rerun or non-bypass actor cannot move/delete its tag or replace its assets; repository administrators are documented as the remaining trust boundary.
+- D7. Ki-Buddy official builds require the checked-in Ki-Core pin, validate provenance, SHA-256 and archive path safety before extraction, and never use `latest` or local sources.
+- D8. Ki-Buddy candidate builds validate Ki-Core repository, workflow, successful run, head SHA and platform artifact.
+- D9. Packaged bundle manifests and installation diagnostics expose matching Ki-Core and AionCore provenance for stable builds.
+- D10. Ki-Buddy first validates the merged Ki-Core release commit through a candidate on an unmerged integration branch, then completes all supported platform builds against the public release before that branch merges. No Ki-Buddy stable release is created by this plan.
+- D11. GitHub release approval, prevent-self-review, exact-ref validation, tag protection, publication-only write permission, concurrency and credential boundaries are configured and documented; candidate credentials are read-only and unavailable to untrusted fork workflows.
+- D12. All verification gates pass, temporary test releases are removed only when they were never public, and abandoned experimental code or workflow branches are absent from the final changes.

--- a/docs/plans/2026-08-05-001-feat-ki-core-independent-release-plan.md
+++ b/docs/plans/2026-08-05-001-feat-ki-core-independent-release-plan.md
@@ -11,7 +11,7 @@ status: superseded
 
 # Ki-Core Independent Release and Ki-Buddy Integration - Plan
 
-> **已废弃（2026-08-06）**  
+> **已废弃（2026-08-06）**
 > 本计划保留为历史记录，不再作为实施或发版依据。Candidate Build 前置、复杂发布状态和多阶段资产发布要求已经被后续对齐方案替代。当前有效方案见[上游发版流程分析与 Ki 双仓目标流程](../contributing/upstream-release-analysis-and-target-alignment.zh-CN.md)，实际操作见[仓库管理者发版和维护手册](../contributing/maintainer-release-and-maintenance-handbook.zh-CN.md)。
 
 ## Goal Capsule


### PR DESCRIPTION
# Pull Request

## Description

更新 Ki-Buddy / Ki-Core 双仓发布流程分析和维护手册，使文档反映 Ki-Core `0.1.0` 已实际发布的状态。

主要内容：

- 记录 `ki-core-v0.1.0`、[Ki-Core 发布 PR #9](https://github.com/xlihub/Ki-Core/pull/9)、Release Please 和六平台稳定版构建结果。
- 将首次发布期间的恢复操作改为历史故障记录，避免后续版本误用 `release-current`。
- 说明 Release Please 对标题、正文、标签和发布分支名的机器协议。
- 将后续实施顺序更新为 AionUi 上游对齐、Ki-Core 正式 pin 和 Ki-Buddy 独立发版体系。

## Related Issues

无。

## Type of Change

- [x] `docs` — 文档更新

## Atomic PR Checklist (Rule 1)

- [x] 本 PR 只包含发布流程文档更新，未混入运行时代码或工作流改动
- [x] PR 标题符合 Conventional Commit 格式：`<type>(<scope>): <subject>`（英文）

## Local Checks (Rule 3)

- [x] `bun run format` — 通过
- [x] `bun run lint` — 0 个错误；仓库既有 warning 未阻断
- [x] `bunx tsc --noEmit` — 通过
- [x] `bunx vitest run` — 3025 个测试通过，5 个跳过
- [x] i18n 校验 — 通过；本 PR 未修改 i18n 文件
- [x] 新增或修改的用户可见文本使用 i18n key — 不适用，仅修改文档

## Runtime Verification

- [ ] 已在 macOS 验证运行时行为
- [ ] 已在 Windows 验证运行时行为
- [ ] 已在 Linux 验证运行时行为
- [x] 已完成文档自查

本 PR 不修改运行时代码，因此没有执行平台运行时验证。

## Screenshots

不适用。

## Additional Context

远端证据：

- [Ki-Core 0.1.0 Release](https://github.com/xlihub/Ki-Core/releases/tag/ki-core-v0.1.0)
- [Ki-Core 发布 PR #9](https://github.com/xlihub/Ki-Core/pull/9)
- [Release Please 运行记录](https://github.com/xlihub/Ki-Core/actions/runs/31068696569)
- [稳定版构建运行记录](https://github.com/xlihub/Ki-Core/actions/runs/31068791622)

本 PR 不修改工作流、依赖或 `bun.lock`。
