### PR TITLE
feat(core): consume verified Ki-Core v0.1.0

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,6 +14,8 @@ Ki-Buddy 打包只允许三种显式来源策略：
 
 正式桌面包与 Web CLI workflow 同时固定 `BUN_INSTALL_REGISTRY` 和 `npm_config_registry` 到 npm 官方 registry。后者用于 Ki-Core 的 `prepare-managed-resources` 安装 Codex、Claude 等平台包，避免 runner 用户级 `.npmrc` 改变正式构建来源。
 
+Reusable desktop build 的 source map 上传默认关闭，只有 `build-and-release.yml` 显式传入 `upload_source_maps: true`。手工六平台验证因此不依赖 Sentry secrets；正式发布仍在 Linux x64 job 中强制验证 Sentry 配置并上传 source maps。
+
 本项目使用 GPT 驱动的 GitHub Actions 工作流辅助 PR 审查。
 
 ## 架构概览

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,5 +1,15 @@
 # GPT Workflows
 
+## Ki-Core 来源策略
+
+Ki-Buddy 打包只允许三种显式来源策略：
+
+- `release-pinned`：正式桌面包与 Web CLI 使用。读取 `package.json` 的完整 Ki-Core tag 和六平台 SHA-256；禁止 `latest`、Actions run ID 和本地 binary。
+- `candidate`：仅 `build-manual.yml` 使用。必须提供 Ki-Core Candidate Build run ID、完整 `product/main` commit SHA，以及只读 `KI_CORE_ACTIONS_TOKEN`。
+- `development`：仅本地开发使用。允许显式 local bundle、local binary 或旧 AionCore 下载路径，不得写入稳定 Ki-Core provenance。
+
+`KI_CORE_ACTIONS_TOKEN` 只授予读取 `xlihub/Ki-Core` Actions run 与 artifact 的权限。普通 PR、Web CLI 和正式发布 workflow 不传递该 secret。首次 Ki-Core release 发布并验证六个平台后，才能填写 `package.json.kiCore.tag` 与 `checksums` 并启用正式构建。
+
 本项目使用 GPT 驱动的 GitHub Actions 工作流辅助 PR 审查。
 
 ## 架构概览

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,11 +4,11 @@
 
 Ki-Buddy 打包只允许三种显式来源策略：
 
-- `release-pinned`：正式桌面包与 Web CLI 使用。读取 `package.json` 的完整 Ki-Core tag 和六平台 SHA-256；禁止 `latest`、Actions run ID 和本地 binary。
+- `release-pinned`：正式桌面包与 Web CLI 使用。读取 `package.json` 的完整 Ki-Core tag、tag commit、AionCore 映射和六平台 SHA-256；下载 Release checksums 后与固定值逐项比对。禁止 `latest`、Actions run ID 和本地 binary。
 - `candidate`：仅 `build-manual.yml` 使用。必须提供 Ki-Core Candidate Build run ID 和完整 `product/main` commit SHA。Ki-Core 是公开仓库，候选读取使用公开 Actions API，不向目标构建分支传递跨仓 token。
 - `development`：仅本地开发使用。允许显式 local bundle、local binary 或旧 AionCore 下载路径，不得写入稳定 Ki-Core provenance。
 
-首次 Ki-Core release 发布并验证六个平台后，才能填写 `package.json.kiCore.tag` 与 `checksums` 并启用正式构建。
+首次 Ki-Core release 发布并验证六个平台后，才能填写 `package.json.kiCore.tag`、`commit`、`aionCore` 与 `checksums` 并启用正式构建。Candidate artifact 只包含当前平台 archive；其可信身份来自指定的 Actions run、workflow、`product/main` commit 和 artifact 名称，不依赖额外 provenance manifest。
 
 本项目使用 GPT 驱动的 GitHub Actions 工作流辅助 PR 审查。
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,11 @@ Ki-Buddy 打包只允许三种显式来源策略：
 - `candidate`：仅 `build-manual.yml` 使用。必须提供 Ki-Core Candidate Build run ID 和完整 `product/main` commit SHA。Ki-Core 是公开仓库，候选读取使用公开 Actions API，不向目标构建分支传递跨仓 token。
 - `development`：仅本地开发使用。允许显式 local bundle、local binary 或旧 AionCore 下载路径，不得写入稳定 Ki-Core provenance。
 
-首次 Ki-Core release 发布并验证六个平台后，才能填写 `package.json.kiCore.tag`、`commit`、`aionCore` 与 `checksums` 并启用正式构建。Candidate artifact 只包含当前平台 archive；其可信身份来自指定的 Actions run、workflow、`product/main` commit 和 artifact 名称，不依赖额外 provenance manifest。
+`build-manual.yml` 默认使用 `release-pinned` 验证已发布版本；选择 `candidate` 时才填写 run ID 与 head SHA，两项必须同时提供。Candidate artifact 只包含当前平台 archive；其可信身份来自指定的 Actions run、workflow、`product/main` commit 和 artifact 名称，不依赖额外 provenance manifest。
+
+当前正式 pin 为 Ki-Core `ki-core-v0.1.0`，对应 AionCore `v0.1.59`。`package.json.kiCore` 固定 Ki-Core tag、tag commit、AionCore tag/commit 和六个平台 SHA-256；更新任何一项都必须作为一次明确的版本消费变更进行验证。
+
+正式桌面包与 Web CLI workflow 同时固定 `BUN_INSTALL_REGISTRY` 和 `npm_config_registry` 到 npm 官方 registry。后者用于 Ki-Core 的 `prepare-managed-resources` 安装 Codex、Claude 等平台包，避免 runner 用户级 `.npmrc` 改变正式构建来源。
 
 本项目使用 GPT 驱动的 GitHub Actions 工作流辅助 PR 审查。
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,10 +5,10 @@
 Ki-Buddy 打包只允许三种显式来源策略：
 
 - `release-pinned`：正式桌面包与 Web CLI 使用。读取 `package.json` 的完整 Ki-Core tag 和六平台 SHA-256；禁止 `latest`、Actions run ID 和本地 binary。
-- `candidate`：仅 `build-manual.yml` 使用。必须提供 Ki-Core Candidate Build run ID、完整 `product/main` commit SHA，以及只读 `KI_CORE_ACTIONS_TOKEN`。
+- `candidate`：仅 `build-manual.yml` 使用。必须提供 Ki-Core Candidate Build run ID 和完整 `product/main` commit SHA。Ki-Core 是公开仓库，候选读取使用公开 Actions API，不向目标构建分支传递跨仓 token。
 - `development`：仅本地开发使用。允许显式 local bundle、local binary 或旧 AionCore 下载路径，不得写入稳定 Ki-Core provenance。
 
-`KI_CORE_ACTIONS_TOKEN` 只授予读取 `xlihub/Ki-Core` Actions run 与 artifact 的权限。普通 PR、Web CLI 和正式发布 workflow 不传递该 secret。首次 Ki-Core release 发布并验证六个平台后，才能填写 `package.json.kiCore.tag` 与 `checksums` 并启用正式构建。
+首次 Ki-Core release 发布并验证六个平台后，才能填写 `package.json.kiCore.tag` 与 `checksums` 并启用正式构建。
 
 本项目使用 GPT 驱动的 GitHub Actions 工作流辅助 PR 审查。
 

--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -23,6 +23,10 @@ on:
         description: 'Only upload primary installers (exe/msi/dmg/deb), skip zip/yml/blockmap'
         type: boolean
         default: false
+      upload_source_maps:
+        description: 'Upload desktop source maps from linux-x64; official release builds only'
+        type: boolean
+        default: false
       ki_core_source_policy:
         description: 'Ki-Core source policy: release-pinned for official builds or candidate for manual integration'
         type: string
@@ -260,7 +264,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "${{ matrix.platform }}" == "linux-x64" ]]; then
+          if [[ "${{ inputs.upload_source_maps }}" == "true" && "${{ matrix.platform }}" == "linux-x64" ]]; then
             echo "SENTRY_UPLOAD_SOURCE_MAPS=true" >> "$GITHUB_ENV"
             echo "Sentry source maps will be uploaded by linux-x64"
           else
@@ -269,7 +273,7 @@ jobs:
           fi
 
       - name: Validate Sentry source map upload configuration
-        if: matrix.platform == 'linux-x64'
+        if: inputs.upload_source_maps && matrix.platform == 'linux-x64'
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -65,6 +65,7 @@ on:
 
 env:
   BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
+  npm_config_registry: 'https://registry.npmjs.org/'
   AIONUI_HUB_TAG: 'dist-ebc6a2b'
   # Discontinued-build flag: only AionUi's final `-final` tag (e.g.
   # v2.1.40-final) produces a build that guides users to the AionPro website.

--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -50,9 +50,6 @@ on:
         required: false
       KEYCHAIN_PASSWORD:
         required: false
-      KI_CORE_ACTIONS_TOKEN:
-        description: 'Read-only token for xlihub/Ki-Core Actions artifacts; candidate policy only'
-        required: false
       P12_PASSWORD:
         required: false
       SENTRY_AUTH_TOKEN:
@@ -413,7 +410,6 @@ jobs:
           AIONUI_BACKEND_RUN_ID: ${{ inputs.ki_core_candidate_run_id }}
           AIONUI_BACKEND_EXPECTED_SHA: ${{ inputs.ki_core_candidate_head_sha }}
           AIONUI_BACKEND_ARCH: ${{ matrix.arch }}
-          KI_CORE_ACTIONS_TOKEN: ${{ inputs.ki_core_source_policy == 'candidate' && secrets.KI_CORE_ACTIONS_TOKEN || '' }}
 
       - name: Build with electron-builder (Windows)
         if: startsWith(matrix.platform, 'windows')
@@ -444,7 +440,6 @@ jobs:
           AIONUI_BACKEND_SOURCE_POLICY: ${{ inputs.ki_core_source_policy }}
           AIONUI_BACKEND_RUN_ID: ${{ inputs.ki_core_candidate_run_id }}
           AIONUI_BACKEND_EXPECTED_SHA: ${{ inputs.ki_core_candidate_head_sha }}
-          KI_CORE_ACTIONS_TOKEN: ${{ inputs.ki_core_source_policy == 'candidate' && secrets.KI_CORE_ACTIONS_TOKEN || '' }}
           # Node.js memory limit for vite bundling (prevents OOM during build)
           # Node.js 内存限制，防止 vite 打包时内存不足
           NODE_OPTIONS: '--max-old-space-size=8192'
@@ -550,7 +545,6 @@ jobs:
           AIONUI_BACKEND_SOURCE_POLICY: ${{ inputs.ki_core_source_policy }}
           AIONUI_BACKEND_RUN_ID: ${{ inputs.ki_core_candidate_run_id }}
           AIONUI_BACKEND_EXPECTED_SHA: ${{ inputs.ki_core_candidate_head_sha }}
-          KI_CORE_ACTIONS_TOKEN: ${{ inputs.ki_core_source_policy == 'candidate' && secrets.KI_CORE_ACTIONS_TOKEN || '' }}
           npm_config_arch: ${{ matrix.arch }}
           APP_ID: ${{ secrets.APP_ID }}
           appleId: ${{ secrets.APPLE_ID }}
@@ -591,7 +585,6 @@ jobs:
           AIONUI_BACKEND_SOURCE_POLICY: ${{ inputs.ki_core_source_policy }}
           AIONUI_BACKEND_RUN_ID: ${{ inputs.ki_core_candidate_run_id }}
           AIONUI_BACKEND_EXPECTED_SHA: ${{ inputs.ki_core_candidate_head_sha }}
-          KI_CORE_ACTIONS_TOKEN: ${{ inputs.ki_core_source_policy == 'candidate' && secrets.KI_CORE_ACTIONS_TOKEN || '' }}
           npm_config_arch: ${{ matrix.arch }}
           npm_config_cache: ${{ runner.temp }}/.npm
           ELECTRON_CACHE: ${{ runner.temp }}/.cache/electron

--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -23,10 +23,48 @@ on:
         description: 'Only upload primary installers (exe/msi/dmg/deb), skip zip/yml/blockmap'
         type: boolean
         default: false
-      aioncore_run_id:
-        description: 'Optional AionCore Manual Build workflow run id to bundle instead of the pinned release'
+      ki_core_source_policy:
+        description: 'Ki-Core source policy: release-pinned for official builds or candidate for manual integration'
+        type: string
+        default: 'release-pinned'
+      ki_core_candidate_run_id:
+        description: 'Ki-Core Candidate Build workflow run ID; candidate policy only'
         type: string
         default: ''
+      ki_core_candidate_head_sha:
+        description: 'Full Ki-Core product/main commit SHA; candidate policy only'
+        type: string
+        default: ''
+    secrets:
+      APP_ID:
+        required: false
+      APPLE_ID:
+        required: false
+      APPLE_ID_PASSWORD:
+        required: false
+      BUILD_CERTIFICATE_BASE64:
+        required: false
+      GH_TOKEN:
+        required: false
+      IDENTITY:
+        required: false
+      KEYCHAIN_PASSWORD:
+        required: false
+      KI_CORE_ACTIONS_TOKEN:
+        description: 'Read-only token for xlihub/Ki-Core Actions artifacts; candidate policy only'
+        required: false
+      P12_PASSWORD:
+        required: false
+      SENTRY_AUTH_TOKEN:
+        required: false
+      SENTRY_DSN:
+        required: false
+      SENTRY_ORG:
+        required: false
+      SENTRY_PROJECT:
+        required: false
+      TEAM_ID:
+        required: false
 
 env:
   BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
@@ -371,12 +409,11 @@ jobs:
         shell: bash
         run: node scripts/prepareAioncore.js
         env:
-          # Version is pinned in repo-root package.json (aioncoreVersion).
-          # Set AIONUI_BACKEND_VERSION here only to override for ad-hoc builds.
-          AIONUI_BACKEND_RUN_ID: ${{ inputs.aioncore_run_id }}
+          AIONUI_BACKEND_SOURCE_POLICY: ${{ inputs.ki_core_source_policy }}
+          AIONUI_BACKEND_RUN_ID: ${{ inputs.ki_core_candidate_run_id }}
+          AIONUI_BACKEND_EXPECTED_SHA: ${{ inputs.ki_core_candidate_head_sha }}
           AIONUI_BACKEND_ARCH: ${{ matrix.arch }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KI_CORE_ACTIONS_TOKEN: ${{ inputs.ki_core_source_policy == 'candidate' && secrets.KI_CORE_ACTIONS_TOKEN || '' }}
 
       - name: Build with electron-builder (Windows)
         if: startsWith(matrix.platform, 'windows')
@@ -404,7 +441,10 @@ jobs:
           }
         env:
           WINDOWS_BUILD_COMMAND: ${{ matrix.command }}
-          AIONUI_BACKEND_RUN_ID: ${{ inputs.aioncore_run_id }}
+          AIONUI_BACKEND_SOURCE_POLICY: ${{ inputs.ki_core_source_policy }}
+          AIONUI_BACKEND_RUN_ID: ${{ inputs.ki_core_candidate_run_id }}
+          AIONUI_BACKEND_EXPECTED_SHA: ${{ inputs.ki_core_candidate_head_sha }}
+          KI_CORE_ACTIONS_TOKEN: ${{ inputs.ki_core_source_policy == 'candidate' && secrets.KI_CORE_ACTIONS_TOKEN || '' }}
           # Node.js memory limit for vite bundling (prevents OOM during build)
           # Node.js 内存限制，防止 vite 打包时内存不足
           NODE_OPTIONS: '--max-old-space-size=8192'
@@ -507,7 +547,10 @@ jobs:
           exit 1
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
-          AIONUI_BACKEND_RUN_ID: ${{ inputs.aioncore_run_id }}
+          AIONUI_BACKEND_SOURCE_POLICY: ${{ inputs.ki_core_source_policy }}
+          AIONUI_BACKEND_RUN_ID: ${{ inputs.ki_core_candidate_run_id }}
+          AIONUI_BACKEND_EXPECTED_SHA: ${{ inputs.ki_core_candidate_head_sha }}
+          KI_CORE_ACTIONS_TOKEN: ${{ inputs.ki_core_source_policy == 'candidate' && secrets.KI_CORE_ACTIONS_TOKEN || '' }}
           npm_config_arch: ${{ matrix.arch }}
           APP_ID: ${{ secrets.APP_ID }}
           appleId: ${{ secrets.APPLE_ID }}
@@ -545,7 +588,10 @@ jobs:
           command: ${{ matrix.command }}
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
-          AIONUI_BACKEND_RUN_ID: ${{ inputs.aioncore_run_id }}
+          AIONUI_BACKEND_SOURCE_POLICY: ${{ inputs.ki_core_source_policy }}
+          AIONUI_BACKEND_RUN_ID: ${{ inputs.ki_core_candidate_run_id }}
+          AIONUI_BACKEND_EXPECTED_SHA: ${{ inputs.ki_core_candidate_head_sha }}
+          KI_CORE_ACTIONS_TOKEN: ${{ inputs.ki_core_source_policy == 'candidate' && secrets.KI_CORE_ACTIONS_TOKEN || '' }}
           npm_config_arch: ${{ matrix.arch }}
           npm_config_cache: ${{ runner.temp }}/.npm
           ELECTRON_CACHE: ${{ runner.temp }}/.cache/electron

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -63,6 +63,7 @@ jobs:
     if: vars.KI_ENABLE_RELEASE_AUTOMATION == 'true' && needs.code-quality.result == 'success' && (github.ref == 'refs/heads/dev' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-dev-')))
     with:
       skip_code_quality: true
+      ki_core_source_policy: release-pinned
       matrix: >-
         {"include":[
           {"platform":"macos-arm64","os":"macos-14","command":"node scripts/build-with-builder.js arm64 --mac --arm64","artifact-name":"macos-build-arm64","arch":"arm64"},

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -63,6 +63,7 @@ jobs:
     if: vars.KI_ENABLE_RELEASE_AUTOMATION == 'true' && needs.code-quality.result == 'success' && (github.ref == 'refs/heads/dev' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-dev-')))
     with:
       skip_code_quality: true
+      upload_source_maps: true
       ki_core_source_policy: release-pinned
       matrix: >-
         {"include":[

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -1,8 +1,8 @@
 name: '🔨 Manual Build'
 
 permissions:
-  contents: write
-  actions: write
+  actions: read
+  contents: read
 
 on:
   workflow_dispatch:
@@ -30,11 +30,14 @@ on:
         required: false
         type: boolean
         default: false
-      aioncore_run_id:
-        description: 'Optional AionCore Manual Build workflow run id to bundle instead of the pinned release'
-        required: false
+      ki_core_candidate_run_id:
+        description: 'Successful Ki-Core Candidate Build workflow run ID'
+        required: true
         type: string
-        default: ''
+      ki_core_candidate_head_sha:
+        description: 'Full merged Ki-Core product/main commit SHA used by the candidate run'
+        required: true
+        type: string
 
 env:
   BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
@@ -87,7 +90,9 @@ jobs:
       matrix: ${{ needs.prepare-matrix.outputs.matrix }}
       ref: ${{ inputs.branch }}
       skip_code_quality: ${{ inputs.skip_code_quality }}
-      aioncore_run_id: ${{ inputs.aioncore_run_id }}
+      ki_core_source_policy: candidate
+      ki_core_candidate_run_id: ${{ inputs.ki_core_candidate_run_id }}
+      ki_core_candidate_head_sha: ${{ inputs.ki_core_candidate_head_sha }}
       append_commit_hash: true
       upload_installers_only: true
     secrets: inherit

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -30,13 +30,23 @@ on:
         required: false
         type: boolean
         default: false
-      ki_core_candidate_run_id:
-        description: 'Successful Ki-Core Candidate Build workflow run ID'
+      ki_core_source_policy:
+        description: 'Ki-Core source: published release pin or verified candidate run'
         required: true
+        type: choice
+        options:
+          - release-pinned
+          - candidate
+        default: release-pinned
+      ki_core_candidate_run_id:
+        description: 'Candidate only: successful Ki-Core Candidate Build workflow run ID'
+        required: false
+        default: ''
         type: string
       ki_core_candidate_head_sha:
-        description: 'Full merged Ki-Core product/main commit SHA used by the candidate run'
-        required: true
+        description: 'Candidate only: full merged Ki-Core product/main commit SHA used by the candidate run'
+        required: false
+        default: ''
         type: string
 
 env:
@@ -50,6 +60,38 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
     steps:
+      - name: Validate Ki-Core source inputs
+        shell: bash
+        env:
+          KI_CORE_SOURCE_POLICY: ${{ inputs.ki_core_source_policy }}
+          KI_CORE_CANDIDATE_RUN_ID: ${{ inputs.ki_core_candidate_run_id }}
+          KI_CORE_CANDIDATE_HEAD_SHA: ${{ inputs.ki_core_candidate_head_sha }}
+        run: |
+          set -euo pipefail
+
+          case "$KI_CORE_SOURCE_POLICY" in
+            release-pinned)
+              if [[ -n "$KI_CORE_CANDIDATE_RUN_ID" || -n "$KI_CORE_CANDIDATE_HEAD_SHA" ]]; then
+                echo 'Candidate run ID and head SHA must be empty when using release-pinned.' >&2
+                exit 1
+              fi
+              ;;
+            candidate)
+              if [[ ! "$KI_CORE_CANDIDATE_RUN_ID" =~ ^[0-9]+$ ]]; then
+                echo 'Candidate source requires a numeric Ki-Core workflow run ID.' >&2
+                exit 1
+              fi
+              if [[ ! "$KI_CORE_CANDIDATE_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+                echo 'Candidate source requires a full lowercase Ki-Core commit SHA.' >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Unsupported Ki-Core source policy: $KI_CORE_SOURCE_POLICY" >&2
+              exit 1
+              ;;
+          esac
+
       - name: Generate build matrix
         id: set-matrix
         shell: bash
@@ -90,7 +132,7 @@ jobs:
       matrix: ${{ needs.prepare-matrix.outputs.matrix }}
       ref: ${{ inputs.branch }}
       skip_code_quality: ${{ inputs.skip_code_quality }}
-      ki_core_source_policy: candidate
+      ki_core_source_policy: ${{ inputs.ki_core_source_policy }}
       ki_core_candidate_run_id: ${{ inputs.ki_core_candidate_run_id }}
       ki_core_candidate_head_sha: ${{ inputs.ki_core_candidate_head_sha }}
       append_commit_hash: true

--- a/.github/workflows/pack-web-cli.yml
+++ b/.github/workflows/pack-web-cli.yml
@@ -28,6 +28,7 @@ on:
 
 env:
   BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
+  npm_config_registry: 'https://registry.npmjs.org/'
 
 jobs:
   code-quality:

--- a/.github/workflows/pack-web-cli.yml
+++ b/.github/workflows/pack-web-cli.yml
@@ -120,8 +120,7 @@ jobs:
         env:
           PACK_PLATFORM: ${{ matrix.platform }}
           PACK_ARCH: ${{ matrix.arch }}
-          # Version is pinned in repo-root package.json (aioncoreVersion).
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AIONUI_BACKEND_SOURCE_POLICY: release-pinned
 
       - name: Upload tarball artifact
         uses: actions/upload-artifact@v6

--- a/bun.lock
+++ b/bun.lock
@@ -97,6 +97,7 @@
         "streamdown": "^1.5.1",
         "strip-json-comments": "^3.1.1",
         "swr": "^2.3.6",
+        "tar": "^7.5.7",
         "tiny-csrf": "^1.1.6",
         "turndown": "^7.2.2",
         "turndown-plugin-gfm": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -264,10 +264,21 @@
   },
   "kiCore": {
     "repository": "xlihub/Ki-Core",
-    "tag": null,
-    "commit": null,
-    "aionCore": null,
-    "checksums": {}
+    "tag": "ki-core-v0.1.0",
+    "commit": "209e6844d39bac0762c61e198c1ba3a007f9dd2e",
+    "aionCore": {
+      "repository": "iOfficeAI/AionCore",
+      "tag": "v0.1.59",
+      "peeledCommit": "815e61ed9bbe942339347dc1e69ddce176cded76"
+    },
+    "checksums": {
+      "macos-x64": "28e75aad3dcf7cc71ee255d894a85f82291a29c29c475fbb800760dc9585e3d0",
+      "macos-arm64": "d2ec1ba6b88190e2d08abbc2dc8c9308ce0daa1698d7b4627640d553f33d9876",
+      "linux-x64": "edfe1c94edd38f31d14b59e59309b8ae6728636b749c461e6e9d643c6c8271bf",
+      "linux-arm64": "a3efd198da1d263fa97964caf5312616022fb391ce78f125d2f4709502b61769",
+      "windows-x64": "a11cce2bbb346bcf07aa6867f65756157bacd74ab4c88c70f2ae08471f3257a1",
+      "windows-arm64": "732e6a3e1d617faef47b7fb26bd6c451a4338b112756d8a947f237919516adf6"
+    }
   },
   "patchedDependencies": {
     "7zip-bin@5.2.0": "patches/7zip-bin@5.2.0.patch"

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "streamdown": "^1.5.1",
     "strip-json-comments": "^3.1.1",
     "swr": "^2.3.6",
+    "tar": "^7.5.7",
     "tiny-csrf": "^1.1.6",
     "turndown": "^7.2.2",
     "turndown-plugin-gfm": "^1.0.2",
@@ -260,6 +261,11 @@
   "aioncoreVersion": "v0.1.58",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
+  },
+  "kiCore": {
+    "repository": "xlihub/Ki-Core",
+    "tag": null,
+    "checksums": {}
   },
   "patchedDependencies": {
     "7zip-bin@5.2.0": "patches/7zip-bin@5.2.0.patch"

--- a/package.json
+++ b/package.json
@@ -265,6 +265,8 @@
   "kiCore": {
     "repository": "xlihub/Ki-Core",
     "tag": null,
+    "commit": null,
+    "aionCore": null,
     "checksums": {}
   },
   "patchedDependencies": {

--- a/packages/desktop/src/process/startup/backendInstallDiagnostics.ts
+++ b/packages/desktop/src/process/startup/backendInstallDiagnostics.ts
@@ -24,6 +24,9 @@ type BackendInstallDiagnosticEnv = {
 };
 
 export type BackendInstallDiagnostics = {
+  aionCorePeeledCommit?: string;
+  aionCoreRepository?: string;
+  aionCoreTag?: string;
   appVersion: string;
   arch: string;
   binaryExists?: boolean;
@@ -41,8 +44,19 @@ export type BackendInstallDiagnostics = {
   manifestParseError?: string;
   manifestPath?: string;
   manifestSize?: number;
+  manifestSchemaVersion?: number;
+  manifestSourceArtifactName?: string;
+  manifestSourceHeadSha?: string;
+  manifestSourcePolicy?: string;
+  manifestSourceRepository?: string;
+  manifestSourceRunId?: string;
   manifestSourceType?: string;
+  manifestSourceWorkflow?: string;
+  manifestValidationError?: string;
   manifestVersion?: string;
+  kiCoreReleaseCommit?: string;
+  kiCoreTag?: string;
+  kiCoreVersion?: string;
   platform: NodeJS.Platform;
   resourcesDirMtimeMs?: number;
   resourcesPath?: string;
@@ -62,6 +76,34 @@ function getStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const strings = value.filter((item): item is string => typeof item === 'string');
   return strings.length === value.length ? strings : undefined;
+}
+
+function getRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function isNullableString(value: unknown): boolean {
+  return value === null || (typeof value === 'string' && value.length > 0);
+}
+
+function hasValidProvenanceShape(
+  kiCore: Record<string, unknown> | undefined,
+  aionCore: Record<string, unknown> | undefined,
+  source: Record<string, unknown> | undefined
+): boolean {
+  return Boolean(
+    kiCore &&
+    aionCore &&
+    source &&
+    isNullableString(kiCore.version) &&
+    isNullableString(kiCore.tag) &&
+    isNullableString(kiCore.releaseCommit) &&
+    isNullableString(aionCore.repository) &&
+    isNullableString(aionCore.tag) &&
+    isNullableString(aionCore.peeledCommit) &&
+    getString(source.policy) &&
+    getString(source.type)
+  );
 }
 
 function getPathApi(platform: NodeJS.Platform): typeof path.win32 | typeof path.posix {
@@ -123,10 +165,46 @@ function applyManifest(diagnostics: BackendInstallDiagnostics, manifestText: str
     const generatedAt = getString(manifest.generatedAt);
     const sourceType = getString(manifest.sourceType);
     const files = getStringArray(manifest.files);
+    const schemaVersion = typeof manifest.schemaVersion === 'number' ? manifest.schemaVersion : undefined;
+    const kiCore = getRecord(manifest.kiCore);
+    const aionCore = getRecord(manifest.aionCore);
+    const source = getRecord(manifest.source);
     if (version) diagnostics.manifestVersion = version;
     if (generatedAt) diagnostics.manifestGeneratedAt = generatedAt;
     if (sourceType) diagnostics.manifestSourceType = sourceType;
     if (files) diagnostics.manifestFiles = files;
+    if (schemaVersion !== undefined) diagnostics.manifestSchemaVersion = schemaVersion;
+    if (schemaVersion !== undefined && schemaVersion !== 2) {
+      diagnostics.manifestValidationError = `Unsupported bundle manifest schemaVersion: ${schemaVersion}`;
+    }
+    if (schemaVersion === 2 && !hasValidProvenanceShape(kiCore, aionCore, source)) {
+      diagnostics.manifestValidationError = 'Bundle manifest provenance objects are malformed';
+    }
+
+    const kiCoreVersion = getString(kiCore?.version);
+    const kiCoreTag = getString(kiCore?.tag);
+    const kiCoreReleaseCommit = getString(kiCore?.releaseCommit);
+    const aionCoreRepository = getString(aionCore?.repository);
+    const aionCoreTag = getString(aionCore?.tag);
+    const aionCorePeeledCommit = getString(aionCore?.peeledCommit);
+    const sourcePolicy = getString(source?.policy);
+    const sourceRepository = getString(source?.repository);
+    const sourceWorkflow = getString(source?.workflow);
+    const sourceRunId = getString(source?.runId);
+    const sourceHeadSha = getString(source?.headSha);
+    const sourceArtifactName = getString(source?.artifactName);
+    if (kiCoreVersion) diagnostics.kiCoreVersion = kiCoreVersion;
+    if (kiCoreTag) diagnostics.kiCoreTag = kiCoreTag;
+    if (kiCoreReleaseCommit) diagnostics.kiCoreReleaseCommit = kiCoreReleaseCommit;
+    if (aionCoreRepository) diagnostics.aionCoreRepository = aionCoreRepository;
+    if (aionCoreTag) diagnostics.aionCoreTag = aionCoreTag;
+    if (aionCorePeeledCommit) diagnostics.aionCorePeeledCommit = aionCorePeeledCommit;
+    if (sourcePolicy) diagnostics.manifestSourcePolicy = sourcePolicy;
+    if (sourceRepository) diagnostics.manifestSourceRepository = sourceRepository;
+    if (sourceWorkflow) diagnostics.manifestSourceWorkflow = sourceWorkflow;
+    if (sourceRunId) diagnostics.manifestSourceRunId = sourceRunId;
+    if (sourceHeadSha) diagnostics.manifestSourceHeadSha = sourceHeadSha;
+    if (sourceArtifactName) diagnostics.manifestSourceArtifactName = sourceArtifactName;
   } catch (error) {
     diagnostics.manifestParseError = error instanceof Error ? error.message : String(error);
   }

--- a/packages/shared-scripts/src/kiCoreRelease.js
+++ b/packages/shared-scripts/src/kiCoreRelease.js
@@ -6,12 +6,10 @@ const { execFileSync } = require('node:child_process');
 const KI_CORE_REPOSITORY = 'xlihub/Ki-Core';
 const KI_CORE_WORKFLOW = {
   candidate: 'build-manual.yml',
-  stable: 'release.yml',
 };
 const KI_CORE_SOURCE_POLICIES = new Set(['candidate', 'development', 'release-pinned']);
 const SHA40_PATTERN = /^[0-9a-f]{40}$/;
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
-const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const ARCHIVE_HELPER_TIMEOUT_MS = 120000;
 
 const CANONICAL_PLATFORMS = {
@@ -110,9 +108,14 @@ function readKiCorePin(projectRoot) {
   if (pin.repository !== KI_CORE_REPOSITORY) {
     throw new Error(`Ki-Core product pin repository must be ${KI_CORE_REPOSITORY}`);
   }
+  requireExactKeys(pin, ['repository', 'tag', 'commit', 'aionCore', 'checksums'], 'Ki-Core product pin');
   if (typeof pin.tag !== 'string' || !/^ki-core-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(pin.tag)) {
     throw new Error('Ki-Core product pin must contain a full ki-core-vX.Y.Z tag');
   }
+  if (typeof pin.commit !== 'string' || !SHA40_PATTERN.test(pin.commit)) {
+    throw new Error('Ki-Core product pin commit must be a full lowercase commit SHA');
+  }
+  validateUpstream(pin.aionCore);
   requireExactKeys(pin.checksums, Object.keys(CANONICAL_PLATFORMS), 'Ki-Core product pin checksums');
   for (const [platformKey, checksum] of Object.entries(pin.checksums)) {
     if (typeof checksum !== 'string' || !SHA256_PATTERN.test(checksum)) {
@@ -122,16 +125,14 @@ function readKiCorePin(projectRoot) {
   return {
     repository: pin.repository,
     tag: pin.tag,
+    commit: pin.commit,
+    aionCore: { ...pin.aionCore },
     checksums: { ...pin.checksums },
   };
 }
 
 function sha256File(filePath) {
   return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
-}
-
-function sha256Text(value) {
-  return crypto.createHash('sha256').update(value).digest('hex');
 }
 
 function parseChecksums(checksumText) {
@@ -159,116 +160,30 @@ function validateUpstream(upstream) {
   if (!SHA40_PATTERN.test(upstream.peeledCommit)) throw new Error('AionCore provenance commit is invalid');
 }
 
-function validatePlatformManifest(platforms, version, sourceType, selectedPlatform) {
-  if (!platforms || typeof platforms !== 'object' || Array.isArray(platforms)) {
-    throw new Error('Ki-Core platforms must be an object');
-  }
-  const expectedKeys = sourceType === 'stable' ? Object.keys(CANONICAL_PLATFORMS) : [selectedPlatform];
-  if (JSON.stringify(Object.keys(platforms).toSorted()) !== JSON.stringify(expectedKeys.toSorted())) {
-    throw new Error(`Ki-Core ${sourceType} manifest has an unexpected platform set`);
-  }
-
-  for (const platformKey of expectedKeys) {
-    const contract = CANONICAL_PLATFORMS[platformKey];
-    const entry = platforms[platformKey];
-    requireExactKeys(entry, ['target', 'archive', 'executable', 'sha256'], `Ki-Core platform ${platformKey}`);
-    const archive = `ki-core-v${version}-${contract.target}${contract.extension}`;
-    if (entry.target !== contract.target || entry.archive !== archive || entry.executable !== contract.executable) {
-      throw new Error(`Ki-Core platform contract does not match: ${platformKey}`);
-    }
-    if (!SHA256_PATTERN.test(entry.sha256)) throw new Error(`Ki-Core platform checksum is malformed: ${platformKey}`);
-  }
-}
-
-function validateReleaseManifest(manifest, expectations) {
-  const { sourceType, platformKey, tag, runId, headSha } = expectations;
-  requireExactKeys(manifest, ['schemaVersion', 'release', 'product', 'upstream', 'platforms'], 'Ki-Core manifest');
-  if (manifest.schemaVersion !== 1) throw new Error('Unsupported Ki-Core release manifest schema');
-
-  requireExactKeys(
-    manifest.release,
-    ['type', 'repository', 'workflow', 'runId', 'headSha'],
-    'Ki-Core release identity'
-  );
-  if (manifest.release.type !== sourceType || manifest.release.repository !== KI_CORE_REPOSITORY) {
-    throw new Error('Ki-Core release source identity does not match the requested policy');
-  }
-  if (manifest.release.workflow !== KI_CORE_WORKFLOW[sourceType]) {
-    throw new Error('Ki-Core release workflow identity is invalid');
-  }
-  if (!/^[1-9]\d*$/.test(manifest.release.runId) || !SHA40_PATTERN.test(manifest.release.headSha)) {
-    throw new Error('Ki-Core release run identity is malformed');
-  }
-  if (runId && manifest.release.runId !== runId) throw new Error('Ki-Core candidate manifest run ID does not match');
-  if (headSha && manifest.release.headSha !== headSha)
-    throw new Error('Ki-Core candidate manifest head SHA does not match');
-
-  requireExactKeys(manifest.product, ['name', 'version', 'tag', 'releaseCommit'], 'Ki-Core product identity');
-  if (manifest.product.name !== 'Ki-Core' || !SEMVER_PATTERN.test(manifest.product.version)) {
-    throw new Error('Ki-Core product identity is malformed');
-  }
-  if (sourceType === 'stable') {
-    if (manifest.product.tag !== tag || tag !== `ki-core-v${manifest.product.version}`) {
-      throw new Error('Ki-Core stable tag does not match its product version');
-    }
-    if (manifest.product.releaseCommit !== manifest.release.headSha) {
-      throw new Error('Ki-Core stable release commit does not match its workflow head SHA');
-    }
-  } else if (manifest.product.tag !== null || manifest.product.releaseCommit !== null) {
-    throw new Error('Ki-Core candidate manifest cannot claim stable product provenance');
-  }
-
-  validateUpstream(manifest.upstream);
-  validatePlatformManifest(manifest.platforms, manifest.product.version, sourceType, platformKey);
-  return manifest;
-}
-
 function validateDownloadedAssets(options) {
-  const { sourceType, platformKey, tag, runId, headSha, manifestPath, checksumPath, archivePath, pinnedChecksums } =
-    options;
-  const manifestText = fs.readFileSync(manifestPath, 'utf8');
-  let manifest;
-  try {
-    manifest = JSON.parse(manifestText);
-  } catch (error) {
-    throw new Error(`Ki-Core manifest is not valid JSON: ${error instanceof Error ? error.message : String(error)}`, {
-      cause: error,
-    });
-  }
-  validateReleaseManifest(manifest, { sourceType, platformKey, tag, runId, headSha });
-
+  const { platformKey, tag, checksumPath, archivePath, pinnedChecksums } = options;
+  const version = tag.replace(/^ki-core-v/, '');
   const checksums = parseChecksums(fs.readFileSync(checksumPath, 'utf8'));
-  const manifestName = sourceType === 'stable' ? 'ki-core-release.json' : 'ki-core-candidate.json';
-  const expectedChecksumNames =
-    sourceType === 'stable'
-      ? [
-          ...Object.entries(CANONICAL_PLATFORMS).map(
-            ([, contract]) => `ki-core-v${manifest.product.version}-${contract.target}${contract.extension}`
-          ),
-          manifestName,
-        ]
-      : [manifest.platforms[platformKey].archive, manifestName];
+  const expectedChecksumNames = Object.values(CANONICAL_PLATFORMS).map(
+    (contract) => `ki-core-v${version}-${contract.target}${contract.extension}`
+  );
   if (checksums.size !== expectedChecksumNames.length || expectedChecksumNames.some((name) => !checksums.has(name))) {
-    throw new Error(`Ki-Core ${sourceType} checksum file does not cover the exact asset set`);
-  }
-  if (checksums.get(manifestName) !== sha256Text(manifestText)) {
-    throw new Error('Ki-Core release manifest checksum does not match');
+    throw new Error('Ki-Core stable checksum file does not cover the exact six-platform asset set');
   }
 
-  for (const [key, entry] of Object.entries(manifest.platforms)) {
-    if (checksums.get(entry.archive) !== entry.sha256) {
-      throw new Error(`Ki-Core checksum and manifest disagree for ${key}`);
-    }
-    if (sourceType === 'stable' && pinnedChecksums?.[key] !== entry.sha256) {
-      throw new Error(`Ki-Core checked-in checksum does not match the release manifest for ${key}`);
+  for (const [key, contract] of Object.entries(CANONICAL_PLATFORMS)) {
+    const archiveName = `ki-core-v${version}-${contract.target}${contract.extension}`;
+    if (pinnedChecksums?.[key] !== checksums.get(archiveName)) {
+      throw new Error(`Ki-Core checked-in checksum does not match the release checksum file for ${key}`);
     }
   }
 
-  const selectedEntry = manifest.platforms[platformKey];
-  if (path.basename(archivePath) !== selectedEntry.archive || sha256File(archivePath) !== selectedEntry.sha256) {
+  const selectedContract = CANONICAL_PLATFORMS[platformKey];
+  const selectedArchive = `ki-core-v${version}-${selectedContract.target}${selectedContract.extension}`;
+  if (path.basename(archivePath) !== selectedArchive || sha256File(archivePath) !== checksums.get(selectedArchive)) {
     throw new Error(`Ki-Core archive checksum does not match for ${platformKey}`);
   }
-  return manifest;
+  return { version, tag };
 }
 
 function validateCandidateRun(run, expectations) {
@@ -325,16 +240,17 @@ function inspectArchiveSafely(archivePath) {
 }
 
 function createBundleProvenance(manifest, source) {
+  const candidateVersion = source?.policy === 'candidate' ? source.version : null;
   return {
     schemaVersion: 2,
-    version: manifest?.product?.version || 'local',
+    version: manifest?.product?.version || candidateVersion || 'local',
     kiCore: manifest
       ? {
           version: manifest.product.version,
           tag: manifest.product.tag,
           releaseCommit: manifest.product.releaseCommit,
         }
-      : { version: null, tag: null, releaseCommit: null },
+      : { version: candidateVersion, tag: null, releaseCommit: null },
     aionCore: manifest
       ? {
           repository: manifest.upstream.repository,
@@ -362,5 +278,4 @@ module.exports = {
   sha256File,
   validateCandidateRun,
   validateDownloadedAssets,
-  validateReleaseManifest,
 };

--- a/packages/shared-scripts/src/kiCoreRelease.js
+++ b/packages/shared-scripts/src/kiCoreRelease.js
@@ -1,0 +1,363 @@
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const KI_CORE_REPOSITORY = 'xlihub/Ki-Core';
+const KI_CORE_WORKFLOW = {
+  candidate: 'build-manual.yml',
+  stable: 'release.yml',
+};
+const KI_CORE_SOURCE_POLICIES = new Set(['candidate', 'development', 'release-pinned']);
+const SHA40_PATTERN = /^[0-9a-f]{40}$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+const CANONICAL_PLATFORMS = {
+  'macos-x64': {
+    runtimeKey: 'darwin-x64',
+    target: 'x86_64-apple-darwin',
+    executable: 'aioncore',
+    extension: '.tar.gz',
+  },
+  'macos-arm64': {
+    runtimeKey: 'darwin-arm64',
+    target: 'aarch64-apple-darwin',
+    executable: 'aioncore',
+    extension: '.tar.gz',
+  },
+  'linux-x64': {
+    runtimeKey: 'linux-x64',
+    target: 'x86_64-unknown-linux-gnu',
+    executable: 'aioncore',
+    extension: '.tar.gz',
+  },
+  'linux-arm64': {
+    runtimeKey: 'linux-arm64',
+    target: 'aarch64-unknown-linux-gnu',
+    executable: 'aioncore',
+    extension: '.tar.gz',
+  },
+  'windows-x64': {
+    runtimeKey: 'win32-x64',
+    target: 'x86_64-pc-windows-msvc',
+    executable: 'aioncore.exe',
+    extension: '.zip',
+  },
+  'windows-arm64': {
+    runtimeKey: 'win32-arm64',
+    target: 'aarch64-pc-windows-msvc',
+    executable: 'aioncore.exe',
+    extension: '.zip',
+  },
+};
+
+const PLATFORM_BY_RUNTIME = Object.fromEntries(
+  Object.entries(CANONICAL_PLATFORMS).map(([platformKey, value]) => [value.runtimeKey, { platformKey, ...value }])
+);
+
+function requireExactKeys(value, keys, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const actual = Object.keys(value).toSorted();
+  const expected = keys.toSorted();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${label} has unexpected or missing fields`);
+  }
+}
+
+function getCanonicalTarget(platform, arch) {
+  const target = PLATFORM_BY_RUNTIME[`${platform}-${arch}`];
+  if (!target) throw new Error(`Unsupported Ki-Core target: ${platform}-${arch}`);
+  return target;
+}
+
+function getArchiveName(tag, target) {
+  if (!/^ki-core-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(tag)) {
+    throw new Error('Ki-Core tag must use the full ki-core-vX.Y.Z form');
+  }
+  return `${tag}-${target.target}${target.extension}`;
+}
+
+function getReleaseUrl(tag, assetName) {
+  return `https://github.com/${KI_CORE_REPOSITORY}/releases/download/${tag}/${assetName}`;
+}
+
+function getSourcePolicy(explicitPolicy) {
+  const policy = String(explicitPolicy || process.env.AIONUI_BACKEND_SOURCE_POLICY || 'development').trim();
+  if (!KI_CORE_SOURCE_POLICIES.has(policy)) {
+    throw new Error(`Unsupported Ki-Core source policy: ${policy}`);
+  }
+  return policy;
+}
+
+function readKiCorePin(projectRoot) {
+  let packageJson;
+  try {
+    packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8'));
+  } catch (error) {
+    throw new Error(`Cannot read Ki-Core product pin: ${error instanceof Error ? error.message : String(error)}`, {
+      cause: error,
+    });
+  }
+
+  const pin = packageJson.kiCore;
+  if (!pin || typeof pin !== 'object' || Array.isArray(pin)) {
+    throw new Error('package.json must define a kiCore product pin');
+  }
+  if (pin.repository !== KI_CORE_REPOSITORY) {
+    throw new Error(`Ki-Core product pin repository must be ${KI_CORE_REPOSITORY}`);
+  }
+  if (typeof pin.tag !== 'string' || !/^ki-core-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(pin.tag)) {
+    throw new Error('Ki-Core product pin must contain a full ki-core-vX.Y.Z tag');
+  }
+  requireExactKeys(pin.checksums, Object.keys(CANONICAL_PLATFORMS), 'Ki-Core product pin checksums');
+  for (const [platformKey, checksum] of Object.entries(pin.checksums)) {
+    if (typeof checksum !== 'string' || !SHA256_PATTERN.test(checksum)) {
+      throw new Error(`Ki-Core product pin checksum is malformed: ${platformKey}`);
+    }
+  }
+  return {
+    repository: pin.repository,
+    tag: pin.tag,
+    checksums: { ...pin.checksums },
+  };
+}
+
+function sha256File(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function sha256Text(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function parseChecksums(checksumText) {
+  const lines = checksumText.split(/\r?\n/);
+  if (lines.at(-1) === '') lines.pop();
+  if (lines.length === 0 || lines.some((line) => line === '')) {
+    throw new Error('Ki-Core checksum file is empty or contains blank entries');
+  }
+
+  const checksums = new Map();
+  for (const line of lines) {
+    const match = /^([0-9a-f]{64})  ([A-Za-z0-9_.-]+)$/.exec(line);
+    if (!match) throw new Error(`Malformed Ki-Core checksum entry: ${line}`);
+    const [, digest, name] = match;
+    if (checksums.has(name)) throw new Error(`Duplicate Ki-Core checksum entry: ${name}`);
+    checksums.set(name, digest);
+  }
+  return checksums;
+}
+
+function validateUpstream(upstream) {
+  requireExactKeys(upstream, ['repository', 'tag', 'peeledCommit'], 'AionCore provenance');
+  if (upstream.repository !== 'iOfficeAI/AionCore') throw new Error('AionCore provenance repository is invalid');
+  if (!/^v\d+\.\d+\.\d+$/.test(upstream.tag)) throw new Error('AionCore provenance tag is invalid');
+  if (!SHA40_PATTERN.test(upstream.peeledCommit)) throw new Error('AionCore provenance commit is invalid');
+}
+
+function validatePlatformManifest(platforms, version, sourceType, selectedPlatform) {
+  if (!platforms || typeof platforms !== 'object' || Array.isArray(platforms)) {
+    throw new Error('Ki-Core platforms must be an object');
+  }
+  const expectedKeys = sourceType === 'stable' ? Object.keys(CANONICAL_PLATFORMS) : [selectedPlatform];
+  if (JSON.stringify(Object.keys(platforms)) !== JSON.stringify(expectedKeys)) {
+    throw new Error(`Ki-Core ${sourceType} manifest has an unexpected platform set`);
+  }
+
+  for (const platformKey of expectedKeys) {
+    const contract = CANONICAL_PLATFORMS[platformKey];
+    const entry = platforms[platformKey];
+    requireExactKeys(entry, ['target', 'archive', 'executable', 'sha256'], `Ki-Core platform ${platformKey}`);
+    const archive = `ki-core-v${version}-${contract.target}${contract.extension}`;
+    if (entry.target !== contract.target || entry.archive !== archive || entry.executable !== contract.executable) {
+      throw new Error(`Ki-Core platform contract does not match: ${platformKey}`);
+    }
+    if (!SHA256_PATTERN.test(entry.sha256)) throw new Error(`Ki-Core platform checksum is malformed: ${platformKey}`);
+  }
+}
+
+function validateReleaseManifest(manifest, expectations) {
+  const { sourceType, platformKey, tag, runId, headSha } = expectations;
+  requireExactKeys(manifest, ['schemaVersion', 'release', 'product', 'upstream', 'platforms'], 'Ki-Core manifest');
+  if (manifest.schemaVersion !== 1) throw new Error('Unsupported Ki-Core release manifest schema');
+
+  requireExactKeys(
+    manifest.release,
+    ['type', 'repository', 'workflow', 'runId', 'headSha'],
+    'Ki-Core release identity'
+  );
+  if (manifest.release.type !== sourceType || manifest.release.repository !== KI_CORE_REPOSITORY) {
+    throw new Error('Ki-Core release source identity does not match the requested policy');
+  }
+  if (manifest.release.workflow !== KI_CORE_WORKFLOW[sourceType]) {
+    throw new Error('Ki-Core release workflow identity is invalid');
+  }
+  if (!/^[1-9]\d*$/.test(manifest.release.runId) || !SHA40_PATTERN.test(manifest.release.headSha)) {
+    throw new Error('Ki-Core release run identity is malformed');
+  }
+  if (runId && manifest.release.runId !== runId) throw new Error('Ki-Core candidate manifest run ID does not match');
+  if (headSha && manifest.release.headSha !== headSha)
+    throw new Error('Ki-Core candidate manifest head SHA does not match');
+
+  requireExactKeys(manifest.product, ['name', 'version', 'tag', 'releaseCommit'], 'Ki-Core product identity');
+  if (manifest.product.name !== 'Ki-Core' || !SEMVER_PATTERN.test(manifest.product.version)) {
+    throw new Error('Ki-Core product identity is malformed');
+  }
+  if (sourceType === 'stable') {
+    if (manifest.product.tag !== tag || tag !== `ki-core-v${manifest.product.version}`) {
+      throw new Error('Ki-Core stable tag does not match its product version');
+    }
+    if (manifest.product.releaseCommit !== manifest.release.headSha) {
+      throw new Error('Ki-Core stable release commit does not match its workflow head SHA');
+    }
+  } else if (manifest.product.tag !== null || manifest.product.releaseCommit !== null) {
+    throw new Error('Ki-Core candidate manifest cannot claim stable product provenance');
+  }
+
+  validateUpstream(manifest.upstream);
+  validatePlatformManifest(manifest.platforms, manifest.product.version, sourceType, platformKey);
+  return manifest;
+}
+
+function validateDownloadedAssets(options) {
+  const { sourceType, platformKey, tag, runId, headSha, manifestPath, checksumPath, archivePath, pinnedChecksums } =
+    options;
+  const manifestText = fs.readFileSync(manifestPath, 'utf8');
+  let manifest;
+  try {
+    manifest = JSON.parse(manifestText);
+  } catch (error) {
+    throw new Error(`Ki-Core manifest is not valid JSON: ${error instanceof Error ? error.message : String(error)}`, {
+      cause: error,
+    });
+  }
+  validateReleaseManifest(manifest, { sourceType, platformKey, tag, runId, headSha });
+
+  const checksums = parseChecksums(fs.readFileSync(checksumPath, 'utf8'));
+  const manifestName = sourceType === 'stable' ? 'ki-core-release.json' : 'ki-core-candidate.json';
+  const expectedChecksumNames =
+    sourceType === 'stable'
+      ? [
+          ...Object.entries(CANONICAL_PLATFORMS).map(
+            ([, contract]) => `ki-core-v${manifest.product.version}-${contract.target}${contract.extension}`
+          ),
+          manifestName,
+        ]
+      : [manifest.platforms[platformKey].archive, manifestName];
+  if (checksums.size !== expectedChecksumNames.length || expectedChecksumNames.some((name) => !checksums.has(name))) {
+    throw new Error(`Ki-Core ${sourceType} checksum file does not cover the exact asset set`);
+  }
+  if (checksums.get(manifestName) !== sha256Text(manifestText)) {
+    throw new Error('Ki-Core release manifest checksum does not match');
+  }
+
+  for (const [key, entry] of Object.entries(manifest.platforms)) {
+    if (checksums.get(entry.archive) !== entry.sha256) {
+      throw new Error(`Ki-Core checksum and manifest disagree for ${key}`);
+    }
+    if (sourceType === 'stable' && pinnedChecksums?.[key] !== entry.sha256) {
+      throw new Error(`Ki-Core checked-in checksum does not match the release manifest for ${key}`);
+    }
+  }
+
+  const selectedEntry = manifest.platforms[platformKey];
+  if (path.basename(archivePath) !== selectedEntry.archive || sha256File(archivePath) !== selectedEntry.sha256) {
+    throw new Error(`Ki-Core archive checksum does not match for ${platformKey}`);
+  }
+  return manifest;
+}
+
+function validateCandidateRun(run, expectations) {
+  if (!run || typeof run !== 'object') throw new Error('Ki-Core candidate workflow run was not found');
+  const repository = run.repository?.full_name || run.repository?.fullName;
+  if (repository !== KI_CORE_REPOSITORY) throw new Error('Ki-Core candidate run repository does not match');
+  if (run.path !== `.github/workflows/${KI_CORE_WORKFLOW.candidate}`) {
+    throw new Error('Ki-Core candidate run workflow does not match');
+  }
+  if (run.event !== 'workflow_dispatch' || run.conclusion !== 'success' || run.status !== 'completed') {
+    throw new Error('Ki-Core candidate run is not a successful completed workflow dispatch');
+  }
+  if (run.head_branch !== 'product/main' || run.head_sha !== expectations.headSha) {
+    throw new Error('Ki-Core candidate run source commit does not match');
+  }
+}
+
+function selectCandidateArtifact(artifacts, expectedName) {
+  const matches = artifacts.filter((artifact) => artifact?.name === expectedName && !artifact.expired);
+  if (matches.length !== 1) {
+    throw new Error(`Ki-Core candidate run must contain exactly one non-expired artifact named ${expectedName}`);
+  }
+  return matches[0];
+}
+
+function extractArchiveSafely(archivePath, outputDir, expectedEntries) {
+  const helperPath = path.join(__dirname, 'safeExtractArchive.js');
+  try {
+    execFileSync(process.execPath, [helperPath, archivePath, outputDir, JSON.stringify(expectedEntries)], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    const detail = error?.stderr?.trim();
+    throw new Error(detail || `Failed to validate and extract ${path.basename(archivePath)}`, { cause: error });
+  }
+}
+
+function inspectArchiveSafely(archivePath) {
+  const helperPath = path.join(__dirname, 'safeExtractArchive.js');
+  try {
+    return JSON.parse(
+      execFileSync(process.execPath, [helperPath, '--inspect', archivePath], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+    );
+  } catch (error) {
+    const detail = error?.stderr?.trim();
+    throw new Error(detail || `Failed to inspect ${path.basename(archivePath)}`, { cause: error });
+  }
+}
+
+function createBundleProvenance(manifest, source) {
+  return {
+    schemaVersion: 2,
+    version: manifest?.product?.version || 'local',
+    kiCore: manifest
+      ? {
+          version: manifest.product.version,
+          tag: manifest.product.tag,
+          releaseCommit: manifest.product.releaseCommit,
+        }
+      : { version: null, tag: null, releaseCommit: null },
+    aionCore: manifest
+      ? {
+          repository: manifest.upstream.repository,
+          tag: manifest.upstream.tag,
+          peeledCommit: manifest.upstream.peeledCommit,
+        }
+      : { repository: null, tag: null, peeledCommit: null },
+    source,
+  };
+}
+
+module.exports = {
+  CANONICAL_PLATFORMS,
+  KI_CORE_REPOSITORY,
+  createBundleProvenance,
+  extractArchiveSafely,
+  getArchiveName,
+  getCanonicalTarget,
+  getReleaseUrl,
+  getSourcePolicy,
+  inspectArchiveSafely,
+  parseChecksums,
+  readKiCorePin,
+  selectCandidateArtifact,
+  sha256File,
+  validateCandidateRun,
+  validateDownloadedAssets,
+  validateReleaseManifest,
+};

--- a/packages/shared-scripts/src/kiCoreRelease.js
+++ b/packages/shared-scripts/src/kiCoreRelease.js
@@ -12,6 +12,7 @@ const KI_CORE_SOURCE_POLICIES = new Set(['candidate', 'development', 'release-pi
 const SHA40_PATTERN = /^[0-9a-f]{40}$/;
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
 const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const ARCHIVE_HELPER_TIMEOUT_MS = 120000;
 
 const CANONICAL_PLATFORMS = {
   'macos-x64': {
@@ -163,7 +164,7 @@ function validatePlatformManifest(platforms, version, sourceType, selectedPlatfo
     throw new Error('Ki-Core platforms must be an object');
   }
   const expectedKeys = sourceType === 'stable' ? Object.keys(CANONICAL_PLATFORMS) : [selectedPlatform];
-  if (JSON.stringify(Object.keys(platforms)) !== JSON.stringify(expectedKeys)) {
+  if (JSON.stringify(Object.keys(platforms).toSorted()) !== JSON.stringify(expectedKeys.toSorted())) {
     throw new Error(`Ki-Core ${sourceType} manifest has an unexpected platform set`);
   }
 
@@ -299,6 +300,7 @@ function extractArchiveSafely(archivePath, outputDir, expectedEntries) {
     execFileSync(process.execPath, [helperPath, archivePath, outputDir, JSON.stringify(expectedEntries)], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: ARCHIVE_HELPER_TIMEOUT_MS,
     });
   } catch (error) {
     const detail = error?.stderr?.trim();
@@ -313,6 +315,7 @@ function inspectArchiveSafely(archivePath) {
       execFileSync(process.execPath, [helperPath, '--inspect', archivePath], {
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: ARCHIVE_HELPER_TIMEOUT_MS,
       })
     );
   } catch (error) {

--- a/packages/shared-scripts/src/prepare-aioncore.js
+++ b/packages/shared-scripts/src/prepare-aioncore.js
@@ -1,64 +1,40 @@
 /**
- * Prepare aioncore binary for packaging.
+ * Prepare the aioncore runtime binary for Ki-Buddy packaging.
  *
- * Resolution order:
- *  1. GitHub Actions artifact download when AIONUI_BACKEND_RUN_ID is set
- *  2. GitHub release download (requires version or defaults to "latest")
- *  3. Complete local bundle from AIONUI_BACKEND_LOCAL_BUNDLE_DIR
- *  4. Local binary fallback from AIONUI_BACKEND_LOCAL_BINARY
- *
- * Output: {projectRoot}/resources/bundled-aioncore/{platform}-{arch}/
- *   - aioncore[.exe]
- *   - manifest.json
- *   - managed-resources/...
+ * Source policies:
+ *  - release-pinned: immutable xlihub/Ki-Core release configured in package.json
+ *  - candidate: verified xlihub/Ki-Core Actions candidate run
+ *  - development: explicit local inputs or the legacy AionCore development release path
  *
  * @module prepare-aioncore
  */
 
-const { execSync, execFileSync } = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const { execFileSync, execSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  KI_CORE_REPOSITORY,
+  createBundleProvenance,
+  extractArchiveSafely,
+  getArchiveName,
+  getCanonicalTarget,
+  getReleaseUrl,
+  getSourcePolicy,
+  inspectArchiveSafely,
+  readKiCorePin,
+  selectCandidateArtifact,
+  validateCandidateRun,
+  validateDownloadedAssets,
+} = require('./kiCoreRelease');
+const { validateEntries } = require('./safeExtractArchive');
 const { verifyBundledAioncoreResources } = require('./verify-bundled-aioncore-resources');
 
-const GITHUB_OWNER = 'iOfficeAI';
-const GITHUB_REPO = 'AionCore';
-
-const ACTIONS_ARTIFACT_TARGETS = {
-  'darwin-arm64': {
-    artifactName: 'aioncore-manual-macos-arm64',
-    manualPlatform: 'macos-arm64',
-  },
-  'darwin-x64': {
-    artifactName: 'aioncore-manual-macos-x64',
-    manualPlatform: 'macos-x64',
-  },
-  'linux-arm64': {
-    artifactName: 'aioncore-manual-linux-arm64',
-    manualPlatform: 'linux-arm64',
-  },
-  'linux-x64': {
-    artifactName: 'aioncore-manual-linux-x64',
-    manualPlatform: 'linux-x64',
-  },
-  'win32-arm64': {
-    artifactName: 'aioncore-manual-windows-arm64',
-    manualPlatform: 'windows-arm64',
-  },
-  'win32-x64': {
-    artifactName: 'aioncore-manual-windows-x64',
-    manualPlatform: 'windows-x64',
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+const LEGACY_GITHUB_OWNER = 'iOfficeAI';
+const LEGACY_GITHUB_REPO = 'AionCore';
 
 function ensureDirectory(dirPath) {
-  if (!fs.existsSync(dirPath)) {
-    fs.mkdirSync(dirPath, { recursive: true });
-  }
+  if (!fs.existsSync(dirPath)) fs.mkdirSync(dirPath, { recursive: true });
 }
 
 function removeDirectorySafe(dirPath) {
@@ -83,23 +59,15 @@ function ensureExecutableMode(filePath) {
 }
 
 function writeJson(filePath, payload) {
-  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2) + '\n', 'utf-8');
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 }
 
 function getBinaryName(platform) {
   return platform === 'win32' ? 'aioncore.exe' : 'aioncore';
 }
 
-function getActionsTarget(platform, arch) {
-  return ACTIONS_ARTIFACT_TARGETS[`${platform}-${arch}`] || null;
-}
-
 function getActionsArtifactName(platform, arch) {
-  return getActionsTarget(platform, arch)?.artifactName || null;
-}
-
-function getActionsManualPlatform(platform, arch) {
-  return getActionsTarget(platform, arch)?.manualPlatform || `${platform}-${arch}`;
+  return `ki-core-candidate-${getCanonicalTarget(platform, arch).platformKey}`;
 }
 
 function getActionsArtifactMissingMessage({ runId, platform, arch, expectedArtifactName, availableArtifactNames }) {
@@ -108,9 +76,9 @@ function getActionsArtifactMissingMessage({ runId, platform, arch, expectedArtif
       ? availableArtifactNames.join(', ')
       : '(none)';
   return [
-    `AionCore run ${runId} does not contain artifact [ ${expectedArtifactName} ] required for [ ${platform}-${arch} ].`,
+    `Ki-Core run ${runId} does not contain artifact [ ${expectedArtifactName} ] required for [ ${platform}-${arch} ].`,
     `Available artifacts: ${available}.`,
-    `Re-run AionCore Manual Build with platform [ ${getActionsManualPlatform(platform, arch)} ] or all.`,
+    `Re-run Ki-Core Candidate Build with platform [ ${getCanonicalTarget(platform, arch).platformKey} ] or all.`,
   ].join(' ');
 }
 
@@ -149,438 +117,374 @@ function verifyPreparedAioncoreBundle(projectRoot, platform, arch) {
   return result;
 }
 
-// ---------------------------------------------------------------------------
-// Source resolvers
-// ---------------------------------------------------------------------------
-
-/**
- * Resolve the actual version tag when "latest" is requested.
- * Uses GitHub API via `gh` CLI (needs GH_TOKEN in CI) or falls back to
- * `curl` with an optional Authorization header (GITHUB_TOKEN / GH_TOKEN).
- */
-function resolveLatestTag() {
-  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
-
-  // 1. Try gh CLI (honours GH_TOKEN automatically)
-  try {
-    const out = execSync(`gh api repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest --jq .tag_name`, {
-      encoding: 'utf-8',
-      timeout: 15000,
-    }).trim();
-    if (out) return out;
-  } catch {
-    // gh CLI not available or no token — fall back to curl
-  }
-
-  // 2. Curl with optional token to avoid rate-limit 403
-  try {
-    const authArgs = token ? ['-H', `Authorization: token ${token}`] : [];
-    const args = ['-fsSL', ...authArgs, `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest`];
-    const out = execFileSync('curl', args, { encoding: 'utf-8', timeout: 15000 });
-    const tag = JSON.parse(out).tag_name;
-    if (tag) return tag;
-  } catch {
-    // network issue or rate-limited
-  }
-
-  return null;
-}
-
-/**
- * Build the release asset filename for the given platform/arch/tag.
- *
- * Expected asset naming convention:
- *   aioncore-v0.1.0-aarch64-apple-darwin.tar.gz
- */
-function getAssetName(platform, arch, tag) {
-  const archMap = { x64: 'x86_64', arm64: 'aarch64' };
-  const platformMap = {
-    darwin: 'apple-darwin',
-    linux: 'unknown-linux-gnu',
-    win32: 'pc-windows-msvc',
-  };
-  const normalizedArch = archMap[arch];
-  const normalizedPlatform = platformMap[platform];
-  if (!normalizedArch || !normalizedPlatform) return null;
-  const ext = platform === 'win32' ? '.zip' : '.tar.gz';
-  return `aioncore-${tag}-${normalizedArch}-${normalizedPlatform}${ext}`;
-}
-
-function getDownloadUrl(assetName, tag) {
-  return `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases/download/${tag}/${assetName}`;
-}
-
-function downloadFile(url, outputPath) {
-  console.log(`  Downloading aioncore from ${url}`);
-  if (process.platform === 'win32') {
-    const ps = `$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -Uri '${url}' -OutFile '${outputPath.replace(/'/g, "''")}'`;
-    execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', ps], {
-      timeout: 120000,
-    });
-    return;
-  }
-  try {
-    execFileSync('curl', ['-L', '--fail', '--silent', '--show-error', '-o', outputPath, url], { timeout: 120000 });
-  } catch {
-    execFileSync('wget', ['-q', '-O', outputPath, url], { timeout: 120000 });
-  }
-}
-
-function extractArchive(archivePath, outputDir, platform) {
-  ensureDirectory(outputDir);
-  if (platform === 'win32' || archivePath.endsWith('.zip')) {
-    if (platform === 'win32') {
-      const ps = `Expand-Archive -LiteralPath '${archivePath.replace(/'/g, "''")}' -DestinationPath '${outputDir.replace(/'/g, "''")}' -Force`;
-      execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', ps]);
-    } else {
-      execFileSync('unzip', ['-o', archivePath, '-d', outputDir]);
-    }
-  } else {
-    execFileSync('tar', ['-xzf', archivePath, '-C', outputDir]);
-  }
-}
-
-function findBinaryInDir(dir, binaryName) {
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
-    if (entry.isFile() && entry.name === binaryName) return fullPath;
-    if (entry.isDirectory()) {
-      const found = findBinaryInDir(fullPath, binaryName);
-      if (found) return found;
-    }
-  }
-  return null;
-}
-
-function findAioncoreArchiveInDir(dir) {
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
-    if (
-      entry.isFile() &&
-      entry.name.startsWith('aioncore-') &&
-      (entry.name.endsWith('.zip') || entry.name.endsWith('.tar.gz'))
-    ) {
-      return fullPath;
-    }
-    if (entry.isDirectory()) {
-      const found = findAioncoreArchiveInDir(fullPath);
-      if (found) return found;
-    }
-  }
-  return null;
-}
-
 function getGitHubToken() {
   return process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
 }
 
-function githubApiGetJson(apiPath) {
-  const token = getGitHubToken();
-
-  try {
-    return JSON.parse(
-      execFileSync('gh', ['api', apiPath], {
-        encoding: 'utf-8',
-        timeout: 15000,
-        env: {
-          ...process.env,
-          GH_TOKEN: token || process.env.GH_TOKEN,
-        },
-      })
-    );
-  } catch {
-    // gh CLI not available or failed — fall back to curl.
+function downloadFile(url, outputPath, token = '') {
+  console.log(`  Downloading Ki-Core asset from ${url}`);
+  if (process.platform === 'win32') {
+    const headers = token ? ` -Headers @{ Authorization = 'Bearer ${token.replace(/'/g, "''")}' }` : '';
+    const ps = `$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -Uri '${url.replace(/'/g, "''")}' -OutFile '${outputPath.replace(/'/g, "''")}'${headers}`;
+    execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', ps], { timeout: 120000 });
+    return;
   }
 
-  const headers = ['-H', 'Accept: application/vnd.github+json'];
-  if (token) {
-    headers.push('-H', `Authorization: Bearer ${token}`);
-  }
-
-  const url = `https://api.github.com/${apiPath}`;
-  const out = execFileSync('curl', ['-fsSL', ...headers, url], {
-    encoding: 'utf-8',
-    timeout: 15000,
-  });
-  return JSON.parse(out);
-}
-
-function downloadFileWithAuth(url, outputPath) {
-  const token = getGitHubToken();
-  const headers = ['-H', 'Accept: application/vnd.github+json'];
-  if (token) {
-    headers.push('-H', `Authorization: Bearer ${token}`);
-  }
-
+  const headers = token ? ['-H', `Authorization: Bearer ${token}`] : [];
   try {
     execFileSync('curl', ['-L', '--fail', '--silent', '--show-error', ...headers, '-o', outputPath, url], {
       timeout: 120000,
     });
-    return;
+  } catch (error) {
+    if (token) throw error;
+    execFileSync('wget', ['-q', '-O', outputPath, url], { timeout: 120000 });
+  }
+}
+
+function githubApiGetJson(apiPath, token) {
+  try {
+    return JSON.parse(
+      execFileSync('gh', ['api', apiPath], {
+        encoding: 'utf8',
+        timeout: 15000,
+        env: { ...process.env, GH_TOKEN: token },
+      })
+    );
   } catch {
-    // curl may be unavailable in some local environments; try gh before failing.
+    const headers = ['-H', 'Accept: application/vnd.github+json', '-H', `Authorization: Bearer ${token}`];
+    const out = execFileSync('curl', ['-fsSL', ...headers, `https://api.github.com/${apiPath}`], {
+      encoding: 'utf8',
+      timeout: 15000,
+    });
+    return JSON.parse(out);
   }
-
-  execFileSync('gh', ['api', url, '--output', outputPath], {
-    timeout: 120000,
-    env: {
-      ...process.env,
-      GH_TOKEN: token || process.env.GH_TOKEN,
-    },
-  });
 }
 
-function listActionsArtifacts(runId) {
-  const response = githubApiGetJson(
-    `repos/${GITHUB_OWNER}/${GITHUB_REPO}/actions/runs/${runId}/artifacts?per_page=100`
+function resolveLatestLegacyTag() {
+  const token = getGitHubToken();
+  try {
+    const out = execSync(`gh api repos/${LEGACY_GITHUB_OWNER}/${LEGACY_GITHUB_REPO}/releases/latest --jq .tag_name`, {
+      encoding: 'utf8',
+      timeout: 15000,
+    }).trim();
+    if (out) return out;
+  } catch {}
+
+  try {
+    const headers = token ? ['-H', `Authorization: Bearer ${token}`] : [];
+    const out = execFileSync(
+      'curl',
+      [
+        '-fsSL',
+        ...headers,
+        `https://api.github.com/repos/${LEGACY_GITHUB_OWNER}/${LEGACY_GITHUB_REPO}/releases/latest`,
+      ],
+      { encoding: 'utf8', timeout: 15000 }
+    );
+    return JSON.parse(out).tag_name || null;
+  } catch {
+    return null;
+  }
+}
+
+function getLegacyAssetName(platform, arch, tag) {
+  const archMap = { x64: 'x86_64', arm64: 'aarch64' };
+  const platformMap = { darwin: 'apple-darwin', linux: 'unknown-linux-gnu', win32: 'pc-windows-msvc' };
+  if (!archMap[arch] || !platformMap[platform]) return null;
+  return `aioncore-${tag}-${archMap[arch]}-${platformMap[platform]}${platform === 'win32' ? '.zip' : '.tar.gz'}`;
+}
+
+function createFreshTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function extractExpectedArchive(archivePath, tempDir, binaryName) {
+  const extractDir = path.join(tempDir, 'binary');
+  extractArchiveSafely(archivePath, extractDir, [binaryName]);
+  return path.join(extractDir, binaryName);
+}
+
+function downloadAndVerifyStable(platform, arch, pin) {
+  const target = getCanonicalTarget(platform, arch);
+  const archiveName = getArchiveName(pin.tag, target);
+  const tempDir = createFreshTempDir('ki-core-release-');
+  const manifestPath = path.join(tempDir, 'ki-core-release.json');
+  const checksumPath = path.join(tempDir, 'ki-core-checksums.txt');
+  const archivePath = path.join(tempDir, archiveName);
+
+  try {
+    downloadFile(getReleaseUrl(pin.tag, 'ki-core-release.json'), manifestPath);
+    downloadFile(getReleaseUrl(pin.tag, 'ki-core-checksums.txt'), checksumPath);
+    downloadFile(getReleaseUrl(pin.tag, archiveName), archivePath);
+    const manifest = validateDownloadedAssets({
+      sourceType: 'stable',
+      platformKey: target.platformKey,
+      tag: pin.tag,
+      manifestPath,
+      checksumPath,
+      archivePath,
+      pinnedChecksums: pin.checksums,
+    });
+    const binaryPath = extractExpectedArchive(archivePath, tempDir, target.executable);
+    return {
+      binaryPath,
+      manifest,
+      tempDir,
+      source: {
+        policy: 'release-pinned',
+        type: 'github-release',
+        repository: KI_CORE_REPOSITORY,
+        tag: pin.tag,
+        assetName: archiveName,
+        url: getReleaseUrl(pin.tag, archiveName),
+      },
+    };
+  } catch (error) {
+    removeDirectorySafe(tempDir);
+    throw error;
+  }
+}
+
+function validateCandidateArtifactEntries(entries, target) {
+  const archivePattern = new RegExp(
+    `^ki-core-v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)-${target.target.replaceAll('.', '\\.')}${target.extension.replaceAll('.', '\\.')}$`
   );
-  return Array.isArray(response?.artifacts) ? response.artifacts : [];
+  const archiveNames = entries.map((entry) => entry.name).filter((name) => archivePattern.test(name));
+  if (archiveNames.length !== 1) {
+    throw new Error('Ki-Core candidate artifact must contain exactly one canonical platform archive');
+  }
+  const expectedEntries = [archiveNames[0], 'ki-core-candidate.json', 'ki-core-checksums.txt'];
+  validateEntries(entries, expectedEntries);
+  return { archiveName: archiveNames[0], expectedEntries };
 }
 
-function downloadAndExtractActionsArtifact(platform, arch, runId) {
-  const expectedArtifactName = getActionsArtifactName(platform, arch);
-  if (!expectedArtifactName) {
-    throw new Error(`Unsupported AionCore Actions artifact target: ${platform}-${arch}`);
-  }
+function downloadAndVerifyCandidate(platform, arch, runId, expectedSha, token) {
+  if (!/^[1-9]\d*$/.test(runId)) throw new Error('Ki-Core candidate run ID must be numeric');
+  if (!/^[0-9a-f]{40}$/.test(expectedSha))
+    throw new Error('Ki-Core candidate head SHA must be a full lowercase commit SHA');
+  if (!token) throw new Error('KI_CORE_ACTIONS_TOKEN is required for Ki-Core candidate downloads');
 
-  const artifacts = listActionsArtifacts(runId);
-  const availableArtifactNames = artifacts
-    .map((artifact) => artifact.name)
-    .filter(Boolean)
-    .toSorted();
-  const artifact = artifacts.find((candidate) => candidate.name === expectedArtifactName);
-  if (!artifact) {
+  const target = getCanonicalTarget(platform, arch);
+  const run = githubApiGetJson(`repos/${KI_CORE_REPOSITORY}/actions/runs/${runId}`, token);
+  validateCandidateRun(run, { headSha: expectedSha });
+  const artifactResponse = githubApiGetJson(
+    `repos/${KI_CORE_REPOSITORY}/actions/runs/${runId}/artifacts?per_page=100`,
+    token
+  );
+  const artifacts = Array.isArray(artifactResponse?.artifacts) ? artifactResponse.artifacts : [];
+  const expectedArtifactName = getActionsArtifactName(platform, arch);
+  let artifact;
+  try {
+    artifact = selectCandidateArtifact(artifacts, expectedArtifactName);
+  } catch {
     throw new Error(
       getActionsArtifactMissingMessage({
         runId,
         platform,
         arch,
         expectedArtifactName,
-        availableArtifactNames,
+        availableArtifactNames: artifacts
+          .map((entry) => entry?.name)
+          .filter(Boolean)
+          .toSorted(),
       })
     );
   }
 
-  const tempDir = path.join(os.tmpdir(), 'aioncore-prepare-actions', runId, `${platform}-${arch}`);
+  const tempDir = createFreshTempDir('ki-core-candidate-');
   const artifactZipPath = path.join(tempDir, `${expectedArtifactName}.zip`);
-  const artifactExtractDir = path.join(tempDir, 'artifact');
-  const binaryExtractDir = path.join(tempDir, 'binary');
-
-  removeDirectorySafe(tempDir);
-  ensureDirectory(tempDir);
-
+  const artifactDir = path.join(tempDir, 'artifact');
   const downloadUrl =
     artifact.archive_download_url ||
-    `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/actions/artifacts/${artifact.id}/zip`;
-  console.log(`  Downloading aioncore from AionCore run ${runId} artifact ${expectedArtifactName}`);
-  downloadFileWithAuth(downloadUrl, artifactZipPath);
-  extractArchive(artifactZipPath, artifactExtractDir, platform);
+    `https://api.github.com/repos/${KI_CORE_REPOSITORY}/actions/artifacts/${artifact.id}/zip`;
 
-  const archivePath = findAioncoreArchiveInDir(artifactExtractDir);
-  if (!archivePath) {
-    throw new Error(`AionCore artifact ${expectedArtifactName} from run ${runId} does not contain an aioncore archive`);
+  try {
+    downloadFile(downloadUrl, artifactZipPath, token);
+    const { archiveName, expectedEntries } = validateCandidateArtifactEntries(
+      inspectArchiveSafely(artifactZipPath),
+      target
+    );
+    extractArchiveSafely(artifactZipPath, artifactDir, expectedEntries);
+    const archivePath = path.join(artifactDir, archiveName);
+    const manifestPath = path.join(artifactDir, 'ki-core-candidate.json');
+    const checksumPath = path.join(artifactDir, 'ki-core-checksums.txt');
+    const manifest = validateDownloadedAssets({
+      sourceType: 'candidate',
+      platformKey: target.platformKey,
+      runId,
+      headSha: expectedSha,
+      manifestPath,
+      checksumPath,
+      archivePath,
+    });
+    const binaryPath = extractExpectedArchive(archivePath, tempDir, target.executable);
+    return {
+      binaryPath,
+      manifest,
+      tempDir,
+      source: {
+        policy: 'candidate',
+        type: 'actions-artifact',
+        repository: KI_CORE_REPOSITORY,
+        workflow: 'build-manual.yml',
+        runId,
+        headSha: expectedSha,
+        artifactName: expectedArtifactName,
+        url: downloadUrl,
+      },
+    };
+  } catch (error) {
+    removeDirectorySafe(tempDir);
+    throw error;
   }
+}
 
-  extractArchive(archivePath, binaryExtractDir, platform);
+function downloadLegacyDevelopment(platform, arch, requestedVersion) {
+  const tag =
+    requestedVersion === 'latest'
+      ? resolveLatestLegacyTag()
+      : requestedVersion?.startsWith('v')
+        ? requestedVersion
+        : `v${requestedVersion}`;
+  if (!tag) throw new Error('Failed to resolve the legacy AionCore development release tag');
+  const assetName = getLegacyAssetName(platform, arch, tag);
+  if (!assetName) throw new Error(`Unsupported AionCore development target: ${platform}-${arch}`);
 
-  const binaryName = getBinaryName(platform);
-  const binaryPath = findBinaryInDir(binaryExtractDir, binaryName);
-  if (!binaryPath) {
-    throw new Error(`Binary ${binaryName} not found in AionCore artifact ${expectedArtifactName} from run ${runId}`);
+  const tempDir = createFreshTempDir('aioncore-development-');
+  const archivePath = path.join(tempDir, assetName);
+  const url = `https://github.com/${LEGACY_GITHUB_OWNER}/${LEGACY_GITHUB_REPO}/releases/download/${tag}/${assetName}`;
+  try {
+    downloadFile(url, archivePath);
+    return {
+      binaryPath: extractExpectedArchive(archivePath, tempDir, getBinaryName(platform)),
+      manifest: null,
+      tempDir,
+      source: { policy: 'development', type: 'legacy-release', repository: 'iOfficeAI/AionCore', tag, url },
+    };
+  } catch (error) {
+    removeDirectorySafe(tempDir);
+    throw error;
   }
+}
 
+function buildBundleManifest({ platform, arch, manifest, source, sourceType, binaryName }) {
   return {
-    binaryPath,
-    tempDir,
-    artifactName: expectedArtifactName,
-    archivePath,
-    url: downloadUrl,
+    ...createBundleProvenance(manifest, source),
+    platform,
+    arch,
+    generatedAt: new Date().toISOString(),
+    sourceType,
+    files: [binaryName, 'managed-resources/'],
   };
 }
 
-function downloadAndExtract(platform, arch, tag) {
-  const assetName = getAssetName(platform, arch, tag);
-  if (!assetName) {
-    throw new Error(`Unsupported aioncore target: ${platform}-${arch}`);
-  }
-
-  const url = getDownloadUrl(assetName, tag);
-  const tempDir = path.join(os.tmpdir(), 'aioncore-prepare', tag, `${platform}-${arch}`);
-  const archivePath = path.join(tempDir, assetName);
-  const extractDir = path.join(tempDir, 'extracted');
-
-  removeDirectorySafe(tempDir);
-  ensureDirectory(tempDir);
-
-  downloadFile(url, archivePath);
-  extractArchive(archivePath, extractDir, platform);
-
-  const binaryName = getBinaryName(platform);
-  const binaryPath = findBinaryInDir(extractDir, binaryName);
-  if (!binaryPath) {
-    throw new Error(`Binary ${binaryName} not found in downloaded archive`);
-  }
-
-  return { binaryPath, tempDir, url };
-}
-
-// ---------------------------------------------------------------------------
-// Main export
-// ---------------------------------------------------------------------------
-
 /**
- * Prepare aioncore binary for packaging.
- *
- * @param {object} options - Configuration options
- * @param {string} options.projectRoot - Project root directory
- * @param {string} options.platform - Target platform (process.platform)
- * @param {string} options.arch - Target architecture (process.arch)
- * @param {string} options.version - Backend version (default: 'latest')
+ * @param {object} options
+ * @param {string} options.projectRoot
+ * @param {string} options.platform
+ * @param {string} options.arch
+ * @param {string | null} [options.version]
+ * @param {'release-pinned' | 'candidate' | 'development'} [options.sourcePolicy]
  * @returns {{ prepared: true; dir: string; sourceType: string }}
  */
 function prepareAioncore(options) {
   const { projectRoot, platform, arch, version = 'latest' } = options;
+  const sourcePolicy = getSourcePolicy(options.sourcePolicy);
   const runtimeKey = `${platform}-${arch}`;
-  const actionsRunId = (process.env.AIONUI_BACKEND_RUN_ID || '').trim();
-
-  let tag = null;
-  if (!actionsRunId) {
-    // Resolve the actual version tag — release asset filenames include the tag.
-    if (version === 'latest') {
-      const resolved = resolveLatestTag();
-      if (!resolved) {
-        throw new Error('Failed to resolve latest aioncore release tag from GitHub API');
-      }
-      tag = resolved;
-      console.log(`Resolved aioncore "latest" → ${tag}`);
-    } else {
-      tag = version.startsWith('v') ? version : `v${version}`;
-    }
-  }
-
   const targetDir = path.join(projectRoot, 'resources', 'bundled-aioncore', runtimeKey);
   const binaryName = getBinaryName(platform);
   const targetBinaryPath = path.join(targetDir, binaryName);
-
-  console.log(
-    `Preparing aioncore for ${runtimeKey} (${actionsRunId ? `actions run: ${actionsRunId}` : `version: ${tag}`})`
-  );
+  let tempDir = null;
 
   removeDirectorySafe(targetDir);
   ensureDirectory(targetDir);
 
-  const localBundleDir = (process.env.AIONUI_BACKEND_LOCAL_BUNDLE_DIR || '').trim();
-  if (localBundleDir) {
-    const resolvedLocalBundleDir = path.resolve(localBundleDir);
-    const localBinaryPath = path.join(resolvedLocalBundleDir, binaryName);
-    const localManagedResourcesDir = path.join(resolvedLocalBundleDir, 'managed-resources');
-    if (
-      fs.existsSync(resolvedLocalBundleDir) &&
-      fs.statSync(resolvedLocalBundleDir).isDirectory() &&
-      fs.existsSync(localBinaryPath) &&
-      fs.existsSync(localManagedResourcesDir)
-    ) {
-      copyDirectorySafe(resolvedLocalBundleDir, targetDir);
-      ensureExecutableMode(targetBinaryPath);
-      const manifest = {
-        platform,
-        arch,
-        version: tag || `actions-run-${actionsRunId}` || 'local-bundle',
-        generatedAt: new Date().toISOString(),
-        sourceType: 'local-bundle',
-        source: { path: resolvedLocalBundleDir },
-        files: [binaryName, 'managed-resources/'],
-      };
-      writeJson(path.join(targetDir, 'manifest.json'), manifest);
-      verifyPreparedAioncoreBundle(projectRoot, platform, arch);
-      console.log(`  Using local aioncore bundle: ${resolvedLocalBundleDir}`);
-      return { prepared: true, dir: targetDir, sourceType: 'local-bundle' };
+  try {
+    if (sourcePolicy === 'development') {
+      const localBundleDir = (process.env.AIONUI_BACKEND_LOCAL_BUNDLE_DIR || '').trim();
+      if (localBundleDir) {
+        const resolvedLocalBundleDir = path.resolve(localBundleDir);
+        const localBinaryPath = path.join(resolvedLocalBundleDir, binaryName);
+        const localManagedResourcesDir = path.join(resolvedLocalBundleDir, 'managed-resources');
+        if (
+          fs.existsSync(resolvedLocalBundleDir) &&
+          fs.statSync(resolvedLocalBundleDir).isDirectory() &&
+          fs.existsSync(localBinaryPath) &&
+          fs.existsSync(localManagedResourcesDir)
+        ) {
+          copyDirectorySafe(resolvedLocalBundleDir, targetDir);
+          ensureExecutableMode(targetBinaryPath);
+          writeJson(
+            path.join(targetDir, 'manifest.json'),
+            buildBundleManifest({
+              platform,
+              arch,
+              manifest: null,
+              source: { policy: 'development', type: 'local-bundle', path: resolvedLocalBundleDir },
+              sourceType: 'local-bundle',
+              binaryName,
+            })
+          );
+          verifyPreparedAioncoreBundle(projectRoot, platform, arch);
+          return { prepared: true, dir: targetDir, sourceType: 'local-bundle' };
+        }
+        console.warn(`  Local aioncore bundle is incomplete or missing: ${resolvedLocalBundleDir}`);
+      }
+    } else if (process.env.AIONUI_BACKEND_LOCAL_BUNDLE_DIR || process.env.AIONUI_BACKEND_LOCAL_BINARY) {
+      throw new Error(`Local Ki-Core inputs are forbidden by the ${sourcePolicy} source policy`);
     }
-    console.warn(`  Local aioncore bundle is incomplete or missing: ${resolvedLocalBundleDir}`);
-  }
 
-  let sourcePath = null;
-  let sourceType = 'none';
-  let sourceDetail = {};
-  let tempDir = null;
-
-  // 1. Download from GitHub Actions artifacts when manual build run id is provided.
-  if (actionsRunId) {
-    const result = downloadAndExtractActionsArtifact(platform, arch, actionsRunId);
-    sourcePath = result.binaryPath;
-    tempDir = result.tempDir;
-    sourceType = 'actions-artifact';
-    sourceDetail = {
-      runId: actionsRunId,
-      artifactName: result.artifactName,
-      url: result.url,
-    };
-    console.log(`  Downloaded from GitHub Actions artifact`);
-  }
-
-  // 2. Download from GitHub releases.
-  if (!sourcePath && tag) {
-    try {
-      const result = downloadAndExtract(platform, arch, tag);
-      sourcePath = result.binaryPath;
-      tempDir = result.tempDir;
-      sourceType = 'download';
-      sourceDetail = { url: result.url };
-      console.log(`  Downloaded from GitHub releases`);
-    } catch (error) {
-      console.warn(`  Download failed: ${error.message}`);
-    }
-  }
-
-  // 3. Use an explicitly supplied local cache when network download is unavailable.
-  if (!sourcePath) {
-    const localBinary = (process.env.AIONUI_BACKEND_LOCAL_BINARY || '').trim();
-    if (localBinary) {
-      const resolvedLocalBinary = path.resolve(localBinary);
-      if (fs.existsSync(resolvedLocalBinary) && fs.statSync(resolvedLocalBinary).isFile()) {
-        sourcePath = resolvedLocalBinary;
-        sourceType = 'local-binary';
-        sourceDetail = { path: resolvedLocalBinary };
-        console.log(`  Using local aioncore binary: ${resolvedLocalBinary}`);
+    let result;
+    if (sourcePolicy === 'release-pinned') {
+      if (process.env.AIONUI_BACKEND_RUN_ID || process.env.AIONUI_BACKEND_VERSION) {
+        throw new Error('release-pinned policy forbids Actions run IDs and version overrides');
+      }
+      result = downloadAndVerifyStable(platform, arch, readKiCorePin(projectRoot));
+    } else if (sourcePolicy === 'candidate') {
+      if (process.env.AIONUI_BACKEND_VERSION) {
+        throw new Error('candidate policy forbids stable version overrides');
+      }
+      const runId = (process.env.AIONUI_BACKEND_RUN_ID || '').trim();
+      const expectedSha = (process.env.AIONUI_BACKEND_EXPECTED_SHA || '').trim();
+      const token = (process.env.KI_CORE_ACTIONS_TOKEN || '').trim();
+      result = downloadAndVerifyCandidate(platform, arch, runId, expectedSha, token);
+    } else {
+      const localBinary = (process.env.AIONUI_BACKEND_LOCAL_BINARY || '').trim();
+      if (localBinary) {
+        const resolvedLocalBinary = path.resolve(localBinary);
+        if (!fs.existsSync(resolvedLocalBinary) || !fs.statSync(resolvedLocalBinary).isFile()) {
+          throw new Error(`Local aioncore binary not found: ${resolvedLocalBinary}`);
+        }
+        result = {
+          binaryPath: resolvedLocalBinary,
+          manifest: null,
+          tempDir: null,
+          source: { policy: 'development', type: 'local-binary', path: resolvedLocalBinary },
+        };
       } else {
-        console.warn(`  Local aioncore binary not found: ${resolvedLocalBinary}`);
+        result = downloadLegacyDevelopment(platform, arch, version || 'latest');
       }
     }
-  }
 
-  // Write result
-  if (sourcePath) {
-    copyFileSafe(sourcePath, targetBinaryPath);
+    tempDir = result.tempDir;
+    copyFileSafe(result.binaryPath, targetBinaryPath);
     ensureExecutableMode(targetBinaryPath);
     const bundledManagedResourcesDir = prepareManagedResources(targetBinaryPath, targetDir);
-
-    // The release tag is the authoritative version — the aioncore
-    // binary does not expose a --version flag (it has --app-version which
-    // takes a value, not a self-report).
-    const manifest = {
-      platform,
-      arch,
-      version: tag || `actions-run-${actionsRunId}`,
-      generatedAt: new Date().toISOString(),
-      sourceType,
-      source: sourceDetail,
-      files: [binaryName, 'managed-resources/'],
-    };
-
-    writeJson(path.join(targetDir, 'manifest.json'), manifest);
-    verifyPreparedAioncoreBundle(projectRoot, platform, arch);
-    console.log(
-      `  Bundled aioncore prepared: resources/bundled-aioncore/${runtimeKey}/${binaryName} [source=${sourceType}]`
+    const sourceType = result.source.type;
+    writeJson(
+      path.join(targetDir, 'manifest.json'),
+      buildBundleManifest({ platform, arch, manifest: result.manifest, source: result.source, sourceType, binaryName })
     );
+    verifyPreparedAioncoreBundle(projectRoot, platform, arch);
+    console.log(`  Bundled aioncore prepared: resources/bundled-aioncore/${runtimeKey}/${binaryName}`);
     console.log(`  Bundled managed resources prepared: ${bundledManagedResourcesDir}`);
-
-    if (tempDir) removeDirectorySafe(tempDir);
     return { prepared: true, dir: targetDir, sourceType };
+  } catch (error) {
+    removeDirectorySafe(targetDir);
+    throw error;
+  } finally {
+    if (tempDir) removeDirectorySafe(tempDir);
   }
-
-  throw new Error(`aioncore binary not found for ${runtimeKey} (tag: ${tag})`);
 }
 
 module.exports = {

--- a/packages/shared-scripts/src/prepare-aioncore.js
+++ b/packages/shared-scripts/src/prepare-aioncore.js
@@ -92,12 +92,14 @@ function prepareManagedResources(binaryPath, targetDir) {
   ensureDirectory(dataDir);
 
   console.log(`  Preparing managed resources under ${path.relative(process.cwd(), bundleOut)}`);
+  const childEnv = {
+    ...process.env,
+    AIONUI_BUNDLED_MANAGED_RESOURCES: '',
+  };
+  delete childEnv.KI_CORE_ACTIONS_TOKEN;
   execFileSync(binaryPath, ['--data-dir', dataDir, 'prepare-managed-resources', '--bundle-out', bundleOut], {
     stdio: 'inherit',
-    env: {
-      ...process.env,
-      AIONUI_BUNDLED_MANAGED_RESOURCES: '',
-    },
+    env: childEnv,
   });
 
   removeDirectorySafe(dataDir);
@@ -142,22 +144,25 @@ function downloadFile(url, outputPath, token = '') {
 }
 
 function githubApiGetJson(apiPath, token) {
-  try {
-    return JSON.parse(
-      execFileSync('gh', ['api', apiPath], {
-        encoding: 'utf8',
-        timeout: 15000,
-        env: { ...process.env, GH_TOKEN: token },
-      })
-    );
-  } catch {
-    const headers = ['-H', 'Accept: application/vnd.github+json', '-H', `Authorization: Bearer ${token}`];
-    const out = execFileSync('curl', ['-fsSL', ...headers, `https://api.github.com/${apiPath}`], {
-      encoding: 'utf8',
-      timeout: 15000,
-    });
-    return JSON.parse(out);
+  if (token) {
+    try {
+      return JSON.parse(
+        execFileSync('gh', ['api', apiPath], {
+          encoding: 'utf8',
+          timeout: 15000,
+          env: { ...process.env, GH_TOKEN: token },
+        })
+      );
+    } catch {}
   }
+
+  const headers = ['-H', 'Accept: application/vnd.github+json'];
+  if (token) headers.push('-H', `Authorization: Bearer ${token}`);
+  const out = execFileSync('curl', ['-fsSL', ...headers, `https://api.github.com/${apiPath}`], {
+    encoding: 'utf8',
+    timeout: 15000,
+  });
+  return JSON.parse(out);
 }
 
 function resolveLatestLegacyTag() {
@@ -262,8 +267,6 @@ function downloadAndVerifyCandidate(platform, arch, runId, expectedSha, token) {
   if (!/^[1-9]\d*$/.test(runId)) throw new Error('Ki-Core candidate run ID must be numeric');
   if (!/^[0-9a-f]{40}$/.test(expectedSha))
     throw new Error('Ki-Core candidate head SHA must be a full lowercase commit SHA');
-  if (!token) throw new Error('KI_CORE_ACTIONS_TOKEN is required for Ki-Core candidate downloads');
-
   const target = getCanonicalTarget(platform, arch);
   const run = githubApiGetJson(`repos/${KI_CORE_REPOSITORY}/actions/runs/${runId}`, token);
   validateCandidateRun(run, { headSha: expectedSha });

--- a/packages/shared-scripts/src/prepare-aioncore.js
+++ b/packages/shared-scripts/src/prepare-aioncore.js
@@ -213,27 +213,27 @@ function downloadAndVerifyStable(platform, arch, pin) {
   const target = getCanonicalTarget(platform, arch);
   const archiveName = getArchiveName(pin.tag, target);
   const tempDir = createFreshTempDir('ki-core-release-');
-  const manifestPath = path.join(tempDir, 'ki-core-release.json');
   const checksumPath = path.join(tempDir, 'ki-core-checksums.txt');
   const archivePath = path.join(tempDir, archiveName);
 
   try {
-    downloadFile(getReleaseUrl(pin.tag, 'ki-core-release.json'), manifestPath);
     downloadFile(getReleaseUrl(pin.tag, 'ki-core-checksums.txt'), checksumPath);
     downloadFile(getReleaseUrl(pin.tag, archiveName), archivePath);
-    const manifest = validateDownloadedAssets({
-      sourceType: 'stable',
+    validateDownloadedAssets({
       platformKey: target.platformKey,
       tag: pin.tag,
-      manifestPath,
       checksumPath,
       archivePath,
       pinnedChecksums: pin.checksums,
     });
     const binaryPath = extractExpectedArchive(archivePath, tempDir, target.executable);
+    const version = pin.tag.replace(/^ki-core-v/, '');
     return {
       binaryPath,
-      manifest,
+      manifest: {
+        product: { version, tag: pin.tag, releaseCommit: pin.commit },
+        upstream: pin.aionCore,
+      },
       tempDir,
       source: {
         policy: 'release-pinned',
@@ -258,9 +258,10 @@ function validateCandidateArtifactEntries(entries, target) {
   if (archiveNames.length !== 1) {
     throw new Error('Ki-Core candidate artifact must contain exactly one canonical platform archive');
   }
-  const expectedEntries = [archiveNames[0], 'ki-core-candidate.json', 'ki-core-checksums.txt'];
+  const expectedEntries = [archiveNames[0]];
   validateEntries(entries, expectedEntries);
-  return { archiveName: archiveNames[0], expectedEntries };
+  const version = archivePattern.exec(archiveNames[0]).slice(1, 4).join('.');
+  return { archiveName: archiveNames[0], expectedEntries, version };
 }
 
 function downloadAndVerifyCandidate(platform, arch, runId, expectedSha, token) {
@@ -303,27 +304,16 @@ function downloadAndVerifyCandidate(platform, arch, runId, expectedSha, token) {
 
   try {
     downloadFile(downloadUrl, artifactZipPath, token);
-    const { archiveName, expectedEntries } = validateCandidateArtifactEntries(
+    const { archiveName, expectedEntries, version } = validateCandidateArtifactEntries(
       inspectArchiveSafely(artifactZipPath),
       target
     );
     extractArchiveSafely(artifactZipPath, artifactDir, expectedEntries);
     const archivePath = path.join(artifactDir, archiveName);
-    const manifestPath = path.join(artifactDir, 'ki-core-candidate.json');
-    const checksumPath = path.join(artifactDir, 'ki-core-checksums.txt');
-    const manifest = validateDownloadedAssets({
-      sourceType: 'candidate',
-      platformKey: target.platformKey,
-      runId,
-      headSha: expectedSha,
-      manifestPath,
-      checksumPath,
-      archivePath,
-    });
     const binaryPath = extractExpectedArchive(archivePath, tempDir, target.executable);
     return {
       binaryPath,
-      manifest,
+      manifest: null,
       tempDir,
       source: {
         policy: 'candidate',
@@ -332,6 +322,7 @@ function downloadAndVerifyCandidate(platform, arch, runId, expectedSha, token) {
         workflow: 'build-manual.yml',
         runId,
         headSha: expectedSha,
+        version,
         artifactName: expectedArtifactName,
         url: downloadUrl,
       },

--- a/packages/shared-scripts/src/safeExtractArchive.js
+++ b/packages/shared-scripts/src/safeExtractArchive.js
@@ -1,0 +1,250 @@
+const fs = require('node:fs');
+const fsPromises = require('node:fs/promises');
+const path = require('node:path');
+const tar = require('tar');
+const yauzl = require('yauzl');
+
+function normalizeArchiveEntry(entryName) {
+  if (typeof entryName !== 'string' || !entryName || entryName.includes('\0')) {
+    throw new Error('Archive contains an empty or invalid entry name');
+  }
+  if (entryName.includes('\\') || entryName.startsWith('/') || /^[A-Za-z]:/.test(entryName)) {
+    throw new Error(`Archive entry is not a portable relative path: ${entryName}`);
+  }
+
+  const segments = entryName.split('/');
+  if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    throw new Error(`Archive entry contains an unsafe path segment: ${entryName}`);
+  }
+
+  const normalized = path.posix.normalize(entryName);
+  if (normalized !== entryName || path.posix.isAbsolute(normalized)) {
+    throw new Error(`Archive entry does not normalize safely: ${entryName}`);
+  }
+  return normalized;
+}
+
+function validateEntries(entries, expectedEntries) {
+  const expected = new Set(expectedEntries);
+  const seen = new Set();
+
+  for (const entry of entries) {
+    const normalized = normalizeArchiveEntry(entry.name);
+    if (seen.has(normalized)) {
+      throw new Error(`Archive contains a duplicate normalized entry: ${normalized}`);
+    }
+    seen.add(normalized);
+    if (!entry.isFile || entry.isSymbolicLink || entry.isHardLink) {
+      throw new Error(`Archive entry must be a regular file: ${normalized}`);
+    }
+    if (!expected.has(normalized)) {
+      throw new Error(`Archive contains an unexpected entry: ${normalized}`);
+    }
+  }
+
+  if (seen.size !== expected.size || [...expected].some((entry) => !seen.has(entry))) {
+    throw new Error(`Archive entries do not match the expected file set: ${[...expected].join(', ')}`);
+  }
+}
+
+async function inspectTarArchive(archivePath) {
+  const entries = [];
+  await tar.t({
+    file: archivePath,
+    preservePaths: true,
+    strict: true,
+    onentry(entry) {
+      entries.push({
+        name: entry.path,
+        isFile: entry.type === 'File' || entry.type === 'OldFile' || entry.type === 'ContiguousFile',
+        isSymbolicLink: entry.type === 'SymbolicLink',
+        isHardLink: entry.type === 'Link',
+      });
+    },
+  });
+  return entries;
+}
+
+function openZip(archivePath) {
+  return new Promise((resolve, reject) => {
+    yauzl.open(
+      archivePath,
+      {
+        autoClose: true,
+        decodeStrings: true,
+        lazyEntries: true,
+        strictFileNames: true,
+        validateEntrySizes: true,
+      },
+      (error, archive) => {
+        if (error) reject(error);
+        else resolve(archive);
+      }
+    );
+  });
+}
+
+async function inspectZipArchive(archivePath) {
+  const archive = await openZip(archivePath);
+  const entries = [];
+
+  await new Promise((resolve, reject) => {
+    archive.on('error', reject);
+    archive.on('end', resolve);
+    archive.on('entry', (entry) => {
+      const unixMode = entry.externalFileAttributes >>> 16;
+      const fileType = unixMode & 0o170000;
+      entries.push({
+        name: entry.fileName,
+        isFile: !entry.fileName.endsWith('/') && fileType !== 0o040000 && fileType !== 0o120000,
+        isSymbolicLink: fileType === 0o120000,
+        isHardLink: false,
+        encrypted: Boolean(entry.generalPurposeBitFlag & 0x1),
+      });
+      archive.readEntry();
+    });
+    archive.readEntry();
+  });
+
+  if (entries.some((entry) => entry.encrypted)) {
+    throw new Error('Encrypted archive entries are not supported');
+  }
+  return entries;
+}
+
+async function inspectArchive(archivePath) {
+  if (archivePath.endsWith('.tar.gz')) return inspectTarArchive(archivePath);
+  if (archivePath.endsWith('.zip')) return inspectZipArchive(archivePath);
+  throw new Error(`Unsupported archive type: ${path.basename(archivePath)}`);
+}
+
+function ensureOutputPath(outputDir, entryName) {
+  const outputRoot = path.resolve(outputDir);
+  const outputPath = path.resolve(outputRoot, entryName);
+  if (outputPath === outputRoot || !outputPath.startsWith(`${outputRoot}${path.sep}`)) {
+    throw new Error(`Archive output escapes its temporary directory: ${entryName}`);
+  }
+  return outputPath;
+}
+
+async function extractZipArchive(archivePath, outputDir, expectedEntries) {
+  const expected = new Set(expectedEntries);
+  const archive = await openZip(archivePath);
+
+  await new Promise((resolve, reject) => {
+    let active = false;
+    archive.on('error', reject);
+    archive.on('end', () => {
+      if (!active) resolve();
+    });
+    archive.on('entry', (entry) => {
+      active = true;
+      if (!expected.has(entry.fileName)) {
+        reject(new Error(`Archive entry changed after validation: ${entry.fileName}`));
+        return;
+      }
+      archive.openReadStream(entry, (error, stream) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        const outputPath = ensureOutputPath(outputDir, entry.fileName);
+        const output = fs.createWriteStream(outputPath, { flags: 'wx', mode: 0o600 });
+        stream.on('error', reject);
+        output.on('error', reject);
+        output.on('finish', () => {
+          active = false;
+          archive.readEntry();
+        });
+        stream.pipe(output);
+      });
+    });
+    archive.readEntry();
+  });
+}
+
+async function verifyExtractedFiles(outputDir, expectedEntries) {
+  const actualEntries = await fsPromises.readdir(outputDir, { withFileTypes: true });
+  const actualNames = actualEntries.map((entry) => entry.name).toSorted();
+  const expectedNames = expectedEntries.toSorted();
+  if (JSON.stringify(actualNames) !== JSON.stringify(expectedNames)) {
+    throw new Error('Extracted archive files do not match the validated entry set');
+  }
+
+  await Promise.all(
+    expectedEntries.map(async (entryName) => {
+      const outputPath = ensureOutputPath(outputDir, entryName);
+      const stat = await fsPromises.lstat(outputPath);
+      if (!stat.isFile() || stat.isSymbolicLink()) {
+        throw new Error(`Extracted archive entry is not a regular file: ${entryName}`);
+      }
+    })
+  );
+}
+
+async function extractArchiveSafely(archivePath, outputDir, expectedEntries) {
+  if (
+    !Array.isArray(expectedEntries) ||
+    expectedEntries.length === 0 ||
+    new Set(expectedEntries).size !== expectedEntries.length
+  ) {
+    throw new Error('Expected archive entries must be a non-empty unique array');
+  }
+  if (fs.existsSync(outputDir)) {
+    throw new Error(`Archive output directory must not already exist: ${outputDir}`);
+  }
+
+  const entries = await inspectArchive(archivePath);
+  validateEntries(entries, expectedEntries);
+
+  try {
+    await fsPromises.mkdir(outputDir, { recursive: false });
+    if (archivePath.endsWith('.tar.gz')) {
+      const expected = new Set(expectedEntries);
+      await tar.x({
+        cwd: outputDir,
+        file: archivePath,
+        preservePaths: false,
+        strict: true,
+        filter(entryPath, entry) {
+          return expected.has(entryPath) && (entry.type === 'File' || entry.type === 'OldFile');
+        },
+      });
+    } else {
+      await extractZipArchive(archivePath, outputDir, expectedEntries);
+    }
+    await verifyExtractedFiles(outputDir, expectedEntries);
+  } catch (error) {
+    await fsPromises.rm(outputDir, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+async function main() {
+  const [archivePath, outputDir, expectedJson] = process.argv.slice(2);
+  if (archivePath === '--inspect') {
+    if (!outputDir || expectedJson) throw new Error('Usage: safeExtractArchive.js --inspect <archive>');
+    const entries = await inspectArchive(outputDir);
+    process.stdout.write(`${JSON.stringify(entries)}\n`);
+    return;
+  }
+  if (!archivePath || !outputDir || !expectedJson) {
+    throw new Error('Usage: safeExtractArchive.js <archive> <new-output-dir> <expected-files-json>');
+  }
+  const expectedEntries = JSON.parse(expectedJson);
+  await extractArchiveSafely(archivePath, outputDir, expectedEntries);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  extractArchiveSafely,
+  inspectArchive,
+  normalizeArchiveEntry,
+  validateEntries,
+};

--- a/scripts/prepareAioncore.js
+++ b/scripts/prepareAioncore.js
@@ -3,15 +3,14 @@
  *
  * Reads environment variables and invokes the shared module.
  *
- * Version resolution order:
- *  1. AIONUI_BACKEND_RUN_ID env (download from AionCore Manual Build artifact)
- *  2. AIONUI_BACKEND_VERSION env (for ad-hoc release overrides)
- *  3. "aioncoreVersion" field in repo-root package.json (the pin)
- *  4. 'latest' (fallback; not recommended for reproducible builds)
+ * Source selection is controlled by AIONUI_BACKEND_SOURCE_POLICY.
  *
  * Environment variables:
- *  - AIONUI_BACKEND_RUN_ID: AionCore Manual Build workflow run id
- *  - AIONUI_BACKEND_VERSION: override the pinned version
+ *  - AIONUI_BACKEND_SOURCE_POLICY: release-pinned, candidate, or development
+ *  - AIONUI_BACKEND_RUN_ID: Ki-Core candidate workflow run id
+ *  - AIONUI_BACKEND_EXPECTED_SHA: expected Ki-Core candidate commit
+ *  - KI_CORE_ACTIONS_TOKEN: read-only token for candidate artifacts
+ *  - AIONUI_BACKEND_VERSION: development-only AionCore override
  *  - AIONUI_BACKEND_ARCH: target architecture (default: process.arch)
  *  - GH_TOKEN / GITHUB_TOKEN: GitHub API token (for rate limiting)
  */

--- a/scripts/prepareAioncore.js
+++ b/scripts/prepareAioncore.js
@@ -9,7 +9,7 @@
  *  - AIONUI_BACKEND_SOURCE_POLICY: release-pinned, candidate, or development
  *  - AIONUI_BACKEND_RUN_ID: Ki-Core candidate workflow run id
  *  - AIONUI_BACKEND_EXPECTED_SHA: expected Ki-Core candidate commit
- *  - KI_CORE_ACTIONS_TOKEN: read-only token for candidate artifacts
+ *  - KI_CORE_ACTIONS_TOKEN: optional read-only token for candidate API rate limits
  *  - AIONUI_BACKEND_VERSION: development-only AionCore override
  *  - AIONUI_BACKEND_ARCH: target architecture (default: process.arch)
  *  - GH_TOKEN / GITHUB_TOKEN: GitHub API token (for rate limiting)

--- a/scripts/resolveAioncoreVersion.js
+++ b/scripts/resolveAioncoreVersion.js
@@ -1,10 +1,9 @@
 /**
  * Resolve the aioncore version tag to download for packaging.
  *
- * Order:
- *   1. AIONUI_BACKEND_VERSION env (ad-hoc override, e.g. CI dispatch input)
- *   2. "aioncoreVersion" field in repo-root package.json (the pin)
- *   3. 'latest' (GitHub API releases/latest; non-reproducible fallback)
+ * release-pinned reads the immutable Ki-Core product tag from package.json.
+ * candidate does not resolve a tag. development preserves the legacy
+ * AionCore override and fallback behavior for local work only.
  *
  * Keep this file tiny and dependency-free — it's required from both
  * scripts/prepareAioncore.js and scripts/pack-web-cli.js before
@@ -13,8 +12,13 @@
 
 const fs = require('fs');
 const path = require('path');
+const { getSourcePolicy, readKiCorePin } = require('../packages/shared-scripts/src/kiCoreRelease');
 
-function resolveAioncoreVersion(projectRoot) {
+function resolveAioncoreVersion(projectRoot, explicitPolicy) {
+  const sourcePolicy = getSourcePolicy(explicitPolicy);
+  if (sourcePolicy === 'release-pinned') return readKiCorePin(projectRoot).tag;
+  if (sourcePolicy === 'candidate') return null;
+
   const envOverride = process.env.AIONUI_BACKEND_VERSION;
   if (envOverride && envOverride.trim()) {
     return envOverride.trim();

--- a/tests/unit/assets/kiCoreWorkflowPolicy.test.ts
+++ b/tests/unit/assets/kiCoreWorkflowPolicy.test.ts
@@ -7,11 +7,20 @@ function workflow(name: string) {
 }
 
 describe('Ki-Core workflow source policies', () => {
-  it('requires candidate run ID and full head SHA only in the manual build workflow', () => {
+  it('lets the manual build select a stable release or a verified candidate', () => {
     const manual = workflow('build-manual.yml');
+    expect(manual).toContain('ki_core_source_policy:');
+    expect(manual).toContain('- release-pinned');
+    expect(manual).toContain('- candidate');
+    expect(manual).toContain('default: release-pinned');
     expect(manual).toContain('ki_core_candidate_run_id:');
     expect(manual).toContain('ki_core_candidate_head_sha:');
-    expect(manual).toContain('ki_core_source_policy: candidate');
+    expect(manual).toContain('KI_CORE_SOURCE_POLICY: ${{ inputs.ki_core_source_policy }}');
+    expect(manual).toContain('KI_CORE_CANDIDATE_RUN_ID: ${{ inputs.ki_core_candidate_run_id }}');
+    expect(manual).toContain('KI_CORE_CANDIDATE_HEAD_SHA: ${{ inputs.ki_core_candidate_head_sha }}');
+    expect(manual).toContain('^[0-9]+$');
+    expect(manual).toContain('^[0-9a-f]{40}$');
+    expect(manual).toContain('ki_core_source_policy: ${{ inputs.ki_core_source_policy }}');
     expect(manual).toContain('contents: read');
     expect(manual).not.toContain('pull_request:');
   });
@@ -28,7 +37,13 @@ describe('Ki-Core workflow source policies', () => {
   it('does not expose a cross-repository token to branch-controlled build commands', () => {
     const reusable = workflow('_build-reusable.yml');
     expect(reusable).toContain("default: 'release-pinned'");
+    expect(reusable).toContain("npm_config_registry: 'https://registry.npmjs.org/'");
     expect(reusable).not.toContain('aioncore_run_id:');
     expect(reusable).not.toContain('KI_CORE_ACTIONS_TOKEN');
+  });
+
+  it('uses the npm registry for managed CLI platform packages in Web CLI builds', () => {
+    const webCli = workflow('pack-web-cli.yml');
+    expect(webCli).toContain("npm_config_registry: 'https://registry.npmjs.org/'");
   });
 });

--- a/tests/unit/assets/kiCoreWorkflowPolicy.test.ts
+++ b/tests/unit/assets/kiCoreWorkflowPolicy.test.ts
@@ -21,6 +21,7 @@ describe('Ki-Core workflow source policies', () => {
     expect(manual).toContain('^[0-9]+$');
     expect(manual).toContain('^[0-9a-f]{40}$');
     expect(manual).toContain('ki_core_source_policy: ${{ inputs.ki_core_source_policy }}');
+    expect(manual).not.toContain('upload_source_maps: true');
     expect(manual).toContain('contents: read');
     expect(manual).not.toContain('pull_request:');
   });
@@ -29,6 +30,7 @@ describe('Ki-Core workflow source policies', () => {
     const stable = workflow('build-and-release.yml');
     const webCli = workflow('pack-web-cli.yml');
     expect(stable).toContain('ki_core_source_policy: release-pinned');
+    expect(stable).toContain('upload_source_maps: true');
     expect(stable).not.toContain('ki_core_candidate_run_id:');
     expect(webCli).toContain('AIONUI_BACKEND_SOURCE_POLICY: release-pinned');
     expect(webCli).not.toContain('KI_CORE_ACTIONS_TOKEN');
@@ -37,6 +39,7 @@ describe('Ki-Core workflow source policies', () => {
   it('does not expose a cross-repository token to branch-controlled build commands', () => {
     const reusable = workflow('_build-reusable.yml');
     expect(reusable).toContain("default: 'release-pinned'");
+    expect(reusable).toContain("if: inputs.upload_source_maps && matrix.platform == 'linux-x64'");
     expect(reusable).toContain("npm_config_registry: 'https://registry.npmjs.org/'");
     expect(reusable).not.toContain('aioncore_run_id:');
     expect(reusable).not.toContain('KI_CORE_ACTIONS_TOKEN');

--- a/tests/unit/assets/kiCoreWorkflowPolicy.test.ts
+++ b/tests/unit/assets/kiCoreWorkflowPolicy.test.ts
@@ -25,12 +25,10 @@ describe('Ki-Core workflow source policies', () => {
     expect(webCli).not.toContain('KI_CORE_ACTIONS_TOKEN');
   });
 
-  it('exposes the candidate token to build commands only when candidate policy is selected', () => {
+  it('does not expose a cross-repository token to branch-controlled build commands', () => {
     const reusable = workflow('_build-reusable.yml');
-    const conditionalToken =
-      "KI_CORE_ACTIONS_TOKEN: ${{ inputs.ki_core_source_policy == 'candidate' && secrets.KI_CORE_ACTIONS_TOKEN || '' }}";
     expect(reusable).toContain("default: 'release-pinned'");
     expect(reusable).not.toContain('aioncore_run_id:');
-    expect(reusable.match(new RegExp(conditionalToken.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'))).toHaveLength(4);
+    expect(reusable).not.toContain('KI_CORE_ACTIONS_TOKEN');
   });
 });

--- a/tests/unit/assets/kiCoreWorkflowPolicy.test.ts
+++ b/tests/unit/assets/kiCoreWorkflowPolicy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function workflow(name: string) {
+  return readFileSync(resolve(process.cwd(), '.github/workflows', name), 'utf8');
+}
+
+describe('Ki-Core workflow source policies', () => {
+  it('requires candidate run ID and full head SHA only in the manual build workflow', () => {
+    const manual = workflow('build-manual.yml');
+    expect(manual).toContain('ki_core_candidate_run_id:');
+    expect(manual).toContain('ki_core_candidate_head_sha:');
+    expect(manual).toContain('ki_core_source_policy: candidate');
+    expect(manual).toContain('contents: read');
+    expect(manual).not.toContain('pull_request:');
+  });
+
+  it('keeps official desktop and Web CLI packaging on release-pinned policy', () => {
+    const stable = workflow('build-and-release.yml');
+    const webCli = workflow('pack-web-cli.yml');
+    expect(stable).toContain('ki_core_source_policy: release-pinned');
+    expect(stable).not.toContain('ki_core_candidate_run_id:');
+    expect(webCli).toContain('AIONUI_BACKEND_SOURCE_POLICY: release-pinned');
+    expect(webCli).not.toContain('KI_CORE_ACTIONS_TOKEN');
+  });
+
+  it('exposes the candidate token to build commands only when candidate policy is selected', () => {
+    const reusable = workflow('_build-reusable.yml');
+    const conditionalToken =
+      "KI_CORE_ACTIONS_TOKEN: ${{ inputs.ki_core_source_policy == 'candidate' && secrets.KI_CORE_ACTIONS_TOKEN || '' }}";
+    expect(reusable).toContain("default: 'release-pinned'");
+    expect(reusable).not.toContain('aioncore_run_id:');
+    expect(reusable.match(new RegExp(conditionalToken.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'))).toHaveLength(4);
+  });
+});

--- a/tests/unit/assets/prepareAioncoreActionsArtifact.test.ts
+++ b/tests/unit/assets/prepareAioncoreActionsArtifact.test.ts
@@ -1,207 +1,125 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { delimiter, dirname, join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 const {
   getActionsArtifactName,
   getActionsArtifactMissingMessage,
   prepareAioncore,
 } = require('../../../packages/shared-scripts/src/prepare-aioncore');
+const { selectCandidateArtifact, validateCandidateRun } = require('../../../packages/shared-scripts/src/kiCoreRelease');
 
-const posixFakeToolchainIt = process.platform === 'win32' ? it.skip : it;
+const VALID_SHA = 'a'.repeat(40);
 
-function writeFile(filePath: string, contents = 'x') {
-  mkdirSync(dirname(filePath), { recursive: true });
-  writeFileSync(filePath, contents);
-}
-
-function writeExecutable(filePath: string, contents: string) {
-  writeFile(filePath, contents);
-  chmodSync(filePath, 0o755);
-}
-
-function createFakeToolchain(root: string, { curlFails = false } = {}) {
-  const binDir = join(root, 'bin');
-  mkdirSync(binDir, { recursive: true });
-
-  writeExecutable(
-    join(binDir, 'curl'),
-    curlFails
-      ? '#!/usr/bin/env bash\nexit 1\n'
-      : `#!/usr/bin/env bash
-set -euo pipefail
-out=''
-while [[ $# -gt 0 ]]; do
-  if [[ "$1" == '-o' ]]; then
-    shift
-    out="$1"
-  fi
-  shift || true
-done
-if [[ -z "$out" ]]; then
-  printf '{}'
-  exit 0
-fi
-mkdir -p "$(dirname "$out")"
-printf 'archive' > "$out"
-`
-  );
-  writeExecutable(join(binDir, 'wget'), '#!/usr/bin/env bash\nexit 1\n');
-  writeExecutable(
-    join(binDir, 'gh'),
-    `#!/usr/bin/env bash
-cat <<'JSON'
-{"artifacts":[{"id":123,"name":"aioncore-manual-linux-x64","archive_download_url":"https://example.invalid/artifact.zip"}]}
-JSON
-`
-  );
-  writeExecutable(
-    join(binDir, 'unzip'),
-    `#!/usr/bin/env bash
-set -euo pipefail
-out=''
-while [[ $# -gt 0 ]]; do
-  if [[ "$1" == '-d' ]]; then
-    shift
-    out="$1"
-  fi
-  shift || true
-done
-mkdir -p "$out"
-printf 'archive' > "$out/aioncore-v0.1.46-x86_64-unknown-linux-gnu.tar.gz"
-`
-  );
-  writeExecutable(
-    join(binDir, 'tar'),
-    `#!/usr/bin/env bash
-set -euo pipefail
-out=''
-while [[ $# -gt 0 ]]; do
-  if [[ "$1" == '-C' ]]; then
-    shift
-    out="$1"
-  fi
-  shift || true
-done
-mkdir -p "$out"
-cat > "$out/aioncore" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-chmod +x "$out/aioncore"
-`
-  );
-
-  return binDir;
+function validRun(overrides = {}) {
+  return {
+    conclusion: 'success',
+    event: 'workflow_dispatch',
+    head_branch: 'product/main',
+    head_sha: VALID_SHA,
+    path: '.github/workflows/build-manual.yml',
+    repository: { full_name: 'xlihub/Ki-Core' },
+    status: 'completed',
+    ...overrides,
+  };
 }
 
 afterEach(() => {
-  delete process.env.AIONUI_BACKEND_RUN_ID;
+  delete process.env.AIONUI_BACKEND_EXPECTED_SHA;
   delete process.env.AIONUI_BACKEND_LOCAL_BINARY;
-  rmSync(join(tmpdir(), 'aioncore-prepare', 'v0.1.46'), { recursive: true, force: true });
-  rmSync(join(tmpdir(), 'aioncore-prepare-actions', '123'), { recursive: true, force: true });
+  delete process.env.AIONUI_BACKEND_RUN_ID;
+  delete process.env.AIONUI_BACKEND_SOURCE_POLICY;
+  delete process.env.KI_CORE_ACTIONS_TOKEN;
 });
 
-describe('prepare-aioncore GitHub Actions artifact resolver', () => {
+describe('Ki-Core candidate artifact mapping', () => {
   it.each([
-    ['win32', 'x64', 'aioncore-manual-windows-x64'],
-    ['win32', 'arm64', 'aioncore-manual-windows-arm64'],
-    ['darwin', 'x64', 'aioncore-manual-macos-x64'],
-    ['darwin', 'arm64', 'aioncore-manual-macos-arm64'],
-    ['linux', 'x64', 'aioncore-manual-linux-x64'],
-    ['linux', 'arm64', 'aioncore-manual-linux-arm64'],
+    ['win32', 'x64', 'ki-core-candidate-windows-x64'],
+    ['win32', 'arm64', 'ki-core-candidate-windows-arm64'],
+    ['darwin', 'x64', 'ki-core-candidate-macos-x64'],
+    ['darwin', 'arm64', 'ki-core-candidate-macos-arm64'],
+    ['linux', 'x64', 'ki-core-candidate-linux-x64'],
+    ['linux', 'arm64', 'ki-core-candidate-linux-arm64'],
   ])('maps %s-%s to %s', (platform, arch, artifactName) => {
     expect(getActionsArtifactName(platform, arch)).toBe(artifactName);
   });
 
-  it('explains which AionCore manual artifact is missing for the requested platform', () => {
+  it('reports the canonical artifact required by a missing candidate', () => {
     expect(
       getActionsArtifactMissingMessage({
         runId: '27319522909',
         platform: 'win32',
         arch: 'x64',
-        expectedArtifactName: 'aioncore-manual-windows-x64',
-        availableArtifactNames: ['aioncore-manual-macos-arm64', 'aioncore-manual-linux-x64'],
+        expectedArtifactName: 'ki-core-candidate-windows-x64',
+        availableArtifactNames: ['ki-core-candidate-macos-arm64'],
       })
-    ).toBe(
-      [
-        'AionCore run 27319522909 does not contain artifact [ aioncore-manual-windows-x64 ] required for [ win32-x64 ].',
-        'Available artifacts: aioncore-manual-macos-arm64, aioncore-manual-linux-x64.',
-        'Re-run AionCore Manual Build with platform [ windows-x64 ] or all.',
-      ].join(' ')
-    );
+    ).toContain('Re-run Ki-Core Candidate Build with platform [ windows-x64 ] or all.');
+  });
+});
+
+describe('Ki-Core candidate run identity', () => {
+  it('accepts the expected repository, workflow, successful conclusion, branch, and head SHA', () => {
+    expect(() => validateCandidateRun(validRun(), { headSha: VALID_SHA })).not.toThrow();
   });
 
-  // These cases execute a temporary POSIX shell-script aioncore binary. Windows
-  // coverage for contract rejection lives in the verifier/local-bundle tests.
-  posixFakeToolchainIt('hard fails Actions artifact input when prepared managed resources lack contract', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'aionui-actions-gate-'));
-    const fakeBin = createFakeToolchain(tmp);
-    const previousPath = process.env.PATH;
-    process.env.PATH = `${fakeBin}${delimiter}${previousPath || ''}`;
+  it.each([
+    ['repository', { repository: { full_name: 'iOfficeAI/AionCore' } }],
+    ['workflow', { path: '.github/workflows/release.yml' }],
+    ['conclusion', { conclusion: 'failure' }],
+    ['head SHA', { head_sha: 'b'.repeat(40) }],
+    ['branch', { head_branch: 'feature/untrusted' }],
+  ])('rejects a candidate with the wrong %s', (_label, override) => {
+    expect(() => validateCandidateRun(validRun(override), { headSha: VALID_SHA })).toThrow(/Ki-Core candidate/);
+  });
+
+  it('rejects missing, expired, or duplicate platform artifacts', () => {
+    const expectedName = 'ki-core-candidate-linux-x64';
+    expect(() => selectCandidateArtifact([], expectedName)).toThrow(/exactly one/);
+    expect(() => selectCandidateArtifact([{ name: expectedName, expired: true }], expectedName)).toThrow(/exactly one/);
+    expect(() =>
+      selectCandidateArtifact(
+        [
+          { name: expectedName, expired: false },
+          { name: expectedName, expired: false },
+        ],
+        expectedName
+      )
+    ).toThrow(/exactly one/);
+  });
+});
+
+describe('Ki-Core candidate source policy', () => {
+  it('fails before network access when the read-only candidate token is missing', () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'ki-core-candidate-token-'));
+    process.env.AIONUI_BACKEND_SOURCE_POLICY = 'candidate';
     process.env.AIONUI_BACKEND_RUN_ID = '123';
-
+    process.env.AIONUI_BACKEND_EXPECTED_SHA = VALID_SHA;
     try {
-      expect(() =>
-        prepareAioncore({
-          projectRoot: join(tmp, 'project'),
-          platform: 'linux',
-          arch: 'x64',
-          version: 'v0.1.46',
-        })
-      ).toThrow(/managed-resources\/manifest\.json/);
+      expect(() => prepareAioncore({ projectRoot, platform: 'linux', arch: 'x64', version: null })).toThrow(
+        /KI_CORE_ACTIONS_TOKEN/
+      );
     } finally {
-      if (previousPath === undefined) delete process.env.PATH;
-      else process.env.PATH = previousPath;
-      rmSync(tmp, { recursive: true, force: true });
+      rmSync(projectRoot, { recursive: true, force: true });
     }
   });
 
-  posixFakeToolchainIt('hard fails GitHub release download input when prepared managed resources lack contract', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'aionui-download-gate-'));
-    const fakeBin = createFakeToolchain(tmp);
-    const previousPath = process.env.PATH;
-    process.env.PATH = `${fakeBin}${delimiter}${previousPath || ''}`;
-
-    try {
-      expect(() =>
-        prepareAioncore({
-          projectRoot: join(tmp, 'project'),
-          platform: 'linux',
-          arch: 'x64',
-          version: 'v0.1.46',
-        })
-      ).toThrow(/managed-resources\/manifest\.json/);
-    } finally {
-      if (previousPath === undefined) delete process.env.PATH;
-      else process.env.PATH = previousPath;
-      rmSync(tmp, { recursive: true, force: true });
-    }
-  });
-
-  posixFakeToolchainIt('hard fails local binary fallback when prepared managed resources lack contract', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'aionui-local-binary-gate-'));
-    const localBinary = join(tmp, 'aioncore');
-    writeExecutable(localBinary, '#!/usr/bin/env bash\nexit 0\n');
-    const fakeBin = createFakeToolchain(tmp, { curlFails: true });
-    const previousPath = process.env.PATH;
-    process.env.PATH = `${fakeBin}${delimiter}${previousPath || ''}`;
+  it('keeps local binary development behavior without stable provenance', () => {
+    if (process.platform === 'win32') return;
+    const root = mkdtempSync(join(tmpdir(), 'ki-core-local-binary-'));
+    const projectRoot = join(root, 'project');
+    const localBinary = join(root, 'aioncore');
+    mkdirSync(dirname(localBinary), { recursive: true });
+    writeFileSync(localBinary, '#!/usr/bin/env bash\nexit 0\n');
+    chmodSync(localBinary, 0o755);
     process.env.AIONUI_BACKEND_LOCAL_BINARY = localBinary;
 
     try {
-      expect(() =>
-        prepareAioncore({
-          projectRoot: join(tmp, 'project'),
-          platform: 'linux',
-          arch: 'x64',
-          version: 'v0.1.46',
-        })
-      ).toThrow(/managed-resources\/manifest\.json/);
+      expect(() => prepareAioncore({ projectRoot, platform: 'linux', arch: 'x64', version: 'v0.1.58' })).toThrow(
+        /managed-resources\/manifest\.json/
+      );
     } finally {
-      if (previousPath === undefined) delete process.env.PATH;
-      else process.env.PATH = previousPath;
-      rmSync(tmp, { recursive: true, force: true });
+      rmSync(root, { recursive: true, force: true });
     }
   });
 });

--- a/tests/unit/assets/prepareAioncoreActionsArtifact.test.ts
+++ b/tests/unit/assets/prepareAioncoreActionsArtifact.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { delimiter, dirname, join } from 'node:path';
+import { crc32 } from 'node:zlib';
+import * as tar from 'tar';
 
 const {
   getActionsArtifactName,
@@ -11,6 +14,152 @@ const {
 const { selectCandidateArtifact, validateCandidateRun } = require('../../../packages/shared-scripts/src/kiCoreRelease');
 
 const VALID_SHA = 'a'.repeat(40);
+
+function sha256(value: string | Buffer) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function writeStoredZip(filePath: string, entries: Array<{ name: string; content: string | Buffer }>) {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name);
+    const content = Buffer.from(entry.content);
+    const checksum = crc32(content);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(0x800, 6);
+    local.writeUInt32LE(checksum, 14);
+    local.writeUInt32LE(content.length, 18);
+    local.writeUInt32LE(content.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    localParts.push(local, name, content);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(0x0314, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(0x800, 8);
+    central.writeUInt32LE(checksum, 16);
+    central.writeUInt32LE(content.length, 20);
+    central.writeUInt32LE(content.length, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt32LE((0o100644 << 16) >>> 0, 38);
+    central.writeUInt32LE(offset, 42);
+    centralParts.push(central, name);
+    offset += local.length + name.length + content.length;
+  }
+
+  const centralSize = centralParts.reduce((total, part) => total + part.length, 0);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralSize, 12);
+  end.writeUInt32LE(offset, 16);
+  writeFileSync(filePath, Buffer.concat([...localParts, ...centralParts, end]));
+}
+
+function shellQuote(value: string) {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+async function createCandidateToolchain(root: string) {
+  const sourceDir = join(root, 'source');
+  const archiveName = 'ki-core-v0.1.0-x86_64-unknown-linux-gnu.tar.gz';
+  const archivePath = join(root, archiveName);
+  const artifactZip = join(root, 'candidate.zip');
+  const binaryPath = join(sourceDir, 'aioncore');
+  mkdirSync(sourceDir, { recursive: true });
+  writeFileSync(
+    binaryPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ -n "\${KI_CORE_ACTIONS_TOKEN:-}" ]]; then exit 91; fi
+bundle=''
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == '--bundle-out' ]]; then shift; bundle="$1"; fi
+  shift || true
+done
+mkdir -p "$bundle/node/node-v24-linux-x64/bin"
+mkdir -p "$bundle/cli/claude/2.1.215/linux-x64"
+mkdir -p "$bundle/cli/codex/0.144.6/linux-x64/vendor/x86_64-unknown-linux-musl/bin"
+mkdir -p "$bundle/cli/codex/0.144.6/linux-x64/vendor/x86_64-unknown-linux-musl/codex-path"
+: > "$bundle/node/node-v24-linux-x64/bin/node"
+: > "$bundle/cli/claude/2.1.215/linux-x64/claude"
+: > "$bundle/cli/codex/0.144.6/linux-x64/vendor/x86_64-unknown-linux-musl/bin/codex"
+: > "$bundle/cli/codex/0.144.6/linux-x64/vendor/x86_64-unknown-linux-musl/bin/codex-code-mode-host"
+: > "$bundle/cli/codex/0.144.6/linux-x64/vendor/x86_64-unknown-linux-musl/codex-path/rg"
+cat > "$bundle/manifest.json" <<'JSON'
+{"schemaVersion":2,"runtimeKey":"linux-x64","node":{"version":"24.0.0","root":"node/node-v24-linux-x64","executable":"bin/node"},"clis":[{"name":"claude","version":"2.1.215","root":"cli/claude/2.1.215/linux-x64","platformDirectory":"linux-x64","executable":"claude","requiredFiles":[],"requiredDirectories":[]},{"name":"codex","version":"0.144.6","root":"cli/codex/0.144.6/linux-x64","platformDirectory":"linux-x64","executable":"vendor/x86_64-unknown-linux-musl/bin/codex","requiredFiles":[],"requiredDirectories":["vendor/x86_64-unknown-linux-musl"]}]}
+JSON
+`
+  );
+  chmodSync(binaryPath, 0o755);
+  await tar.c({ cwd: sourceDir, file: archivePath, gzip: true }, ['aioncore']);
+
+  const archiveHash = sha256(readFileSync(archivePath));
+  const manifest = {
+    schemaVersion: 1,
+    release: {
+      type: 'candidate',
+      repository: 'xlihub/Ki-Core',
+      workflow: 'build-manual.yml',
+      runId: '123',
+      headSha: VALID_SHA,
+    },
+    product: { name: 'Ki-Core', version: '0.1.0', tag: null, releaseCommit: null },
+    upstream: { repository: 'iOfficeAI/AionCore', tag: 'v0.1.58', peeledCommit: 'b'.repeat(40) },
+    platforms: {
+      'linux-x64': {
+        target: 'x86_64-unknown-linux-gnu',
+        archive: archiveName,
+        executable: 'aioncore',
+        sha256: archiveHash,
+      },
+    },
+  };
+  const manifestText = `${JSON.stringify(manifest, null, 2)}\n`;
+  const checksumText = `${archiveHash}  ${archiveName}\n${sha256(manifestText)}  ki-core-candidate.json\n`;
+  writeStoredZip(artifactZip, [
+    { name: archiveName, content: readFileSync(archivePath) },
+    { name: 'ki-core-candidate.json', content: manifestText },
+    { name: 'ki-core-checksums.txt', content: checksumText },
+  ]);
+
+  const binDir = join(root, 'bin');
+  const curlPath = join(binDir, 'curl');
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(
+    curlPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+out=''
+url=''
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == '-o' ]]; then shift; out="$1"; else url="$1"; fi
+  shift || true
+done
+if [[ "$url" == *'/actions/runs/123/artifacts?per_page=100' ]]; then
+  printf '%s' '{"artifacts":[{"id":456,"name":"ki-core-candidate-linux-x64","expired":false,"archive_download_url":"https://example.invalid/candidate.zip"}]}'
+elif [[ "$url" == *'/actions/runs/123' ]]; then
+  printf '%s' '{"conclusion":"success","event":"workflow_dispatch","head_branch":"product/main","head_sha":"${VALID_SHA}","path":".github/workflows/build-manual.yml","repository":{"full_name":"xlihub/Ki-Core"},"status":"completed"}'
+elif [[ "$url" == 'https://example.invalid/candidate.zip' ]]; then
+  cp ${shellQuote(artifactZip)} "$out"
+else
+  exit 22
+fi
+`
+  );
+  chmodSync(curlPath, 0o755);
+  const ghPath = join(binDir, 'gh');
+  writeFileSync(ghPath, '#!/usr/bin/env bash\nexit 1\n');
+  chmodSync(ghPath, 0o755);
+  return binDir;
+}
 
 function validRun(overrides = {}) {
   return {
@@ -66,7 +215,9 @@ describe('Ki-Core candidate run identity', () => {
   it.each([
     ['repository', { repository: { full_name: 'iOfficeAI/AionCore' } }],
     ['workflow', { path: '.github/workflows/release.yml' }],
+    ['event', { event: 'push' }],
     ['conclusion', { conclusion: 'failure' }],
+    ['status', { status: 'in_progress' }],
     ['head SHA', { head_sha: 'b'.repeat(40) }],
     ['branch', { head_branch: 'feature/untrusted' }],
   ])('rejects a candidate with the wrong %s', (_label, override) => {
@@ -90,17 +241,51 @@ describe('Ki-Core candidate run identity', () => {
 });
 
 describe('Ki-Core candidate source policy', () => {
-  it('fails before network access when the read-only candidate token is missing', () => {
-    const projectRoot = mkdtempSync(join(tmpdir(), 'ki-core-candidate-token-'));
+  it('does not require a cross-repository token for the public Ki-Core repository', () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'ki-core-public-candidate-'));
     process.env.AIONUI_BACKEND_SOURCE_POLICY = 'candidate';
-    process.env.AIONUI_BACKEND_RUN_ID = '123';
+    process.env.AIONUI_BACKEND_RUN_ID = '';
     process.env.AIONUI_BACKEND_EXPECTED_SHA = VALID_SHA;
     try {
       expect(() => prepareAioncore({ projectRoot, platform: 'linux', arch: 'x64', version: null })).toThrow(
-        /KI_CORE_ACTIONS_TOKEN/
+        /run ID must be numeric/
       );
     } finally {
       rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('downloads, verifies, installs, and records a public candidate without exposing a token to the binary', async () => {
+    if (process.platform === 'win32') return;
+    const root = mkdtempSync(join(tmpdir(), 'ki-core-candidate-e2e-'));
+    const projectRoot = join(root, 'project');
+    const fakeBin = await createCandidateToolchain(root);
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${fakeBin}${delimiter}${previousPath || ''}`;
+    process.env.AIONUI_BACKEND_SOURCE_POLICY = 'candidate';
+    process.env.AIONUI_BACKEND_RUN_ID = '123';
+    process.env.AIONUI_BACKEND_EXPECTED_SHA = VALID_SHA;
+    process.env.KI_CORE_ACTIONS_TOKEN = 'must-not-reach-candidate-binary';
+
+    try {
+      const result = prepareAioncore({ projectRoot, platform: 'linux', arch: 'x64', version: null });
+      const bundleDir = join(projectRoot, 'resources', 'bundled-aioncore', 'linux-x64');
+      const manifest = JSON.parse(readFileSync(join(bundleDir, 'manifest.json'), 'utf8'));
+      expect(result).toMatchObject({ prepared: true, sourceType: 'actions-artifact' });
+      expect(readFileSync(join(bundleDir, 'aioncore'), 'utf8')).toContain('#!/usr/bin/env bash');
+      expect(manifest.source).toMatchObject({
+        policy: 'candidate',
+        repository: 'xlihub/Ki-Core',
+        runId: '123',
+        headSha: VALID_SHA,
+        artifactName: 'ki-core-candidate-linux-x64',
+      });
+      expect(manifest.kiCore).toEqual({ version: '0.1.0', tag: null, releaseCommit: null });
+      expect(manifest.aionCore.peeledCommit).toBe('b'.repeat(40));
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      rmSync(root, { recursive: true, force: true });
     }
   });
 

--- a/tests/unit/assets/prepareAioncoreActionsArtifact.test.ts
+++ b/tests/unit/assets/prepareAioncoreActionsArtifact.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { createHash } from 'node:crypto';
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, join } from 'node:path';
@@ -14,10 +13,6 @@ const {
 const { selectCandidateArtifact, validateCandidateRun } = require('../../../packages/shared-scripts/src/kiCoreRelease');
 
 const VALID_SHA = 'a'.repeat(40);
-
-function sha256(value: string | Buffer) {
-  return createHash('sha256').update(value).digest('hex');
-}
 
 function writeStoredZip(filePath: string, entries: Array<{ name: string; content: string | Buffer }>) {
   const localParts: Buffer[] = [];
@@ -101,34 +96,7 @@ JSON
   chmodSync(binaryPath, 0o755);
   await tar.c({ cwd: sourceDir, file: archivePath, gzip: true }, ['aioncore']);
 
-  const archiveHash = sha256(readFileSync(archivePath));
-  const manifest = {
-    schemaVersion: 1,
-    release: {
-      type: 'candidate',
-      repository: 'xlihub/Ki-Core',
-      workflow: 'build-manual.yml',
-      runId: '123',
-      headSha: VALID_SHA,
-    },
-    product: { name: 'Ki-Core', version: '0.1.0', tag: null, releaseCommit: null },
-    upstream: { repository: 'iOfficeAI/AionCore', tag: 'v0.1.58', peeledCommit: 'b'.repeat(40) },
-    platforms: {
-      'linux-x64': {
-        target: 'x86_64-unknown-linux-gnu',
-        archive: archiveName,
-        executable: 'aioncore',
-        sha256: archiveHash,
-      },
-    },
-  };
-  const manifestText = `${JSON.stringify(manifest, null, 2)}\n`;
-  const checksumText = `${archiveHash}  ${archiveName}\n${sha256(manifestText)}  ki-core-candidate.json\n`;
-  writeStoredZip(artifactZip, [
-    { name: archiveName, content: readFileSync(archivePath) },
-    { name: 'ki-core-candidate.json', content: manifestText },
-    { name: 'ki-core-checksums.txt', content: checksumText },
-  ]);
+  writeStoredZip(artifactZip, [{ name: archiveName, content: readFileSync(archivePath) }]);
 
   const binDir = join(root, 'bin');
   const curlPath = join(binDir, 'curl');
@@ -278,10 +246,11 @@ describe('Ki-Core candidate source policy', () => {
         repository: 'xlihub/Ki-Core',
         runId: '123',
         headSha: VALID_SHA,
+        version: '0.1.0',
         artifactName: 'ki-core-candidate-linux-x64',
       });
       expect(manifest.kiCore).toEqual({ version: '0.1.0', tag: null, releaseCommit: null });
-      expect(manifest.aionCore.peeledCommit).toBe('b'.repeat(40));
+      expect(manifest.aionCore).toEqual({ repository: null, tag: null, peeledCommit: null });
     } finally {
       if (previousPath === undefined) delete process.env.PATH;
       else process.env.PATH = previousPath;

--- a/tests/unit/assets/prepareAioncoreRelease.test.ts
+++ b/tests/unit/assets/prepareAioncoreRelease.test.ts
@@ -124,6 +124,19 @@ afterEach(() => {
 });
 
 describe('Ki-Core stable release naming and pin', () => {
+  it('loads the published Ki-Core 0.1.0 product pin', () => {
+    expect(readKiCorePin(process.cwd())).toMatchObject({
+      repository: 'xlihub/Ki-Core',
+      tag: 'ki-core-v0.1.0',
+      commit: '209e6844d39bac0762c61e198c1ba3a007f9dd2e',
+      aionCore: {
+        repository: 'iOfficeAI/AionCore',
+        tag: 'v0.1.59',
+        peeledCommit: '815e61ed9bbe942339347dc1e69ddce176cded76',
+      },
+    });
+  });
+
   it.each([
     ['darwin', 'x64', 'ki-core-v0.1.0-x86_64-apple-darwin.tar.gz'],
     ['darwin', 'arm64', 'ki-core-v0.1.0-aarch64-apple-darwin.tar.gz'],

--- a/tests/unit/assets/prepareAioncoreRelease.test.ts
+++ b/tests/unit/assets/prepareAioncoreRelease.test.ts
@@ -1,0 +1,445 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { crc32 } from 'node:zlib';
+import * as tar from 'tar';
+
+const {
+  CANONICAL_PLATFORMS,
+  createBundleProvenance,
+  extractArchiveSafely,
+  getArchiveName,
+  getCanonicalTarget,
+  getReleaseUrl,
+  readKiCorePin,
+  validateDownloadedAssets,
+} = require('../../../packages/shared-scripts/src/kiCoreRelease');
+const { validateEntries } = require('../../../packages/shared-scripts/src/safeExtractArchive');
+const { prepareAioncore } = require('../../../packages/shared-scripts/src/prepare-aioncore');
+const { resolveAioncoreVersion } = require('../../../scripts/resolveAioncoreVersion');
+
+const VERSION = '0.1.0';
+const TAG = `ki-core-v${VERSION}`;
+const RELEASE_SHA = 'a'.repeat(40);
+const UPSTREAM_SHA = 'b'.repeat(40);
+
+function sha256(value: string | Buffer) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function writeStoredZip(filePath: string, entries: Array<{ name: string; content: string | Buffer; mode?: number }>) {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name);
+    const content = Buffer.from(entry.content);
+    const checksum = crc32(content);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(0x800, 6);
+    local.writeUInt32LE(checksum, 14);
+    local.writeUInt32LE(content.length, 18);
+    local.writeUInt32LE(content.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    localParts.push(local, name, content);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(0x0314, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(0x800, 8);
+    central.writeUInt32LE(checksum, 16);
+    central.writeUInt32LE(content.length, 20);
+    central.writeUInt32LE(content.length, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt32LE(((entry.mode ?? 0o100644) << 16) >>> 0, 38);
+    central.writeUInt32LE(offset, 42);
+    centralParts.push(central, name);
+    offset += local.length + name.length + content.length;
+  }
+
+  const centralSize = centralParts.reduce((total, part) => total + part.length, 0);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralSize, 12);
+  end.writeUInt32LE(offset, 16);
+  writeFileSync(filePath, Buffer.concat([...localParts, ...centralParts, end]));
+}
+
+async function createStableFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'ki-core-stable-fixture-'));
+  const binaryDir = join(root, 'binary-source');
+  mkdirSync(binaryDir);
+  writeFileSync(join(binaryDir, 'aioncore'), 'verified-binary');
+
+  const selected = getCanonicalTarget('linux', 'x64');
+  const archiveName = getArchiveName(TAG, selected);
+  const archivePath = join(root, archiveName);
+  await tar.c({ cwd: binaryDir, file: archivePath, gzip: true }, ['aioncore']);
+  const selectedHash = sha256(readFileSync(archivePath));
+
+  const platforms = Object.fromEntries(
+    Object.entries(CANONICAL_PLATFORMS).map(([platformKey, contract], index) => {
+      const name = `${TAG}-${contract.target}${contract.extension}`;
+      return [
+        platformKey,
+        {
+          target: contract.target,
+          archive: name,
+          executable: contract.executable,
+          sha256: platformKey === selected.platformKey ? selectedHash : String(index + 1).repeat(64),
+        },
+      ];
+    })
+  );
+  const manifest = {
+    schemaVersion: 1,
+    release: {
+      type: 'stable',
+      repository: 'xlihub/Ki-Core',
+      workflow: 'release.yml',
+      runId: '12345',
+      headSha: RELEASE_SHA,
+    },
+    product: { name: 'Ki-Core', version: VERSION, tag: TAG, releaseCommit: RELEASE_SHA },
+    upstream: { repository: 'iOfficeAI/AionCore', tag: 'v0.1.58', peeledCommit: UPSTREAM_SHA },
+    platforms,
+  };
+  const manifestText = `${JSON.stringify(manifest, null, 2)}\n`;
+  const manifestPath = join(root, 'ki-core-release.json');
+  const checksumPath = join(root, 'ki-core-checksums.txt');
+  writeFileSync(manifestPath, manifestText);
+  writeFileSync(
+    checksumPath,
+    `${Object.values(platforms)
+      .map((entry) => `${entry.sha256}  ${entry.archive}`)
+      .join('\n')}\n${sha256(manifestText)}  ki-core-release.json\n`
+  );
+
+  return {
+    archivePath,
+    checksumPath,
+    manifest,
+    manifestPath,
+    pin: {
+      repository: 'xlihub/Ki-Core',
+      tag: TAG,
+      checksums: Object.fromEntries(
+        Object.entries(platforms).map(([platformKey, entry]) => [platformKey, entry.sha256])
+      ),
+    },
+    root,
+    selected,
+  };
+}
+
+async function createCandidateFixture() {
+  const fixture = await createStableFixture();
+  const selectedEntry = fixture.manifest.platforms[fixture.selected.platformKey];
+  const manifest = {
+    ...fixture.manifest,
+    release: {
+      type: 'candidate',
+      repository: 'xlihub/Ki-Core',
+      workflow: 'build-manual.yml',
+      runId: '54321',
+      headSha: RELEASE_SHA,
+    },
+    product: { name: 'Ki-Core', version: VERSION, tag: null, releaseCommit: null },
+    platforms: { [fixture.selected.platformKey]: selectedEntry },
+  };
+  const manifestText = `${JSON.stringify(manifest, null, 2)}\n`;
+  const manifestPath = join(fixture.root, 'ki-core-candidate.json');
+  writeFileSync(manifestPath, manifestText);
+  writeFileSync(
+    fixture.checksumPath,
+    `${selectedEntry.sha256}  ${selectedEntry.archive}\n${sha256(manifestText)}  ki-core-candidate.json\n`
+  );
+  return { ...fixture, manifest, manifestPath };
+}
+
+afterEach(() => {
+  delete process.env.AIONUI_BACKEND_LOCAL_BINARY;
+  delete process.env.AIONUI_BACKEND_SOURCE_POLICY;
+  delete process.env.AIONUI_BACKEND_VERSION;
+});
+
+describe('Ki-Core stable release naming', () => {
+  it.each([
+    ['darwin', 'x64', 'ki-core-v0.1.0-x86_64-apple-darwin.tar.gz'],
+    ['darwin', 'arm64', 'ki-core-v0.1.0-aarch64-apple-darwin.tar.gz'],
+    ['linux', 'x64', 'ki-core-v0.1.0-x86_64-unknown-linux-gnu.tar.gz'],
+    ['linux', 'arm64', 'ki-core-v0.1.0-aarch64-unknown-linux-gnu.tar.gz'],
+    ['win32', 'x64', 'ki-core-v0.1.0-x86_64-pc-windows-msvc.zip'],
+    ['win32', 'arm64', 'ki-core-v0.1.0-aarch64-pc-windows-msvc.zip'],
+  ])('maps %s-%s to the xlihub/Ki-Core asset %s', (platform, arch, expectedAsset) => {
+    const asset = getArchiveName(TAG, getCanonicalTarget(platform, arch));
+    expect(asset).toBe(expectedAsset);
+    expect(getReleaseUrl(TAG, asset)).toBe(
+      `https://github.com/xlihub/Ki-Core/releases/download/${TAG}/${expectedAsset}`
+    );
+  });
+
+  it('fails when the checked-in stable pin is incomplete', () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'ki-core-missing-pin-'));
+    writeFileSync(
+      join(projectRoot, 'package.json'),
+      JSON.stringify({ kiCore: { repository: 'xlihub/Ki-Core', tag: null, checksums: {} } })
+    );
+    try {
+      expect(() => readKiCorePin(projectRoot)).toThrow(/full ki-core-vX\.Y\.Z tag/);
+      expect(() => resolveAioncoreVersion(projectRoot, 'release-pinned')).toThrow(/product pin/);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('forbids local sources under release-pinned policy', () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'ki-core-release-policy-'));
+    process.env.AIONUI_BACKEND_SOURCE_POLICY = 'release-pinned';
+    process.env.AIONUI_BACKEND_LOCAL_BINARY = join(projectRoot, 'aioncore');
+    try {
+      expect(() => prepareAioncore({ projectRoot, platform: 'linux', arch: 'x64', version: TAG })).toThrow(
+        /Local Ki-Core inputs are forbidden/
+      );
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('Ki-Core stable asset verification', () => {
+  it('accepts matching manifest, checksum file, archive, and checked-in platform pins', async () => {
+    const fixture = await createStableFixture();
+    try {
+      const manifest = validateDownloadedAssets({
+        sourceType: 'stable',
+        platformKey: fixture.selected.platformKey,
+        tag: TAG,
+        manifestPath: fixture.manifestPath,
+        checksumPath: fixture.checksumPath,
+        archivePath: fixture.archivePath,
+        pinnedChecksums: fixture.pin.checksums,
+      });
+      expect(manifest.product.releaseCommit).toBe(RELEASE_SHA);
+      expect(manifest.upstream.peeledCommit).toBe(UPSTREAM_SHA);
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a duplicate checksum before extraction', async () => {
+    const fixture = await createStableFixture();
+    try {
+      const firstLine = readFileSync(fixture.checksumPath, 'utf8').split('\n')[0];
+      writeFileSync(fixture.checksumPath, `${readFileSync(fixture.checksumPath, 'utf8')}${firstLine}\n`);
+      expect(() =>
+        validateDownloadedAssets({
+          sourceType: 'stable',
+          platformKey: fixture.selected.platformKey,
+          tag: TAG,
+          manifestPath: fixture.manifestPath,
+          checksumPath: fixture.checksumPath,
+          archivePath: fixture.archivePath,
+          pinnedChecksums: fixture.pin.checksums,
+        })
+      ).toThrow(/Duplicate Ki-Core checksum/);
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a tampered archive before extraction', async () => {
+    const fixture = await createStableFixture();
+    try {
+      writeFileSync(fixture.archivePath, 'tampered');
+      expect(() =>
+        validateDownloadedAssets({
+          sourceType: 'stable',
+          platformKey: fixture.selected.platformKey,
+          tag: TAG,
+          manifestPath: fixture.manifestPath,
+          checksumPath: fixture.checksumPath,
+          archivePath: fixture.archivePath,
+          pinnedChecksums: fixture.pin.checksums,
+        })
+      ).toThrow(/archive checksum/);
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a manifest that disagrees with the checked-in platform checksum', async () => {
+    const fixture = await createStableFixture();
+    try {
+      fixture.pin.checksums['macos-x64'] = 'f'.repeat(64);
+      expect(() =>
+        validateDownloadedAssets({
+          sourceType: 'stable',
+          platformKey: fixture.selected.platformKey,
+          tag: TAG,
+          manifestPath: fixture.manifestPath,
+          checksumPath: fixture.checksumPath,
+          archivePath: fixture.archivePath,
+          pinnedChecksums: fixture.pin.checksums,
+        })
+      ).toThrow(/checked-in checksum/);
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('Ki-Core candidate asset verification', () => {
+  it('accepts artifact provenance only for the requested run and head SHA', async () => {
+    const fixture = await createCandidateFixture();
+    try {
+      const manifest = validateDownloadedAssets({
+        sourceType: 'candidate',
+        platformKey: fixture.selected.platformKey,
+        runId: '54321',
+        headSha: RELEASE_SHA,
+        manifestPath: fixture.manifestPath,
+        checksumPath: fixture.checksumPath,
+        archivePath: fixture.archivePath,
+      });
+      expect(manifest.product.tag).toBeNull();
+      expect(manifest.release.workflow).toBe('build-manual.yml');
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ['run ID', '99999', RELEASE_SHA],
+    ['head SHA', '54321', 'c'.repeat(40)],
+  ])('rejects candidate manifest %s substitution', async (expectedError, runId, headSha) => {
+    const fixture = await createCandidateFixture();
+    try {
+      expect(() =>
+        validateDownloadedAssets({
+          sourceType: 'candidate',
+          platformKey: fixture.selected.platformKey,
+          runId,
+          headSha,
+          manifestPath: fixture.manifestPath,
+          checksumPath: fixture.checksumPath,
+          archivePath: fixture.archivePath,
+        })
+      ).toThrow(expectedError);
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('Ki-Core bundle provenance', () => {
+  it('carries stable Ki-Core and AionCore identity from the verified release manifest', async () => {
+    const fixture = await createStableFixture();
+    try {
+      const provenance = createBundleProvenance(fixture.manifest, {
+        policy: 'release-pinned',
+        repository: 'xlihub/Ki-Core',
+      });
+      expect(provenance.kiCore).toEqual({ version: VERSION, tag: TAG, releaseCommit: RELEASE_SHA });
+      expect(provenance.aionCore).toEqual({
+        repository: 'iOfficeAI/AionCore',
+        tag: 'v0.1.58',
+        peeledCommit: UPSTREAM_SHA,
+      });
+      expect(provenance.version).toBe(VERSION);
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not let local sources claim stable product or upstream identity', () => {
+    const provenance = createBundleProvenance(null, { policy: 'development', type: 'local-binary' });
+    expect(provenance.kiCore).toEqual({ version: null, tag: null, releaseCommit: null });
+    expect(provenance.aionCore).toEqual({ repository: null, tag: null, peeledCommit: null });
+    expect(provenance.version).toBe('local');
+  });
+});
+
+describe('Ki-Core archive extraction safety', () => {
+  it.each([
+    ['absolute path', '/aioncore'],
+    ['parent traversal', '../aioncore'],
+    ['Windows drive path', 'C:/aioncore.exe'],
+    ['backslash traversal', '..\\aioncore.exe'],
+  ])('rejects %s entries', (_label, entryName) => {
+    expect(() =>
+      validateEntries([{ name: entryName, isFile: true, isSymbolicLink: false, isHardLink: false }], ['aioncore'])
+    ).toThrow(/Archive entry/);
+  });
+
+  it('rejects symbolic links, hard links, normalized duplicates, and unexpected content', () => {
+    expect(() =>
+      validateEntries([{ name: 'aioncore', isFile: false, isSymbolicLink: true, isHardLink: false }], ['aioncore'])
+    ).toThrow(/regular file/);
+    expect(() =>
+      validateEntries([{ name: 'aioncore', isFile: false, isSymbolicLink: false, isHardLink: true }], ['aioncore'])
+    ).toThrow(/regular file/);
+    expect(() =>
+      validateEntries(
+        [
+          { name: 'aioncore', isFile: true, isSymbolicLink: false, isHardLink: false },
+          { name: 'aioncore', isFile: true, isSymbolicLink: false, isHardLink: false },
+        ],
+        ['aioncore']
+      )
+    ).toThrow(/duplicate normalized entry/);
+    expect(() =>
+      validateEntries([{ name: 'extra', isFile: true, isSymbolicLink: false, isHardLink: false }], ['aioncore'])
+    ).toThrow(/unexpected entry/);
+  });
+
+  it('extracts one verified executable into a newly created temporary directory', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ki-core-safe-extract-'));
+    const sourceDir = join(root, 'source');
+    const archivePath = join(root, 'valid.tar.gz');
+    const outputDir = join(root, 'output');
+    mkdirSync(sourceDir);
+    writeFileSync(join(sourceDir, 'aioncore'), 'verified-binary');
+    await tar.c({ cwd: sourceDir, file: archivePath, gzip: true }, ['aioncore']);
+    try {
+      extractArchiveSafely(archivePath, outputDir, ['aioncore']);
+      expect(readFileSync(join(outputDir, 'aioncore'), 'utf8')).toBe('verified-binary');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('extracts a verified Windows executable from ZIP without invoking a system unzip command', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ki-core-safe-zip-'));
+    const archivePath = join(root, 'valid.zip');
+    const outputDir = join(root, 'output');
+    writeStoredZip(archivePath, [{ name: 'aioncore.exe', content: 'verified-windows-binary' }]);
+    try {
+      extractArchiveSafely(archivePath, outputDir, ['aioncore.exe']);
+      expect(readFileSync(join(outputDir, 'aioncore.exe'), 'utf8')).toBe('verified-windows-binary');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a ZIP symbolic link before creating the output directory', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ki-core-unsafe-zip-'));
+    const archivePath = join(root, 'link.zip');
+    const outputDir = join(root, 'output');
+    writeStoredZip(archivePath, [{ name: 'aioncore.exe', content: 'outside.exe', mode: 0o120777 }]);
+    try {
+      expect(() => extractArchiveSafely(archivePath, outputDir, ['aioncore.exe'])).toThrow(/regular file/);
+      expect(() => readFileSync(join(outputDir, 'aioncore.exe'))).toThrow();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/assets/prepareAioncoreRelease.test.ts
+++ b/tests/unit/assets/prepareAioncoreRelease.test.ts
@@ -88,85 +88,33 @@ async function createStableFixture() {
   const archivePath = join(root, archiveName);
   await tar.c({ cwd: binaryDir, file: archivePath, gzip: true }, ['aioncore']);
   const selectedHash = sha256(readFileSync(archivePath));
-
-  const platforms = Object.fromEntries(
-    Object.entries(CANONICAL_PLATFORMS).map(([platformKey, contract], index) => {
-      const name = `${TAG}-${contract.target}${contract.extension}`;
-      return [
-        platformKey,
-        {
-          target: contract.target,
-          archive: name,
-          executable: contract.executable,
-          sha256: platformKey === selected.platformKey ? selectedHash : String(index + 1).repeat(64),
-        },
-      ];
-    })
+  const checksums = Object.fromEntries(
+    Object.entries(CANONICAL_PLATFORMS).map(([platformKey, _contract], index) => [
+      platformKey,
+      platformKey === selected.platformKey ? selectedHash : String(index + 1).repeat(64),
+    ])
   );
-  const manifest = {
-    schemaVersion: 1,
-    release: {
-      type: 'stable',
-      repository: 'xlihub/Ki-Core',
-      workflow: 'release.yml',
-      runId: '12345',
-      headSha: RELEASE_SHA,
-    },
-    product: { name: 'Ki-Core', version: VERSION, tag: TAG, releaseCommit: RELEASE_SHA },
-    upstream: { repository: 'iOfficeAI/AionCore', tag: 'v0.1.58', peeledCommit: UPSTREAM_SHA },
-    platforms,
-  };
-  const manifestText = `${JSON.stringify(manifest, null, 2)}\n`;
-  const manifestPath = join(root, 'ki-core-release.json');
   const checksumPath = join(root, 'ki-core-checksums.txt');
-  writeFileSync(manifestPath, manifestText);
   writeFileSync(
     checksumPath,
-    `${Object.values(platforms)
-      .map((entry) => `${entry.sha256}  ${entry.archive}`)
-      .join('\n')}\n${sha256(manifestText)}  ki-core-release.json\n`
+    `${Object.entries(CANONICAL_PLATFORMS)
+      .map(([platformKey, contract]) => `${checksums[platformKey]}  ${TAG}-${contract.target}${contract.extension}`)
+      .join('\n')}\n`
   );
 
   return {
     archivePath,
     checksumPath,
-    manifest,
-    manifestPath,
     pin: {
       repository: 'xlihub/Ki-Core',
       tag: TAG,
-      checksums: Object.fromEntries(
-        Object.entries(platforms).map(([platformKey, entry]) => [platformKey, entry.sha256])
-      ),
+      commit: RELEASE_SHA,
+      aionCore: { repository: 'iOfficeAI/AionCore', tag: 'v0.1.59', peeledCommit: UPSTREAM_SHA },
+      checksums,
     },
     root,
     selected,
   };
-}
-
-async function createCandidateFixture() {
-  const fixture = await createStableFixture();
-  const selectedEntry = fixture.manifest.platforms[fixture.selected.platformKey];
-  const manifest = {
-    ...fixture.manifest,
-    release: {
-      type: 'candidate',
-      repository: 'xlihub/Ki-Core',
-      workflow: 'build-manual.yml',
-      runId: '54321',
-      headSha: RELEASE_SHA,
-    },
-    product: { name: 'Ki-Core', version: VERSION, tag: null, releaseCommit: null },
-    platforms: { [fixture.selected.platformKey]: selectedEntry },
-  };
-  const manifestText = `${JSON.stringify(manifest, null, 2)}\n`;
-  const manifestPath = join(fixture.root, 'ki-core-candidate.json');
-  writeFileSync(manifestPath, manifestText);
-  writeFileSync(
-    fixture.checksumPath,
-    `${selectedEntry.sha256}  ${selectedEntry.archive}\n${sha256(manifestText)}  ki-core-candidate.json\n`
-  );
-  return { ...fixture, manifest, manifestPath };
 }
 
 afterEach(() => {
@@ -175,7 +123,7 @@ afterEach(() => {
   delete process.env.AIONUI_BACKEND_VERSION;
 });
 
-describe('Ki-Core stable release naming', () => {
+describe('Ki-Core stable release naming and pin', () => {
   it.each([
     ['darwin', 'x64', 'ki-core-v0.1.0-x86_64-apple-darwin.tar.gz'],
     ['darwin', 'arm64', 'ki-core-v0.1.0-aarch64-apple-darwin.tar.gz'],
@@ -183,7 +131,7 @@ describe('Ki-Core stable release naming', () => {
     ['linux', 'arm64', 'ki-core-v0.1.0-aarch64-unknown-linux-gnu.tar.gz'],
     ['win32', 'x64', 'ki-core-v0.1.0-x86_64-pc-windows-msvc.zip'],
     ['win32', 'arm64', 'ki-core-v0.1.0-aarch64-pc-windows-msvc.zip'],
-  ])('maps %s-%s to the xlihub/Ki-Core asset %s', (platform, arch, expectedAsset) => {
+  ])('maps %s-%s to the release asset %s', (platform, arch, expectedAsset) => {
     const asset = getArchiveName(TAG, getCanonicalTarget(platform, arch));
     expect(asset).toBe(expectedAsset);
     expect(getReleaseUrl(TAG, asset)).toBe(
@@ -191,11 +139,25 @@ describe('Ki-Core stable release naming', () => {
     );
   });
 
+  it('accepts a complete product pin with explicit upstream mapping', async () => {
+    const fixture = await createStableFixture();
+    const projectRoot = mkdtempSync(join(tmpdir(), 'ki-core-complete-pin-'));
+    writeFileSync(join(projectRoot, 'package.json'), JSON.stringify({ kiCore: fixture.pin }));
+    try {
+      expect(readKiCorePin(projectRoot)).toEqual(fixture.pin);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
   it('fails when the checked-in stable pin is incomplete', () => {
     const projectRoot = mkdtempSync(join(tmpdir(), 'ki-core-missing-pin-'));
     writeFileSync(
       join(projectRoot, 'package.json'),
-      JSON.stringify({ kiCore: { repository: 'xlihub/Ki-Core', tag: null, checksums: {} } })
+      JSON.stringify({
+        kiCore: { repository: 'xlihub/Ki-Core', tag: null, commit: null, aionCore: null, checksums: {} },
+      })
     );
     try {
       expect(() => readKiCorePin(projectRoot)).toThrow(/full ki-core-vX\.Y\.Z tag/);
@@ -220,85 +182,73 @@ describe('Ki-Core stable release naming', () => {
 });
 
 describe('Ki-Core stable asset verification', () => {
-  it('accepts matching manifest, checksum file, archive, and checked-in platform pins', async () => {
+  it('accepts the exact six release checksums and the selected archive', async () => {
     const fixture = await createStableFixture();
     try {
-      const manifest = validateDownloadedAssets({
-        sourceType: 'stable',
-        platformKey: fixture.selected.platformKey,
-        tag: TAG,
-        manifestPath: fixture.manifestPath,
-        checksumPath: fixture.checksumPath,
-        archivePath: fixture.archivePath,
-        pinnedChecksums: fixture.pin.checksums,
-      });
-      expect(manifest.product.releaseCommit).toBe(RELEASE_SHA);
-      expect(manifest.upstream.peeledCommit).toBe(UPSTREAM_SHA);
-    } finally {
-      rmSync(fixture.root, { recursive: true, force: true });
-    }
-  });
-
-  it('accepts a stable manifest whose platform object uses a different key order', async () => {
-    const fixture = await createStableFixture();
-    try {
-      fixture.manifest.platforms = Object.fromEntries(Object.entries(fixture.manifest.platforms).toReversed());
-      const manifestText = `${JSON.stringify(fixture.manifest, null, 2)}\n`;
-      writeFileSync(fixture.manifestPath, manifestText);
-      writeFileSync(
-        fixture.checksumPath,
-        `${Object.values(fixture.manifest.platforms)
-          .map((entry) => `${entry.sha256}  ${entry.archive}`)
-          .join('\n')}\n${sha256(manifestText)}  ki-core-release.json\n`
-      );
-
-      expect(() =>
+      expect(
         validateDownloadedAssets({
-          sourceType: 'stable',
           platformKey: fixture.selected.platformKey,
           tag: TAG,
-          manifestPath: fixture.manifestPath,
           checksumPath: fixture.checksumPath,
           archivePath: fixture.archivePath,
           pinnedChecksums: fixture.pin.checksums,
         })
-      ).not.toThrow();
+      ).toEqual({ version: VERSION, tag: TAG });
     } finally {
       rmSync(fixture.root, { recursive: true, force: true });
     }
   });
 
-  it('rejects a duplicate checksum before extraction', async () => {
+  it('rejects duplicate or incomplete release checksums', async () => {
     const fixture = await createStableFixture();
     try {
-      const firstLine = readFileSync(fixture.checksumPath, 'utf8').split('\n')[0];
-      writeFileSync(fixture.checksumPath, `${readFileSync(fixture.checksumPath, 'utf8')}${firstLine}\n`);
+      const lines = readFileSync(fixture.checksumPath, 'utf8').trimEnd().split('\n');
+      writeFileSync(fixture.checksumPath, `${lines.join('\n')}\n${lines[0]}\n`);
       expect(() =>
         validateDownloadedAssets({
-          sourceType: 'stable',
           platformKey: fixture.selected.platformKey,
           tag: TAG,
-          manifestPath: fixture.manifestPath,
           checksumPath: fixture.checksumPath,
           archivePath: fixture.archivePath,
           pinnedChecksums: fixture.pin.checksums,
         })
       ).toThrow(/Duplicate Ki-Core checksum/);
+
+      writeFileSync(fixture.checksumPath, `${lines.slice(1).join('\n')}\n`);
+      expect(() =>
+        validateDownloadedAssets({
+          platformKey: fixture.selected.platformKey,
+          tag: TAG,
+          checksumPath: fixture.checksumPath,
+          archivePath: fixture.archivePath,
+          pinnedChecksums: fixture.pin.checksums,
+        })
+      ).toThrow(/exact six-platform asset set/);
     } finally {
       rmSync(fixture.root, { recursive: true, force: true });
     }
   });
 
-  it('rejects a tampered archive before extraction', async () => {
+  it('rejects a tampered archive and a mismatched checked-in checksum', async () => {
     const fixture = await createStableFixture();
     try {
+      fixture.pin.checksums['macos-x64'] = 'f'.repeat(64);
+      expect(() =>
+        validateDownloadedAssets({
+          platformKey: fixture.selected.platformKey,
+          tag: TAG,
+          checksumPath: fixture.checksumPath,
+          archivePath: fixture.archivePath,
+          pinnedChecksums: fixture.pin.checksums,
+        })
+      ).toThrow(/checked-in checksum/);
+
+      fixture.pin.checksums['macos-x64'] = readFileSync(fixture.checksumPath, 'utf8').split('  ')[0];
       writeFileSync(fixture.archivePath, 'tampered');
       expect(() =>
         validateDownloadedAssets({
-          sourceType: 'stable',
           platformKey: fixture.selected.platformKey,
           tag: TAG,
-          manifestPath: fixture.manifestPath,
           checksumPath: fixture.checksumPath,
           archivePath: fixture.archivePath,
           pinnedChecksums: fixture.pin.checksums,
@@ -308,85 +258,22 @@ describe('Ki-Core stable asset verification', () => {
       rmSync(fixture.root, { recursive: true, force: true });
     }
   });
-
-  it('rejects a manifest that disagrees with the checked-in platform checksum', async () => {
-    const fixture = await createStableFixture();
-    try {
-      fixture.pin.checksums['macos-x64'] = 'f'.repeat(64);
-      expect(() =>
-        validateDownloadedAssets({
-          sourceType: 'stable',
-          platformKey: fixture.selected.platformKey,
-          tag: TAG,
-          manifestPath: fixture.manifestPath,
-          checksumPath: fixture.checksumPath,
-          archivePath: fixture.archivePath,
-          pinnedChecksums: fixture.pin.checksums,
-        })
-      ).toThrow(/checked-in checksum/);
-    } finally {
-      rmSync(fixture.root, { recursive: true, force: true });
-    }
-  });
-});
-
-describe('Ki-Core candidate asset verification', () => {
-  it('accepts artifact provenance only for the requested run and head SHA', async () => {
-    const fixture = await createCandidateFixture();
-    try {
-      const manifest = validateDownloadedAssets({
-        sourceType: 'candidate',
-        platformKey: fixture.selected.platformKey,
-        runId: '54321',
-        headSha: RELEASE_SHA,
-        manifestPath: fixture.manifestPath,
-        checksumPath: fixture.checksumPath,
-        archivePath: fixture.archivePath,
-      });
-      expect(manifest.product.tag).toBeNull();
-      expect(manifest.release.workflow).toBe('build-manual.yml');
-    } finally {
-      rmSync(fixture.root, { recursive: true, force: true });
-    }
-  });
-
-  it.each([
-    ['run ID', '99999', RELEASE_SHA],
-    ['head SHA', '54321', 'c'.repeat(40)],
-  ])('rejects candidate manifest %s substitution', async (expectedError, runId, headSha) => {
-    const fixture = await createCandidateFixture();
-    try {
-      expect(() =>
-        validateDownloadedAssets({
-          sourceType: 'candidate',
-          platformKey: fixture.selected.platformKey,
-          runId,
-          headSha,
-          manifestPath: fixture.manifestPath,
-          checksumPath: fixture.checksumPath,
-          archivePath: fixture.archivePath,
-        })
-      ).toThrow(expectedError);
-    } finally {
-      rmSync(fixture.root, { recursive: true, force: true });
-    }
-  });
 });
 
 describe('Ki-Core bundle provenance', () => {
-  it('carries stable Ki-Core and AionCore identity from the verified release manifest', async () => {
+  it('records stable Ki-Core and AionCore identity from the checked-in pin', async () => {
     const fixture = await createStableFixture();
+    const identity = {
+      product: { version: VERSION, tag: TAG, releaseCommit: RELEASE_SHA },
+      upstream: fixture.pin.aionCore,
+    };
     try {
-      const provenance = createBundleProvenance(fixture.manifest, {
+      const provenance = createBundleProvenance(identity, {
         policy: 'release-pinned',
         repository: 'xlihub/Ki-Core',
       });
       expect(provenance.kiCore).toEqual({ version: VERSION, tag: TAG, releaseCommit: RELEASE_SHA });
-      expect(provenance.aionCore).toEqual({
-        repository: 'iOfficeAI/AionCore',
-        tag: 'v0.1.58',
-        peeledCommit: UPSTREAM_SHA,
-      });
+      expect(provenance.aionCore).toEqual(fixture.pin.aionCore);
       expect(provenance.version).toBe(VERSION);
     } finally {
       rmSync(fixture.root, { recursive: true, force: true });
@@ -413,12 +300,9 @@ describe('Ki-Core archive extraction safety', () => {
     ).toThrow(/Archive entry/);
   });
 
-  it('rejects symbolic links, hard links, normalized duplicates, and unexpected content', () => {
+  it('rejects symbolic links, normalized duplicates, and unexpected content', () => {
     expect(() =>
       validateEntries([{ name: 'aioncore', isFile: false, isSymbolicLink: true, isHardLink: false }], ['aioncore'])
-    ).toThrow(/regular file/);
-    expect(() =>
-      validateEntries([{ name: 'aioncore', isFile: false, isSymbolicLink: false, isHardLink: true }], ['aioncore'])
     ).toThrow(/regular file/);
     expect(() =>
       validateEntries(
@@ -434,7 +318,7 @@ describe('Ki-Core archive extraction safety', () => {
     ).toThrow(/unexpected entry/);
   });
 
-  it('extracts one verified executable into a newly created temporary directory', async () => {
+  it('extracts one verified executable from tar.gz', async () => {
     const root = mkdtempSync(join(tmpdir(), 'ki-core-safe-extract-'));
     const sourceDir = join(root, 'source');
     const archivePath = join(root, 'valid.tar.gz');
@@ -450,7 +334,7 @@ describe('Ki-Core archive extraction safety', () => {
     }
   });
 
-  it('extracts a verified Windows executable from ZIP without invoking a system unzip command', () => {
+  it('extracts one verified Windows executable from ZIP', () => {
     const root = mkdtempSync(join(tmpdir(), 'ki-core-safe-zip-'));
     const archivePath = join(root, 'valid.zip');
     const outputDir = join(root, 'output');
@@ -463,27 +347,19 @@ describe('Ki-Core archive extraction safety', () => {
     }
   });
 
-  it('rejects a ZIP symbolic link before creating the output directory', () => {
+  it('rejects symbolic-link and encrypted ZIP entries', () => {
     const root = mkdtempSync(join(tmpdir(), 'ki-core-unsafe-zip-'));
-    const archivePath = join(root, 'link.zip');
-    const outputDir = join(root, 'output');
-    writeStoredZip(archivePath, [{ name: 'aioncore.exe', content: 'outside.exe', mode: 0o120777 }]);
+    const linkArchive = join(root, 'link.zip');
+    const encryptedArchive = join(root, 'encrypted.zip');
+    writeStoredZip(linkArchive, [{ name: 'aioncore.exe', content: 'outside.exe', mode: 0o120777 }]);
+    writeStoredZip(encryptedArchive, [{ name: 'aioncore.exe', content: 'encrypted', encrypted: true }]);
     try {
-      expect(() => extractArchiveSafely(archivePath, outputDir, ['aioncore.exe'])).toThrow(/regular file/);
-      expect(() => readFileSync(join(outputDir, 'aioncore.exe'))).toThrow();
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it('rejects an encrypted ZIP entry before creating the output directory', () => {
-    const root = mkdtempSync(join(tmpdir(), 'ki-core-encrypted-zip-'));
-    const archivePath = join(root, 'encrypted.zip');
-    const outputDir = join(root, 'output');
-    writeStoredZip(archivePath, [{ name: 'aioncore.exe', content: 'encrypted', encrypted: true }]);
-    try {
-      expect(() => extractArchiveSafely(archivePath, outputDir, ['aioncore.exe'])).toThrow(/Encrypted/);
-      expect(() => readFileSync(join(outputDir, 'aioncore.exe'))).toThrow();
+      expect(() => extractArchiveSafely(linkArchive, join(root, 'link-output'), ['aioncore.exe'])).toThrow(
+        /regular file/
+      );
+      expect(() => extractArchiveSafely(encryptedArchive, join(root, 'encrypted-output'), ['aioncore.exe'])).toThrow(
+        /Encrypted/
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/unit/assets/prepareAioncoreRelease.test.ts
+++ b/tests/unit/assets/prepareAioncoreRelease.test.ts
@@ -29,7 +29,10 @@ function sha256(value: string | Buffer) {
   return createHash('sha256').update(value).digest('hex');
 }
 
-function writeStoredZip(filePath: string, entries: Array<{ name: string; content: string | Buffer; mode?: number }>) {
+function writeStoredZip(
+  filePath: string,
+  entries: Array<{ name: string; content: string | Buffer; encrypted?: boolean; mode?: number }>
+) {
   const localParts: Buffer[] = [];
   const centralParts: Buffer[] = [];
   let offset = 0;
@@ -37,30 +40,31 @@ function writeStoredZip(filePath: string, entries: Array<{ name: string; content
   for (const entry of entries) {
     const name = Buffer.from(entry.name);
     const content = Buffer.from(entry.content);
+    const payload = entry.encrypted ? Buffer.concat([Buffer.alloc(12), content]) : content;
     const checksum = crc32(content);
     const local = Buffer.alloc(30);
     local.writeUInt32LE(0x04034b50, 0);
     local.writeUInt16LE(20, 4);
-    local.writeUInt16LE(0x800, 6);
+    local.writeUInt16LE(entry.encrypted ? 0x801 : 0x800, 6);
     local.writeUInt32LE(checksum, 14);
-    local.writeUInt32LE(content.length, 18);
+    local.writeUInt32LE(payload.length, 18);
     local.writeUInt32LE(content.length, 22);
     local.writeUInt16LE(name.length, 26);
-    localParts.push(local, name, content);
+    localParts.push(local, name, payload);
 
     const central = Buffer.alloc(46);
     central.writeUInt32LE(0x02014b50, 0);
     central.writeUInt16LE(0x0314, 4);
     central.writeUInt16LE(20, 6);
-    central.writeUInt16LE(0x800, 8);
+    central.writeUInt16LE(entry.encrypted ? 0x801 : 0x800, 8);
     central.writeUInt32LE(checksum, 16);
-    central.writeUInt32LE(content.length, 20);
+    central.writeUInt32LE(payload.length, 20);
     central.writeUInt32LE(content.length, 24);
     central.writeUInt16LE(name.length, 28);
     central.writeUInt32LE(((entry.mode ?? 0o100644) << 16) >>> 0, 38);
     central.writeUInt32LE(offset, 42);
     centralParts.push(central, name);
-    offset += local.length + name.length + content.length;
+    offset += local.length + name.length + payload.length;
   }
 
   const centralSize = centralParts.reduce((total, part) => total + part.length, 0);
@@ -230,6 +234,35 @@ describe('Ki-Core stable asset verification', () => {
       });
       expect(manifest.product.releaseCommit).toBe(RELEASE_SHA);
       expect(manifest.upstream.peeledCommit).toBe(UPSTREAM_SHA);
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts a stable manifest whose platform object uses a different key order', async () => {
+    const fixture = await createStableFixture();
+    try {
+      fixture.manifest.platforms = Object.fromEntries(Object.entries(fixture.manifest.platforms).toReversed());
+      const manifestText = `${JSON.stringify(fixture.manifest, null, 2)}\n`;
+      writeFileSync(fixture.manifestPath, manifestText);
+      writeFileSync(
+        fixture.checksumPath,
+        `${Object.values(fixture.manifest.platforms)
+          .map((entry) => `${entry.sha256}  ${entry.archive}`)
+          .join('\n')}\n${sha256(manifestText)}  ki-core-release.json\n`
+      );
+
+      expect(() =>
+        validateDownloadedAssets({
+          sourceType: 'stable',
+          platformKey: fixture.selected.platformKey,
+          tag: TAG,
+          manifestPath: fixture.manifestPath,
+          checksumPath: fixture.checksumPath,
+          archivePath: fixture.archivePath,
+          pinnedChecksums: fixture.pin.checksums,
+        })
+      ).not.toThrow();
     } finally {
       rmSync(fixture.root, { recursive: true, force: true });
     }
@@ -437,6 +470,19 @@ describe('Ki-Core archive extraction safety', () => {
     writeStoredZip(archivePath, [{ name: 'aioncore.exe', content: 'outside.exe', mode: 0o120777 }]);
     try {
       expect(() => extractArchiveSafely(archivePath, outputDir, ['aioncore.exe'])).toThrow(/regular file/);
+      expect(() => readFileSync(join(outputDir, 'aioncore.exe'))).toThrow();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an encrypted ZIP entry before creating the output directory', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ki-core-encrypted-zip-'));
+    const archivePath = join(root, 'encrypted.zip');
+    const outputDir = join(root, 'output');
+    writeStoredZip(archivePath, [{ name: 'aioncore.exe', content: 'encrypted', encrypted: true }]);
+    try {
+      expect(() => extractArchiveSafely(archivePath, outputDir, ['aioncore.exe'])).toThrow(/Encrypted/);
       expect(() => readFileSync(join(outputDir, 'aioncore.exe'))).toThrow();
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/tests/unit/bootstrap/backendInstallDiagnostics.test.ts
+++ b/tests/unit/bootstrap/backendInstallDiagnostics.test.ts
@@ -65,6 +65,66 @@ describe('collectBackendInstallDiagnostics', () => {
       runtimeKey: 'win32-x64',
     });
   });
+
+  it('exposes verified Ki-Core and AionCore provenance for support reports', () => {
+    const manifestPath = '/opt/Ki-Buddy/resources/bundled-aioncore/linux-x64/manifest.json';
+    const diagnostics = collectBackendInstallDiagnostics(
+      {
+        runtimeKey: 'linux-x64',
+        binaryName: 'aioncore',
+        resourcesPath: '/opt/Ki-Buddy/resources',
+      },
+      {
+        platform: 'linux',
+        readFile: (filePath) =>
+          filePath === manifestPath
+            ? JSON.stringify({
+                schemaVersion: 2,
+                version: '0.1.0',
+                generatedAt: '2026-08-05T00:00:00.000Z',
+                sourceType: 'actions-artifact',
+                files: ['aioncore', 'managed-resources/'],
+                kiCore: { version: '0.1.0', tag: null, releaseCommit: null },
+                aionCore: {
+                  repository: 'iOfficeAI/AionCore',
+                  tag: 'v0.1.58',
+                  peeledCommit: 'b'.repeat(40),
+                },
+                source: {
+                  policy: 'candidate',
+                  type: 'actions-artifact',
+                  repository: 'xlihub/Ki-Core',
+                  workflow: 'build-manual.yml',
+                  runId: '12345',
+                  headSha: 'a'.repeat(40),
+                  artifactName: 'ki-core-candidate-linux-x64',
+                },
+              })
+            : undefined,
+        stat: (filePath) => (filePath === manifestPath ? { mtimeMs: 1, size: 2 } : undefined),
+      }
+    );
+
+    expect(diagnostics.kiCoreVersion).toBe('0.1.0');
+    expect(diagnostics.aionCoreTag).toBe('v0.1.58');
+    expect(diagnostics.aionCorePeeledCommit).toBe('b'.repeat(40));
+    expect(diagnostics.manifestSourceRunId).toBe('12345');
+    expect(diagnostics.manifestSourceHeadSha).toBe('a'.repeat(40));
+  });
+
+  it('reports malformed provenance without crashing startup diagnostics', () => {
+    const diagnostics = collectBackendInstallDiagnostics(
+      { runtimeKey: 'linux-x64', resourcesPath: '/resources' },
+      {
+        platform: 'linux',
+        readFile: () => JSON.stringify({ schemaVersion: 2, kiCore: 'invalid', aionCore: null, source: [] }),
+        stat: () => ({ mtimeMs: 1, size: 2 }),
+      }
+    );
+
+    expect(diagnostics.manifestValidationError).toBe('Bundle manifest provenance objects are malformed');
+    expect(diagnostics.manifestParseError).toBeUndefined();
+  });
 });
 
 describe('appendAutoUpdateDiagnosticEvent', () => {


### PR DESCRIPTION
## Description

完成 Ki-Buddy 对 Ki-Core 正式版本的受验证消费，并保留未来联调未发布 Ki-Core 的 candidate 路径。

主要内容：

- 固定 Ki-Core `ki-core-v0.1.0`、tag commit `209e6844d39bac0762c61e198c1ba3a007f9dd2e`。
- 记录对应 AionCore `v0.1.59`、peeled commit `815e61ed9bbe942339347dc1e69ddce176cded76`。
- 固定六个平台 Release archive 的 SHA-256，并将正式桌面包和 Web CLI 限制为 `release-pinned`。
- 手工构建默认验证已发布版本，也可显式选择 `candidate`；candidate 模式必须提供合法的 workflow run ID 和完整 commit SHA。
- Release checksums、仓库内固定 checksum、archive 内容与路径安全均在解压前验证。
- bundle manifest 和安装诊断记录 Ki-Core、AionCore 与实际来源。
- 正式 workflow 固定 npm 官方 registry，避免 runner 用户级 `.npmrc` 改变 managed CLI 平台包来源。

本地已经使用公开的 macOS ARM64 Release 资产完整执行 `release-pinned` 流程，包括 checksum 比对、安全解压、Ki-Core 启动、managed resources 生成和 manifest 验证。六平台打包验证将在本 Draft PR 上通过 GitHub Actions 完成。

## Related Issues

- Closes #1
- Ki-Core Release：https://github.com/xlihub/Ki-Core/releases/tag/ki-core-v0.1.0
- AionCore 上游版本：https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.59

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [x] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] 本 PR 只实现 Ki-Core 的受验证消费与来源记录，不包含 Ki-Buddy 版本体系或产品功能改造
- [x] PR 标题符合 Conventional Commit 格式：`<type>(<scope>): <subject>`（英文）

## Local Checks (Rule 3)

- [x] `bunx oxfmt <changed files>` + `bun run format:check` — 通过
- [x] `bun run lint` — 0 error；仓库现有 874 条 warning
- [x] `bunx tsc --noEmit` — 通过
- [x] `bun run test` — 424 个文件通过、1 个跳过；3662 个测试通过、5 个跳过
- [x] `bun run test:coverage` — 通过；当前全仓 lines 50.72%，未配置强制阈值
- [x] `bun run i18n:types` + `node scripts/check-i18n.js` — 通过；本 PR 不修改 i18n 或 UI 文本
- [x] 定向测试 — 5 个文件、62 个测试通过

## Runtime Verification

- [x] macOS ARM64：真实下载并验证 Ki-Core `0.1.0`，成功生成 Node `24.11.0`、Claude `2.1.215`、Codex `0.144.6` managed resources
- [ ] Windows：等待 Draft PR 六平台构建
- [ ] Linux：等待 Draft PR 六平台构建
- [ ] Maintainer final review

## Screenshots

不适用。本 PR 不包含 UI 改动。

## Additional Context

- `bun.lock` 相对 `product/main` 仅增加 `tar` 根依赖条目，没有大范围锁文件重写。
- `aioncoreVersion: v0.1.58` 保留为 AionUi v2.1.49 的 legacy development fallback；正式构建使用 `package.json.kiCore` 中固定的 Ki-Core/AionCore 映射。
- Draft PR 在六个平台正式消费构建全部完成前不应转为 Ready 或合并。
