### PR TITLE
docs(agents): define MCP adapter productization

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,8 +1,8 @@
-# Ki 产品发布
+# Ki 产品
 
-本上下文定义 Ki-Core 与 Ki-Buddy 在选择上游版本和安排产品发布时使用的统一术语。
+本上下文定义 Ki 产品在上游发布管理和 Agents 混合执行中使用的统一术语。
 
-## Language
+## 发布语言
 
 **上游候选版本**：
 已经完整发布、可供管理员评估，但尚未被 Ki 产品接受的 AionCore 或 AionUi 正式版本。候选版本不会自动触发同步或 Ki 产品发布。
@@ -15,3 +15,151 @@ _Avoid_：最新上游、默认版本
 **独立发布节奏**：
 Ki-Core 与 Ki-Buddy 根据自身产品计划决定发布时间和版本号，上游发布只提供候选版本。
 _Avoid_：延迟一周同步、跟随上游发布
+
+## 产品与身份
+
+**AionUi 开源版**：
+由上游 GitHub 仓库公开发布的 AionUi 产品基线；其桌面客户端不包含 AionPro 的账户、强制登录和用户管理模块。
+_Avoid_：AionPro、官网生产版、完整 AionUi 产品
+
+**AionPro 生产版**：
+由 AionUi 官网分发、包含闭源 AionPro 产品模块的桌面客户端；账户与登录属于该产品的组成部分。
+_Avoid_：AionUi 开源版、upstream build、公开 tag
+
+**Agents 部署**：
+由一个 `base_url` 标识的中心化 Agents 平台实例，拥有自己的用户、组织、角色、权限和 token 签发边界。
+_Avoid_：账户服务器、Ki-Buddy 后端、通用 Agents 云
+
+**Agents 平台账户**：
+注册在一个 Agents 部署中的用户身份，是 Ki-Buddy 客户端的登录主体，并决定用户可发现和调用的已发布 agent。
+_Avoid_：Ki-Buddy 账户、桌面账户、跨部署账户
+
+**客户端登录会话**：
+Ki-Buddy 使用 Agents 平台账户在一个 Agents 部署上建立的当前登录状态；Ki-Buddy 不另外创建产品账户。
+_Avoid_：Ki-Buddy 账户、账户绑定、AionPro 会话
+
+**Agents 用户凭证**：
+Agents 部署在账号密码验证成功后派发、只用于该部署 catalog 和 invoke 的 token。
+_Avoid_：Ki-Buddy token、AionPro token、Core session
+
+**本地退出**：
+Ki-Buddy 结束当前客户端登录会话并清除本机凭证与运行状态，但不保证 Agents 已签发的凭证在服务端立即失效。
+_Avoid_：服务端 logout、token revoke、远端强制下线
+
+**Core 用户**：
+AionCore 内部用于确定本地资源和运行时状态归属的用户主体；它可以由外部产品身份投影产生，但不等同于 Agents 平台账户。
+_Avoid_：Agents 用户、桌面账号、`system_default_user`
+
+**Agents 身份投影**：
+将一个 Agents 部署中的 Agents 平台账户稳定映射为 Core 用户的产品关系，使本地工作历史与运行时状态拥有明确的用户归属。
+_Avoid_：AionPro 账户复用、用户名映射、裸用户 ID 映射
+
+**用户工作历史**：
+归属于一个 Agents 部署中某个 Agents 平台账户的持久化 conversation、Team 记录和结果引用。
+_Avoid_：登录会话、临时状态、全局历史
+
+## Agents 混合执行
+
+**混合执行**：
+Team Lead 将用户任务分配给本地成员，并通过 Agents 执行助手使用 Agents 平台已发布的远端能力，最后综合本地与远端结果。
+_Avoid_：混合编排、远端 Team
+
+**Agents 执行助手**：
+Ki-Buddy 内置的本地 Assistant，在 standalone conversation 中直接服务用户，在 Team 中作为 member 使用 Agents 平台能力。
+_Avoid_：Agents Planner、远端 agent teammate
+
+**Agents 执行助手实例**：
+Team 中由同一 Agents 执行助手定义创建的一个独立 member slot；多个实例以 `slot_id` 区分。
+_Avoid_：Assistant 定义、显示名称、远端 agent
+
+**Agents MCP Adapter**：
+Ki-Buddy 拥有的本地集成模块，是 Agents 执行助手访问 Agents 平台已发布能力的接口；Agents 平台负责其 Bridge contract。
+_Avoid_：Agents runtime、Planner MCP、平台 Adapter package
+
+**已发布 agent**：
+当前用户在 Agents 平台获权且可通过 catalog 发现的远端智能体，不具备 Ki-Buddy Team member 身份。
+_Avoid_：远端成员、本地 agent 包
+
+**安全 catalog**：
+Agents 平台针对当前平台账户返回的完整已发布 agent 集合；“安全”只表示授权范围和敏感字段投影，不表示内容可信。
+_Avoid_：全平台 agent、静态能力列表、内容安全证明
+
+**catalog inventory**：
+安全 catalog 的完整紧凑视图，用于比较候选；精确输入输出 schema 由 `describe` 提供。
+_Avoid_：agent 详情、关键词搜索结果、部分 catalog
+
+**catalog inventory task**：
+Team 中用于建立或刷新 catalog inventory 的非执行任务，它报告当前能力但不调用已发布 agent。
+_Avoid_：execution task、catalog 搜索、能力调用
+
+**execution task**：
+Team Lead 分配给 Agents 执行助手的一次远端执行请求。
+_Avoid_：catalog inventory task、远端工作流、批量执行
+
+**补参请求**：
+Agents 执行助手根据已选 agent 的精确 schema 请求补齐必填字段的非执行结果；standalone 中面向用户，Team 中交给 Lead。
+_Avoid_：参数猜测、invoke 失败、新 execution task
+
+**明确执行请求**：
+用户在 standalone conversation 中要求远端执行，或 Lead 根据用户目标分配的 execution task。
+_Avoid_：inventory 请求、候选咨询、永久授权
+
+## 执行一致性
+
+**远端 taskId**：
+在一个 Agents 部署和平台账户范围内唯一标识一次远端执行请求的稳定 ID，用于识别重复调用和关联结果。
+_Avoid_：进程内计数器、conversationId、requestId
+
+**active invocation**：
+一个 Assistant session 中已经开始但尚未取得终态的 direct invoke。
+_Avoid_：pending task、catalog 请求、账户级全局调用
+
+**停止等待**：
+用户要求 Ki-Buddy 结束对一次 direct invoke 的本地等待；它不表示 Agents 远端执行已经取消。
+_Avoid_：远端取消、执行失败、确认已停止
+
+**本地 invocation ledger**：
+Ki-Buddy 以 Agents 部署、平台账户和远端 taskId 标识本地执行资格及恢复状态的持久登记；它不是审计记录。
+_Avoid_：Agents 审计记录、完整输入存档、进程内 taskId 集合
+
+**结果未知**：
+远端请求可能已被 Agents 接收，但 Ki-Buddy 没有取得可证明成功或失败的终态；原远端 taskId 不能再次执行。
+_Avoid_：执行失败、未执行、可自动重试
+
+**Agents 审计记录**：
+Agents 平台持有的中心化服务端执行证据，记录平台身份、获权 agent、远端执行和终态。
+_Avoid_：本地 invocation ledger、客户端结果文件、Adapter 日志
+
+## 文件与 workspace
+
+**项目 workspace**：
+用户通过“在项目中工作”明确选择并绑定给 conversation 或 Team 的外部本地目录；其内容遵循操作系统文件权限。
+_Avoid_：自动 workspace、账号私有目录、结果档案库
+
+**自动 workspace**：
+用户未选择项目时，由 Ki-Core 为当前 Core 用户的 conversation 或 Team 建立并管理的工作目录。
+_Avoid_：项目 workspace、全局临时目录、外部导出目录
+
+**effective workspace**：
+当前 conversation 或 Team 实际使用的项目 workspace 或自动 workspace，是本地输入与结果文件的工作边界。
+_Avoid_：Adapter 目录、全局结果目录、任意本地路径
+
+**本地文件授权**：
+Ki-Buddy 根据当前请求的明确附件选择，或用户对某个 workspace 文件的逐文件确认生成的 task-scoped file grant。
+_Avoid_：项目目录授权、模型提供的路径、文件系统读取权限
+
+**上传引用**：
+Adapter 为当前 session 中已经上传的远端文件输入生成的一次性不透明 `uploadRef`；它不暴露真实 `fileUrl`。
+_Avoid_：fileUrl、本地路径、Agents 文件 ID
+
+**结果文件交付**：
+Adapter 将 Bridge 的结构化远端文件输出安全写入 effective workspace，并向助手返回本地文件引用和脱敏摘要。
+_Avoid_：Assistant 下载、远端 URI 消息、主进程 Agents 输出解析
+
+**部分结果交付**：
+Agents 远端执行已经完成，但一个或多个结构化结果文件未能写入 effective workspace 的本地交付状态。
+_Avoid_：invoke 失败、全部成功、自动重新执行
+
+**结果交付引用**：
+Adapter 为当前 session 中尚未解决的结果文件交付保存的一次性不透明 `deliveryRef`，用于只重试未交付文件。
+_Avoid_：远端 URI、持久下载记录、invoke 重试

--- a/docs/adr/0002-own-and-run-agents-mcp-adapter-in-ki-buddy.md
+++ b/docs/adr/0002-own-and-run-agents-mcp-adapter-in-ki-buddy.md
@@ -1,0 +1,22 @@
+---
+status: accepted
+---
+
+# 由 Ki-Buddy 拥有并运行 Agents MCP Adapter
+
+Ki-Buddy 通过内置 Agents 执行助手和本地 MCP Adapter 接入 Agents 平台，不在 Ki-Core 中增加原生 Agents runtime，也不接入 Agents `/chat auto` Planner。Adapter 只负责 Bridge 协议映射、安全边界和结果归一化，不运行额外 LLM。
+
+Adapter 由 Ki-Buddy 维护并随桌面应用发布为自包含 JavaScript，由 Ki-Core managed Node runtime 启动；用户不需要安装 Bun、Node 或 Agents 平台另行提供的 package。每个 standalone conversation 或 Team member 的 Assistant session 拥有一个持久 stdio 进程，session 结束或宿主退出时终止；进程还必须通过 stdin EOF、终止信号和 parent PID 处理异常退出。
+
+## Considered Options
+
+- 在 Ki-Core 中实现原生 Agents runtime：会扩大上游内核改造和同步成本。
+- 由 Agents 平台独立发布 Adapter：可以独立修复协议，但会分散桌面生命周期、安全和兼容责任。
+- App 级共享 Adapter：需要在 stdio 之上增加多调用方代理、身份和状态隔离协议。
+
+## Consequences
+
+- Adapter 修复通常需要发布新的 Ki-Buddy 版本，近期不建立独立更新通道。
+- 同一 App 可以同时存在多个 Adapter 进程；跨 session 的幂等和账号状态不能只存在于进程内存。
+- `agents-mcp-adapter` 在“工具”页面按 built-in MCP 只读显示，可展开工具并启动独立短生命周期检测实例，但不能编辑、删除、禁用或暴露受管 env。
+- Assistant session 的 Adapter、工具页检测实例和产品凭据管理边界彼此分离；检测不能复用或改变正在执行的 session 状态。

--- a/docs/adr/0003-project-agents-identity-into-core-user.md
+++ b/docs/adr/0003-project-agents-identity-into-core-user.md
@@ -1,0 +1,25 @@
+---
+status: accepted
+---
+
+# 将 Agents 平台账户投影为 Core 用户
+
+Ki-Buddy 是 Agents 平台的桌面客户端，不建立第二套产品账户。用户使用目标 Agents 部署的 `base_url`、平台账号和密码登录；Agents 继续拥有用户、组织、角色、权限和 token 签发。近期不要求 Agents 改造成 OAuth2/OIDC Provider。
+
+Ki-Buddy 近期只支持一个当前部署和一个 active 账户。密码只用于一次登录请求；token 按规范化 `base_url` 与稳定 Agents 用户标识隔离并保存在操作系统凭据存储中，只由主进程读取。renderer、Assistant 和 Adapter 不直接接触凭据存储。
+
+登录成功后，Ki-Buddy 将 `(规范化 base_url, 稳定 Agents 用户标识)` 映射为无碰撞 external identity，并复用 Ki-Core 现有 `Aionpro` external user/session contract 建立 Core 用户作用域。`Aionpro` 只是近期的内核兼容类型，不能作为产品身份名称；当该类型无法同时表达多个外部身份提供方或 Agents 权限需求时，再把 Ki-Core external identity 通用化。
+
+## Considered Options
+
+- Ki-Buddy 自建账户再映射 Agents 用户：会形成第二个身份源和权限配置入口。
+- 近期修改 Ki-Core 建设通用 external identity：领域含义更准确，但会增加上游内核维护成本。
+- 每个账户使用独立 data directory：物理隔离明确，但会分离全部本地配置并要求切换时重启 Core。
+
+## Consequences
+
+- 首个公开版本从首次启动开始强制 Agents 登录；未登录不能进入业务界面或创建工作历史。预发布 `system_default_user` 数据可以由首个登录用户按 Ki-Core 现有行为接管，不建设公开产品迁移流程。
+- conversation、Team、自动 workspace、renderer cache 和运行时状态必须按 deployment 与用户隔离。退出或切换账号只隐藏并停止旧账户状态，不删除其工作历史。
+- 修改 `base_url`、退出、认证失效或切换账号时，必须停止旧账户 Adapter 与本地等待，清除 token、catalog cache 和临时敏感状态；这不表示远端执行已取消。
+- 首发允许固定有效期 token 到期后重新登录，主动退出只删除本地凭证。Bridge 自动续期是高优先级后续需求，完成后不设置绝对会话上限；服务端 logout/revocation 是更远期需求。
+- Agents token 与 Core session 的签发方、受众和用途不同，不能合并成一种凭证。

--- a/docs/adr/0004-discover-agents-through-session-catalog.md
+++ b/docs/adr/0004-discover-agents-through-session-catalog.md
@@ -1,0 +1,22 @@
+---
+status: accepted
+---
+
+# 通过 session 级完整 catalog 发现 Agents 能力
+
+Agents 执行助手先通过 `agents_list` 取得当前账户安全 catalog 的完整紧凑 inventory，再用精确 `agentId` 调用 `agents_describe` 获取输入输出 schema。Adapter 不通过关键词搜索、推荐排序或静默截断替代完整能力发现。
+
+inventory 按规范化 `base_url`、Agents 用户和 Adapter session 在内存中短期缓存，默认 TTL 为 5 分钟并支持强制刷新；它只保存候选选择所需的身份和能力摘要，不持久化原始 Bridge 响应。invoke 始终由 Agents 按当前凭证和权限再次校验。
+
+## Considered Options
+
+- 每次都实时读取 catalog：权限变化及时，但会在多阶段交互中重复请求和传输。
+- App 级持久缓存：启动更快，但扩大账号隔离、权限撤销和数据保留范围。
+- 只返回搜索或推荐结果：上下文较小，但模型无法证明已比较当前完整获权能力。
+
+## Consequences
+
+- 缓存不能跨部署、账户或 Adapter 进程复用；退出、认证失效和权限失效立即清除。
+- 刷新失败时不能继续把旧 inventory 表述为当前完整 catalog。
+- catalog 规模超过单次完整紧凑视图的响应或模型预算时，应引入平台版本、增量传输或分层 inventory contract，而不是静默改变完整性语义。
+- `describe` 或 invoke 发现 agent 已下架或被撤权时，当前请求不自动改选其他 agent；刷新 inventory 后由用户或 Lead 决定后续动作。

--- a/docs/adr/0005-coordinate-standalone-and-team-agent-execution.md
+++ b/docs/adr/0005-coordinate-standalone-and-team-agent-execution.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+---
+
+# 以 Agents 执行助手协调 standalone 与 Team 执行
+
+Agents 执行助手在 standalone conversation 中直接服务用户，在 Team 中作为普通 member 由用户预选或由 Lead 通过现有 list、describe 和 spawn 能力按需创建。每个远端执行请求最多选择、描述并 direct invoke 一个已发布 agent 一次，不在助手内部创建不可见的远端 Planner。
+
+standalone 缺参时由助手直接询问用户；Team 缺参时把同一个 execution task 设为 `pending` 并交还 Lead，由 Lead 补齐后重新分配。首次使用、catalog 过期或明确刷新时，Team 使用单独的 inventory task 建立真实能力视图；仍有效时可由同一 Assistant session 的后续 execution task 复用。
+
+## Considered Options
+
+- 把每个远端 agent 建模为 Team member：当前 direct invoke 不具备 member 的 mailbox、heartbeat、resume 和 cancel 生命周期。
+- 只允许用户预先添加执行助手：忘记添加后，Lead 无法在当前 Team 使用远端能力。
+- Team member 直接向用户补参：会建立第二条用户协调路径并绕过 Lead。
+
+## Consequences
+
+- 同一 Team 沿用普通 Assistant 多实例语义；实例身份使用 `slot_id`，不按显示名称或 Assistant 定义去重。
+- 每个实例拥有独立 session、Adapter 进程、catalog cache 和 active invocation；不同实例可以用不同 taskId 并行工作。
+- 同一 session 的后续请求沿用 Ki-Core/AionUi 现有队列，不在 Adapter 中再建队列，也不自动创建新实例绕过 busy 状态。
+- inventory、候选比较和 `describe` 不构成执行请求。用户明确要求远端执行，或 Lead 分配 execution task 后，参数完整且候选明确时不增加重复确认；Agents 后续发布 `requiresApproval` 等正式 contract 时再调整。
+- 补参、排队和上传准备都不能消耗 invoke 次数；用户改变意图或拒绝提供必填参数时保持零 invoke。

--- a/docs/adr/0006-guard-remote-invocations-with-local-ledger.md
+++ b/docs/adr/0006-guard-remote-invocations-with-local-ledger.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+---
+
+# 使用本地 ledger 保护远端 invocation
+
+同一 Assistant session 同时最多有一个 active invocation，不同 session 使用不同 taskId 时可以并行。Ki-Buddy 在自己的应用数据目录维护产品自有 SQLite invocation ledger，以 `(规范化 base_url, Agents 用户标识, 远端 taskId)` 唯一约束跨 Adapter 进程和 App 重启的一次本地执行资格；它不进入 AionCore，也不承担中心化审计。
+
+Adapter 在远端 dispatch 前通过数据库事务取得执行资格。只有能够证明尚未开始 dispatch 的 reservation 才能恢复；请求可能已送达但没有可信终态时记为结果未知，原 taskId 永不自动重试。Agents 当前同步窗口结束返回 `running`、dispatch 后断线、进程崩溃和用户停止等待都遵循该语义。
+
+## Considered Options
+
+- 只保存进程内状态：不能处理多个 Adapter 或 App 崩溃后的重复调用。
+- 要求 Agents 首发提供服务端幂等和状态查询：保证更强，但会扩大外部平台改造范围。
+- 自动重试未取得响应的请求：体验连续，却可能重复产生结果或外部副作用。
+
+## Consequences
+
+- ledger 只保存幂等、恢复和结果关联所需的脱敏字段，不保存 token、headers、密码、完整 inputs、完整远端结果、`fileUrl` 或本地文件内容。
+- 结果未知既不是成功也不是失败。再次执行必须来自新的明确请求和新 taskId，并提示原请求可能已经执行。
+- “停止”等产品动作必须表述为停止本地等待；首发不承诺远端 cancel。退出、网络恢复或重新登录不能改变结果未知状态。
+- ledger 随关联 conversation 或 Team 历史保留；退出、切换账号和固定时间经过都不删除。用户显式删除工作历史并终止相关进程后，才删除对应记录。
+- 如果 Agents 后续提供稳定 invocation ID、服务端幂等、status 或 cancel contract，可以重新评估结果未知和恢复策略。

--- a/docs/adr/0007-upload-authorized-local-files-inside-adapter.md
+++ b/docs/adr/0007-upload-authorized-local-files-inside-adapter.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+---
+
+# 在 Adapter 内上传经过授权的本地文件
+
+Agents MCP Adapter 在 invoke 前调用 Agents 文件服务上传本地文件，取得 `fileUrl` 后写入精确文件参数。renderer 只负责文件选择与确认，Ki-Core 保持现有 workspace 语义，Bridge 不接收 multipart。选择“在项目中工作”只授予本地 workspace 能力，不自动授权把目录内容发送给 Agents。
+
+Adapter 只能读取当前请求明确附加，或用户针对目标 deployment、agent 和输入字段逐文件确认的文件。授权通过不透明 file grant 传给 Adapter；`fileUrl` 只保存在当前 Adapter session 内存，并以一次性 `uploadRef` 间接提供给 invoke，不能进入模型、消息历史或 invocation ledger。
+
+## Considered Options
+
+- 由主进程上传：会把 Agents 文件 contract 和 schema 转换分散到 Adapter 之外。
+- 允许 Adapter 读取 effective workspace 任意路径：会把本地访问权错误扩大为远端传输权。
+- 持久保存上传映射：可跨进程恢复，但需要保存敏感 URL 并建设过期、加密和清理模型。
+
+## Consequences
+
+- file grant、上传状态和 `uploadRef` 必须绑定 deployment、账户、session、task、agent 和输入字段，并在文件替换、task 结束、退出、切换部署或 Adapter 重启时失效。
+- 每个 `type=file` 参数首发只接受一个文件；需要多个文件时由 agent schema 声明多个字段。Adapter 不接受模型直接提供的本地路径或 `fileUrl`。
+- 上传采用流式 multipart，不设置 Ki-Buddy 固定大小上限；实际准入由目标部署决定。Adapter 按精确 schema 的 `allowed_file_types` 校验 metadata，但不把它描述为内容扫描。
+- 没有取得有效成功响应时不自动重传；用户显式重试可以继续使用尚未 invoke 的原 taskId。上传准备和失败都保持零 invoke。
+- 当前 Agents 文件服务缺少可靠 owner、TTL、task binding 和安全删除 contract，失败、取消、替换或崩溃可能留下孤立远端文件；首发接受该平台限制，不能宣称远端上传文件按账户完整隔离。

--- a/docs/adr/0008-deliver-remote-result-files-inside-adapter.md
+++ b/docs/adr/0008-deliver-remote-result-files-inside-adapter.md
@@ -1,0 +1,24 @@
+---
+status: accepted
+---
+
+# 在 Adapter 内安全交付远端结果文件
+
+Agents MCP Adapter 只识别 Bridge `result.outputs` 中的结构化文件输出，在确定性边界内下载并写入当前 Ki-Core effective workspace。用户选择项目时写入项目 workspace；未选择时写入当前 Core 用户的自动 workspace。远端 URI 不进入模型、conversation/Team 消息、结果 Markdown、普通日志或 invocation ledger。
+
+默认只允许当前 Agents `base_url` 同源结果；部署管理员可以通过 MCP env 配置额外精确 origin，每次重定向都重新校验且不转发 Agents 凭据。下载使用流式传输、受控临时文件和不可覆盖的最终发布；单文件与单次 invoke 累计字节预算由 env 配置，默认 500 MiB 和 1 GiB。
+
+## Considered Options
+
+- 由 Assistant 调用普通下载工具：会让不可信 URI 进入模型和历史。
+- 在 Ki-Core 或主进程解析 Agents 输出：会把 Agents 特有 contract 分散到 Adapter 之外。
+- 建立 Ki-Buddy 全局结果目录：需要第二套账号归属、清理和导出模型，也违背项目 workspace 选择。
+
+## Consequences
+
+- 不对结果文件数量设置固定上限，但下载必须使用有界并发或顺序处理，共享累计预算；大量小文件的请求和 inode 风险是首发已知限制。
+- 文件名、路径、类型、大小和内容都视为不可信。路径只取清理后的 basename；同名时原子创建递增序号副本，绝不覆盖 workspace 现有文件。
+- 远端 invoke 终态与本地文件交付状态分别记录。远端完成但部分文件未交付时保留已成功文件并标记 `partial` 或 `failed`，不能自动重新 invoke。
+- 可重试的交付失败可以在当前 Adapter session 内通过一次性 `deliveryRef` 只重试未交付文件；引用不持久化，不能跨账号、部署、session 或 Adapter 重启恢复。Team 中由 Lead 让用户选择重试或接受当前结果。
+- 成功发布后的结果沿用普通本地文件预览和系统打开体验，不自动打开，不增加 Agents 专用来源标签、类型 denylist 或警告层；恶意文件风险必须如实记录。
+- 项目 workspace 受操作系统权限约束，不按 Agents 账户隔离；自动 workspace 继续遵循 Ki-Core 的 Core 用户和会话生命周期。

--- a/docs/adr/0009-separate-platform-and-client-security-responsibilities.md
+++ b/docs/adr/0009-separate-platform-and-client-security-responsibilities.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+---
+
+# 分离 Agents 平台与 Ki-Buddy 的安全责任
+
+Agents 平台拥有用户、组织、角色、权限、已发布 agent、远端执行授权、内容治理和中心化审计。Ki-Buddy 拥有本地凭据边界、Core 用户隔离、Adapter 协议校验、task-scoped 文件授权、结果下载限制和本地工具授权；本地 invocation ledger 只负责防重与恢复，不是审计副本。
+
+首发把 catalog 描述和 invoke 返回作为普通 MCP tool 内容交给 Agents 执行助手，不增加 `trust=untrusted` 标记、启发式关键词过滤或专用 prompt-injection 边界。Agents 执行助手也沿用普通 AionCLI 的本地工具和 Ki-Buddy 现有授权策略，不创建专用受限 runtime 或额外确认层。
+
+## Considered Options
+
+- Ki-Buddy 镜像完整服务端审计：会复制用户输入输出并形成第二套保留、删除和访问控制责任。
+- 客户端维护 agent 风险 allowlist 或内容过滤：容易与平台事实漂移，也无法可靠识别语义风险。
+- 为 Agents 执行助手建立专用本地工具权限：可以减少部分影响，但会分叉普通 AionCLI 行为和产品授权模型。
+
+## Consequences
+
+- Ki-Buddy 不能宣称远端内容经过 prompt-injection 隔离或净化；恶意描述和结果可能影响模型后续判断。Adapter 的 schema、凭据、来源和容量校验不能被描述为内容安全防护。
+- Agents 平台不能替代 Ki-Buddy 对本地文件、shell、浏览器和其他副作用的授权判断；远端 agent 权限与本地工具权限是两个独立边界。
+- 明确执行请求当前构成一次 invoke 的同意，客户端不自行推断风险。Agents 后续发布 `sideEffect`、`riskLevel`、`requiresApproval` 等稳定 contract 时，Ki-Buddy 必须重新评估确认流程。
+- 中心化审计完整性由 Agents 验证。Ki-Buddy 只保存脱敏关联 ID、执行状态和本地结果引用，不保存完整请求响应，也不建设管理员审计 UI。
+- 扩大自动授权范围、支持一次请求多次 invoke，或平台内容治理无法满足要求时，必须同时重新评估远端内容信任和本地工具权限。

--- a/docs/adr/0010-probe-bridge-contract-and-gate-packaged-release.md
+++ b/docs/adr/0010-probe-bridge-contract-and-gate-packaged-release.md
@@ -1,0 +1,24 @@
+---
+status: accepted
+---
+
+# 探测 Bridge contract 并以打包目录 E2E 验收发布
+
+Agents Bridge 当前没有稳定版本化 capability contract。Ki-Buddy 不维护 Agents release 白名单，而是在登录后的集成初始化、每次实际响应和工具页手动检测中严格校验真实 catalog、describe 与 invoke envelope；不兼容时 fail closed。Ki-Buddy 从已验证 Agents 基线采集并维护脱敏 contract fixtures，Agents 平台首发不承担客户端 fixture 发布责任。
+
+发布自动化以 contract tests 和 electron-builder `out/` 中 unpacked packaged app 的 Playwright Electron E2E 为门槛。真实登录、权限、invoke 和文件链路连接共享非生产部署中的专用 E2E 组织；需要精确控制断线、崩溃、超时、容量和恶意响应时使用本地 fake Bridge/file server。最终安装版发布后采用人工测试与反馈，不建设 DMG、NSIS 或 DEB 安装后的自动化 Agents E2E。
+
+## Considered Options
+
+- 要求 Agents 首发增加 contract version/capability 接口：边界清晰，但会扩大平台配合范围。
+- 仅使用本地 fixtures：结果稳定，却不能证明真实平台身份、权限和执行链路。
+- 所有故障场景连接真实 Agents：真实度高，但共享环境无法安全、可重复地制造异常。
+- 自动化安装最终分发包：覆盖更多安装问题，但多平台安装、签名和权限驱动成本较高。
+
+## Consequences
+
+- 运行时结构探测不能证明字段语义没有变化；支持的 Agents 基线仍需 contract tests 和真实非生产 E2E。
+- Agents 管理员预先维护专用组织、普通测试账号、权限差异和受保护测试 agents；E2E 只读校验版本化 manifest，不持有管理员权限或自动修改平台配置。
+- 真实层与本地故障层必须启动同一 unpacked packaged app，并用不同证据类型标记；本地 fixture 通过不能替代真实平台场景。
+- evidence 只保存产品 commit、fixture 版本、场景、脱敏关联 ID、状态、workspace 相对路径和断言，不保存凭据、完整 `base_url`、业务输入、远端 URI 或文件内容。
+- 安装器路径、系统钥匙串权限、首次启动、升级、签名和杀毒软件问题不会被 Agents 自动化完全覆盖，这是首发接受的发布风险。

--- a/docs/architecture/research/agents-auth-contract.md
+++ b/docs/architecture/research/agents-auth-contract.md
@@ -1,0 +1,271 @@
+# Agents 认证 Contract 事实调研
+
+## 结论
+
+截至 2026-08-11 已刷新的上游基线 `bed8ba415d2d34f98c65fceffefc1b4bfaba590e`，**没有发现 Agents 平台向第三方客户端承诺的稳定 OAuth 2.0 / OIDC 认证 contract**。具体缺失项包括 OIDC discovery、标准 authorization endpoint、标准 token endpoint 响应、PKCE、`refresh_token` grant、token revocation、公开 logout、稳定的 issuer/audience/tenant/org claims，以及登录 JWT 的 JWKS。
+
+仓库中存在可运行的登录、JWT、SSO 和 token 缓存代码，但它们属于以下三类内部实现，不能直接视为第三方集成承诺：
+
+1. Agents Java app 自定义登录和 HMAC JWT；
+2. Java app 作为 OAuth2 客户端接入外部 SSO；
+3. `server_next` Bridge 从请求、会话注册表或环境变量取得 credential，再转发给 Java app 校验。
+
+因此，Agents MCP Adapter 产品化时不应把现有实现包装成“支持 OAuth/OIDC”。如果 Adapter 需要第三方授权，应先定义并发布独立的认证 contract，或者明确把 Agents 作为受信任后端，由 Adapter 使用受控的服务凭证并另行完成终端用户授权。
+
+## 调研基线与工作区记录
+
+- 初次调研时间：2026-08-10；基线复核时间：2026-08-11。2026-08-11 已成功执行 `git fetch origin dev`；没有 checkout 或 pull。
+- `/Users/xli/agents` 当前分支：`feat/browser-control-service-scaffold`。
+- 当前 HEAD：`acab8f46f03ac30ace3f1e93a9a469de5e49d707`。
+- 当前 upstream：`origin/feat/browser-control-service-scaffold`，本地记录的 upstream 与 HEAD 相同。
+- remote：`origin = git@gitlab.kingsware.cn:AI/product/agents.git`（fetch/push）。
+- fetch 后的 `origin/dev`：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e`，提交时间 `2026-08-11T10:28:34+08:00`，作为本报告当前上游基线。
+- 当前 HEAD 与 `origin/dev` 的 merge-base 是 `129c7af5a9e3d7a02c910addd5a4ef3fde261ad1`；`git rev-list --left-right --count HEAD...origin/dev` 为 `57 836`，两者已明显分叉。
+- 工作区在调研开始前已有改动：4 个 staged、3 个 tracked unstaged、9 个 untracked，共 16 个路径，集中在 `browser-control-service/` 和 `browser-use-server/`。本次调研未修改这些内容。
+- 正文源码行号仍以初次取证的 Git 对象 `f4b82997…` 为准。2026-08-11 对比 `f4b82997…bed8ba415` 后，`JwtTokenFilter`、`TokenLibrary`、auth controllers、`server_next/agent_engines/openclaw/bridge_router.py` 和 `server/core/kagent/kagent_api.py` 均无相关改动，因此正文旧证据继续适用。引用中的 `@ f4b82997…` 表示取证位置，且已复核至 `bed8ba415…`。
+
+## 状态定义
+
+| 状态            | 含义                                                        |
+| --------------- | ----------------------------------------------------------- |
+| **Implemented** | 基线源码中存在执行路径；不代表稳定或公开                    |
+| **Tested**      | 基线仓库中有测试源码覆盖该行为；本次没有执行测试套件        |
+| **Proposed**    | 只在设计稿、PRD 或待确认项中出现                            |
+| **Unknown**     | 在约定的源码、路由、测试和文档范围内未发现可确认的 contract |
+
+## 能力矩阵
+
+| 能力                               | 状态                          | 事实判断                                                                                                                       | 是否可作为第三方稳定 contract                      |
+| ---------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
+| OIDC discovery / issuer metadata   | **Unknown**                   | 未发现 `/.well-known/openid-configuration`、OIDC discovery 或 issuer metadata 路由                                             | 否                                                 |
+| OAuth authorization endpoint       | **Unknown**                   | Agents 自身没有 authorization server 路由；SSO 的 `login-url` 返回的是外部 provider 地址                                       | 否                                                 |
+| 自定义 token issuance              | **Implemented**               | `/api/v1/getToken`、`/api/auth/login`、`/api/auth/external/login` 和 SSO callback 可签发 Agents JWT                            | 只能按私有 API 评估，不能称为 OAuth token endpoint |
+| Bearer access token 接受           | **Implemented / Tested**      | Java filter 接受 `Authorization: Bearer`，也兼容 `token` header 和 query token；有 token 解析单测                              | 可确认兼容行为，尚无独立版本化 auth contract       |
+| Cookie session                     | **Unknown**                   | 认证 filter/controller/client 范围内未发现 cookie 解析或 `Set-Cookie` 登录态                                                   | 否                                                 |
+| PKCE                               | **Unknown**                   | 外部 SSO authorization-code 流程未构造 `code_challenge` / `code_verifier`                                                      | 否                                                 |
+| OAuth `refresh_token` grant        | **Unknown**                   | 没有 `grant_type=refresh_token` 的 Agents endpoint                                                                             | 否                                                 |
+| 临期自动换 JWT                     | **Implemented / 部分 Tested** | filter 在剩余不足 30 分钟时自签新 JWT，并通过 `X-Refreshed-Token` 返回；JWT 工具有单测，未发现 filter 端到端测试或前端接收逻辑 | 私有行为，不是 OAuth refresh                       |
+| revocation endpoint                | **Unknown**                   | Redis 层可以删除 token，但未发现公开 revoke 路由                                                                               | 否                                                 |
+| logout endpoint                    | **Unknown**                   | 未发现服务端 logout 路由；Web 客户端只删除本地存储                                                                             | 否                                                 |
+| 稳定 subject / tenant / org claims | **Unknown**                   | `sub` 是 username；org/role 多在 Redis 登录对象中，普通 JWT 不携带；外部登录的自定义 claims 会在自动换 JWT 时丢失              | 否                                                 |
+| 登录 JWT JWKS                      | **Unknown**                   | 登录 JWT 使用共享 HMAC secret；未发现对应 JWKS                                                                                 | 否                                                 |
+| Bridge catalog/invoke 鉴权         | **Implemented / Tested**      | Bridge 解析或恢复 credential，但 Bridge 本身不验 JWT；无 header 时可使用会话或环境 token                                       | 目前是内部桥接机制，不是第三方认证边界             |
+
+## 事实证据
+
+### 1. Token issuance 是私有登录 API，不是 OAuth/OIDC token endpoint
+
+`POST /api/v1/getToken` 带有 Swagger `@Operation`，但方法只接收 `clientId`、`clientSecret`，返回单个 `token` 字段；没有 `grant_type`、`token_type`、`expires_in`、`scope`、`refresh_token` 或 OAuth error contract。服务实现把 `clientId/clientSecret` 直接交给本地用户名密码登录逻辑：
+
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/api/controller/APILoginController.java:16-41 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/api/service/impl/APILoginServiceImpl.java:13-17 @ f4b82997…`
+
+普通平台登录 `POST /api/auth/login` 同样调用本地用户名密码认证。`POST /api/auth/external/login` 则依赖静态 `systemId/systemSecret` 信任外部系统，并签发 Agents JWT。这两个响应自行写入 `expiresIn: 7200`，没有对应的 OAuth token response schema：
+
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/api/controller/ExternalAuthController.java:37-55 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/api/controller/ExternalAuthController.java:65-92 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/api/controller/ExternalAuthController.java:99-122 @ f4b82997…`
+
+`/api/auth/` 和 `/api/v1/getToken` 被列入 Java app 白名单，因此它们可以作为登录入口调用；这只能证明路由可达，不能证明 OAuth 合规或长期兼容承诺：
+
+- `/Users/xli/agents/app/agents-app/src/main/resources/application-prod.yml:149-184 @ f4b82997…`
+
+### 2. JWT 是 Agents 自签 HMAC token，身份语义依赖 Redis 登录对象
+
+`JwtTokenUtil` 使用共享 HMAC key 验签和签名。标准字段包括 `iss=kingsware`、`sub`、`iat`、`exp`，另有私有 `created`；代码中的 `audience` 是自定义 claim 名，不是明确发布的 OIDC `aud` contract：
+
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/security/JwtTokenUtil.java:30-45 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/security/JwtTokenUtil.java:117-126 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/security/JwtTokenUtil.java:185-203 @ f4b82997…`
+
+普通登录只把 username 放进 `sub`。权限、用户 uuid、orgId、roles 等在登录响应和 Redis session object 中，不在普通 JWT 中：
+
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/service/basic/impl/LoadUserAuthorityImpl.java:89-103 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/service/basic/impl/BasicUserServiceImpl.java:952-962 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/global/TokenLibrary.java:226-258 @ f4b82997…`
+
+因此，`sub` 当前表示可登录 username，不是已承诺的不可变 user id；也没有统一 tenant/org claim。Adapter 仅离线解析 JWT 无法重建 Java app 实际采用的组织和权限上下文。
+
+### 3. Bearer、header、query token 都是兼容输入；真正校验发生在 Java filter
+
+`JwtTokenFilter` 的解析优先级是 `token` header、`Authorization: Bearer`、`token` query、`_token` query。之后它检查 JWT 过期时间，从 Redis 取登录对象或按 `sub` 重新加载用户，再把认证对象放入 Spring Security context：
+
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/filter/JwtTokenFilter.java:94-140 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/filter/JwtTokenFilter.java:142-178 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/filter/JwtTokenFilter.java:198-215 @ f4b82997…`
+
+仓库单测确认了四种 token 输入的优先级，但没有覆盖完整的 Redis、失效、自动换 token 和 Spring Security 过滤链：
+
+- `/Users/xli/agents/app/agents-app/src/test/java/com/kingsware/aiam/manage/filter/JwtTokenFilterTest.java:9-31 @ f4b82997…`
+
+`POST /api/auth/token/verify` 提供私有校验 API，解析规则与 filter 类似，并返回完整 login object。它不是 OAuth introspection endpoint：请求和响应没有 RFC 7662 的 `token` form contract、`active`、`client_id`、`scope` 等字段：
+
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/api/controller/ExternalAuthController.java:125-170 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/api/controller/ExternalAuthController.java:173-191 @ f4b82997…`
+
+### 4. “刷新”是活跃请求触发的自签 JWT 轮换，不是 refresh token grant
+
+filter 在 JWT 剩余有效期不足 30 分钟时调用 `refreshToken(oldJwt)`，删除旧 token 的 Redis 映射、写入新 token，并把新 JWT 放在响应头 `X-Refreshed-Token`：
+
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/filter/JwtTokenFilter.java:149-166 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/filter/JwtTokenFilter.java:273-276 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/global/TokenLibrary.java:261-270 @ f4b82997…`
+
+`JwtTokenUtil.refreshToken` 只从旧 token 重建 `sub`、`audience`、`atoken`、`rtoken`。外部登录写入的 `externalUserId`、`deptId`、`userType` 不在保留清单中，因此这些 claims 在自动轮换后会消失：
+
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/security/JwtTokenUtil.java:212-226 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/security/JwtTokenUtil.java:248-263 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/api/controller/ExternalAuthController.java:65-73 @ f4b82997…`
+
+JWT 工具单测确认新 token 的时间戳变化，以及指定私有 claims 的保留；它没有把该机制定义成公开 refresh contract：
+
+- `/Users/xli/agents/app/agents-app/src/test/java/com/kingsware/aiam/manage/security/JwtTokenUtilTest.java:41-62 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/test/java/com/kingsware/aiam/manage/security/JwtTokenUtilTest.java:299-320 @ f4b82997…`
+
+前端统一请求代码只从 `localStorage.token` 发送 `token` header，未读取 `X-Refreshed-Token`。这意味着仓库内可见的客户端没有完成服务端轮换协议：
+
+- `/Users/xli/agents/k-agentic-flow/app/utils/request.ts:124-167 @ f4b82997…`
+
+默认 JWT 配置是 7 天，并按小时边界生成过期时间；这与两个登录接口硬编码返回的 `expiresIn: 7200` 不一致，所以客户端不能把 `expiresIn` 当成可靠 contract：
+
+- `/Users/xli/agents/app/agents-app/src/main/resources/application-prod.yml:109-114 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/security/JwtTokenUtil.java:129-143 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/api/controller/ExternalAuthController.java:87-90 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/api/controller/ExternalAuthController.java:108-118 @ f4b82997…`
+
+### 5. Redis 删除能力不等于公开 revocation/logout contract
+
+`TokenLibrary.logout(token)` 会删除 token key 和对应 online-user key，filter 在 token 解析失败、过期或用户禁用时也会调用它：
+
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/global/TokenLibrary.java:304-316 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/filter/JwtTokenFilter.java:110-147 @ f4b82997…`
+
+但是，在 controller、route definition、测试和仓库内官方文档中未发现面向客户端的 logout 或 revocation endpoint。Web 端 `handleLogout` 只删除 `localStorage` 并跳转或通知父窗口，没有通知服务端撤销 Redis 登录态：
+
+- `/Users/xli/agents/k-agentic-flow/app/utils/auth.ts:12-42 @ f4b82997…`
+
+### 6. SSO 是 OAuth2 client，不是 Agents 的 authorization server
+
+Agents 的 SSO 路由只有“生成外部 provider 登录 URL”和“接收 code callback”。回调校验一次性 state、向外部 provider 换 access token、读取用户资料，然后签发 Agents 自有 JWT：
+
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/sso/controller/SsoAuthController.java:41-77 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/sso/service/impl/SsoStateServiceImpl.java:17-30 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/sso/service/impl/SsoLoginServiceImpl.java:34-57 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/sso/service/impl/SsoLoginServiceImpl.java:59-87 @ f4b82997…`
+
+provider 构造的是 authorization-code 请求，带 `client_secret` 换 token；没有 PKCE。代码读取并返回 access token，虽然日志检查上游响应中的 `refresh_token`，但没有保存或使用它：
+
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/sso/provider/impl/GjzqOauth2Provider.java:49-58 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/sso/provider/impl/GjzqOauth2Provider.java:89-115 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/sso/provider/impl/GjzqOauth2Provider.java:124-141 @ f4b82997…`
+
+单测覆盖 state、code exchange、用户创建后签发 Agents JWT，但没有 PKCE、OIDC id token、refresh、logout 或 revocation：
+
+- `/Users/xli/agents/app/agents-app/src/test/java/com/kingsware/aiam/manage/sso/service/impl/SsoLoginServiceImplTest.java:43-115 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/test/java/com/kingsware/aiam/manage/sso/provider/impl/GjzqOauth2ProviderTest.java:43-64 @ f4b82997…`
+
+仓库文档中的青松 `/oauth/token` 是 Java app 调用青松引擎的客户端配置，不是 Agents 对外 token endpoint：
+
+- `/Users/xli/agents/app/agents-app/docs/agenticflow/tad/agenticflow-runtime-architecture.md:58-89 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/agenticflow/client/QingsongClientImpl.java:17-27 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/agenticflow/client/QingsongClientImpl.java:43-68 @ f4b82997…`
+
+### 7. 登录 JWT 没有 discovery/JWKS；仓库中的 JWKS 仅是附件 ticket 提案
+
+登录 JWT 使用共享 HMAC secret，因此当前没有供第三方自助验签的公钥发现机制。仓库中确有 `/.well-known/jwks.json` 文本，但它属于“跨服务文件下载 ticket”的设计提案，文档使用“建议增加”，并把是否开放 JWKS 列为待确认事项；它不是已实现的登录 JWT discovery：
+
+- `/Users/xli/agents/app/agents-app/docs/agenticflow/prd/af-cross-service-file-download-auth-architecture.md:216-241 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/docs/agenticflow/prd/af-cross-service-file-download-auth-architecture.md:704-724 @ f4b82997…`
+
+该项状态应标为 **Proposed**，且不能用来推导 Agents 支持 OIDC。
+
+### 8. Bridge catalog/invoke 的 token 路径是 credential resolution，不是认证协议
+
+`GET /bridge/agents/catalog` 和 `POST /bridge/agents/invoke` 的 token 来源依次包括显式 header、conversation/session registry、环境变量和字符串 `internal`。这个函数不验签、不检查 expiry，也不要求 token 必须来自终端用户：
+
+- `/Users/xli/agents/server_next/agent_engines/openclaw/bridge_router.py:294-340 @ f4b82997…`
+- `/Users/xli/agents/server_next/agent_engines/openclaw/bridge_router.py:417-443 @ f4b82997…`
+- `/Users/xli/agents/server_next/agent_engines/openclaw/bridge_router.py:440-480 @ f4b82997…`
+
+Bridge 的会话注册表把原始 token 保存在进程内存，默认 TTL 为 1 小时；这个 TTL 与 JWT 自身 expiry 无关，也没有 refresh/revocation 同步机制：
+
+- `/Users/xli/agents/server_next/agent_engines/openclaw/token_registry.py:1-28 @ f4b82997…`
+- `/Users/xli/agents/server_next/agent_engines/openclaw/token_registry.py:45-76 @ f4b82997…`
+- `/Users/xli/agents/server_next/agent_engines/openclaw/token_registry.py:93-126 @ f4b82997…`
+
+Bridge 把 token 作为历史 `token` header 转发到 Java app 的 `/kagent/agentMarket/all`，由 Java `JwtTokenFilter` 建立 login object；agent list 再按该 login object 中的 orgId、uuid 和 roles 过滤：
+
+- `/Users/xli/agents/server/core/kagent/kagent_api.py:9-42 @ f4b82997…`
+- `/Users/xli/agents/server_next/legacy_server.py:29-71 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/controller/agents/AgentConfigController.java:363-380 @ f4b82997…`
+- `/Users/xli/agents/app/agents-app/src/main/java/com/kingsware/aiam/manage/service/agents/impl/AgentConfigServiceImpl.java:2752-2785 @ f4b82997…`
+
+Bridge 单测确认 Bearer 和 `X-KI-Token` 只是被原样交给 `get_catalog`；同时也明确测试了**无请求 token**时使用环境内部 token，以及 invoke 无认证 header 仍能进入调用路径：
+
+- `/Users/xli/agents/server_next/agent_engines/openclaw/tests/test_bridge_router.py:31-36 @ f4b82997…`
+- `/Users/xli/agents/server_next/agent_engines/openclaw/tests/test_bridge_router.py:58-78 @ f4b82997…`
+- `/Users/xli/agents/server_next/agent_engines/openclaw/tests/test_bridge_router.py:127-142 @ f4b82997…`
+
+仓库内 OpenClaw skill 的 catalog/invoke 示例也不带认证 header，只传 conversation id，说明当前设计预期依赖内部会话恢复，而不是第三方 OAuth client：
+
+- `/Users/xli/agents/server_next/agent_engines/openclaw/kiagents/SKILL.md:26-57 @ f4b82997…`
+- `/Users/xli/agents/server_next/agent_engines/openclaw/kiagents/SKILL.md:99-145 @ f4b82997…`
+
+官方集成方案记录了 header、registry、环境变量和内部 token 的解析优先级。这是内部桥接说明，未定义 token issuance、refresh 或 revocation：
+
+- `/Users/xli/agents/docs/OpenClaw集成技术方案.md:549-631 @ f4b82997…`
+- `/Users/xli/agents/docs/OpenClaw集成技术方案.md:654-680 @ f4b82997…`
+
+## 不修改 Agents 时的首发影响
+
+Agents 不配合修改不会阻止 Ki-Buddy 完成首个公开版本的基础用户接入，但会把认证能力限制为“固定 JWT + 失效后重新登录”，不能提供滑动会话和服务端 logout。
+
+Ki-Buddy 可以独立完成以下功能：
+
+1. 调用 Agents 现有私有登录 API，取得 JWT。
+2. 将 JWT 保存到操作系统钥匙串，不写入普通配置文件或 renderer 存储。
+3. 在 Bridge catalog/invoke 请求中携带固定 JWT。
+4. 收到 `401` 后清除本地凭据并要求用户重新登录。
+5. 用户点击 logout 时清除钥匙串和 Ki-Buddy 本地登录状态。
+
+首发限制如下：
+
+1. **无法形成滑动会话。** Java `JwtTokenFilter` 临期签发的新 JWT 只通过下游响应头 `X-Refreshed-Token` 返回。现有 Bridge catalog/invoke 路径只转发 credential 并返回业务结果，没有把 Java 下游的该响应头传回 Ki-Buddy；Ki-Buddy 因此无法更新钥匙串中的 token。
+2. **logout 只在本地生效。** Ki-Buddy 删除本地 token 后，Agents 没有公开 logout/revoke endpoint，已签发 token 仍可能在远端有效到 JWT 的 `exp`。共享设备、token 泄露和需要立即撤销权限的场景会受到影响。
+3. **有效期提示不可靠。** 登录响应写死 `expiresIn: 7200`，默认 JWT 配置却是 7 天。Ki-Buddy 不能据此准确安排刷新或提示剩余登录时间，只能以服务端 `401` 作为重新登录依据。
+4. **请求可能被登录失效打断。** catalog/invoke 或长任务遇到 token 失效时需要结束当前操作并重新登录；首发版本不具备无感续期能力。
+
+这些限制在首个公开版本可以接受，前提是产品明确采用本地退出、不承诺服务端立即撤销，并且 token 只存放在操作系统凭据存储。企业共享设备、强制即时登出、凭证泄露处置或更严格安全要求出现后，现状不再适合。
+
+## 已确认的首发范围与远期需求
+
+2026-08-11 的产品决定见 ADR 0003：首发允许使用 Agents 现有固定有效期 token，到期后返回登录页；Bridge 自动续期是高优先级后续需求，不阻塞首发。续期完成后不设置绝对会话上限，退出仍只清除 Ki-Buddy 本地凭证和运行状态。服务端 logout/revoke、强制下线和绝对会话上限不属于首发 Agents 配合范围。
+
+该选择没有消除以下事实：旧 token 副本不会因本地退出立即失效；能够持续触发轮换的凭证副本可能长期保持访问；登录响应的 `expiresIn` 与 JWT 默认配置仍不一致。服务端 logout/revocation 已作为远期需求记录，触发原因包括共享设备、管理员强制下线、密码修改后立即失效、权限事件要求立即终止既有会话、凭证泄露处置、合规审计和多设备会话管理。
+
+## 对 Agents MCP Adapter 的直接约束
+
+1. **不能宣称 OAuth/OIDC 支持。** 当前最多能描述为“接受 Agents 私有 JWT 或内部服务 credential”。
+2. **不要把 `/api/v1/getToken` 当 OAuth token endpoint。** 它缺少标准 request/response/error/refresh/revocation contract，且本质上是本地用户名密码登录。
+3. **不要在 Adapter 内只解析 JWT 并自行授权。** `sub` 是 username，orgId/uuid/roles 来自 Redis login object；正确权限结果依赖 Java app。
+4. **Bridge 必须新增明确的入口鉴权边界。** 现状允许 registry/env/internal credential resolution，适合受信任内部部署；直接暴露给第三方会把服务账号能力间接开放给无 token 调用者。
+5. **完成 Bridge contract 后才能依赖 `X-Refreshed-Token`。** 当前 Bridge 和可见客户端尚未传递或接收它；首发改造必须覆盖所有能够触发轮换的远程路径，并验证系统凭据存储确实更新。
+6. **本地退出不等于 logout/revocation。** 仅清理客户端凭证不会撤销 Redis token；Bridge registry 也不会同步撤销。首发接受该限制，远期服务端失效能力仍需要独立 contract。
+7. **如要支持用户委托授权，应先确认 identity model。** 至少需要稳定 `sub`、tenant/org、scope/audience、token lifetime、key rotation、revocation 行为和 service-account impersonation 边界。
+
+## 尚未解决的阻塞项
+
+- Agents 产品是否愿意成为 OAuth 2.0 Authorization Server / OIDC Provider，还是由现有企业 IdP 负责；源码无法回答产品责任边界。
+- 第三方 Adapter 使用终端用户 token、服务账号 token，还是 token exchange/on-behalf-of；现有 contract 没有定义。
+- `sub=username` 是否允许改为不可变 user uuid；组织隔离应使用 `orgId`、`deptId`、tenant id 中的哪一个；现有实现不一致。
+- 是否允许 Bridge 的环境 token 代表所有调用者，以及如何做调用者级审计和权限缩减。
+- 登录 JWT 的签名算法、issuer、audience、JWKS/key rotation 是否会公开并版本化。
+- refresh 后自定义 claims 丢失、`expiresIn` 与 JWT expiry 不一致、前端未接收新 token，这些实现问题在成为任何 contract 前需要先解决并补充端到端测试。
+
+## 验证说明
+
+- 2026-08-11 已成功 fetch `origin/dev`，当前复核基线为 `bed8ba415d2d34f98c65fceffefc1b4bfaba590e`。
+- 本次通过 `git diff --name-only f4b82997..bed8ba415` 和工作区只读检查进行静态核查；指定的 auth 与 Bridge 路径没有相关改动。没有访问运行中的 Agents 部署。
+- 检查范围覆盖 `server_next`、legacy Python server、Java app、`k-agentic-flow` Web client、route/OpenAPI annotations、测试和仓库内官方文档。
+- 针对 `openid-configuration`、OIDC、authorization/token endpoint、PKCE、`code_challenge`、`code_verifier`、`refresh_token` grant、logout、revocation、JWKS、Bearer、cookie、claims 和 Bridge 路径进行了仓库检索。
+- **本次未运行 Java、Python 或 Web 测试套件。** 文中的 **Tested** 仅表示基线仓库存在相应测试源码，不表示本次确认测试通过。

--- a/docs/architecture/research/agents-file-upload-execution-chain.md
+++ b/docs/architecture/research/agents-file-upload-execution-chain.md
@@ -1,0 +1,174 @@
+# Agents 已发布 Agent 表单文件上传与执行链路
+
+## 调研基线
+
+- `k-agent-flow-design`：已于 2026-08-11 fetch `origin/dev`，基线 commit 为 `45eb4e94f0e1ebcbf99919cfa3a9acab87c0ccb2`（提交时间 2026-08-07 10:36:13 +0800）。该仓库是表单前端。
+- `agents`：已于 2026-08-11 fetch `origin/dev`，基线 commit 为 `bed8ba415d2d34f98c65fceffefc1b4bfaba590e`（提交时间 2026-08-11 10:28:34 +0800）。该仓库包含文件服务、任务编排和各类 A2A adapter。
+- 两个仓库均有未提交改动；调研直接读取 `origin/dev` 对象，没有切换分支或修改工作区。
+
+本文只把源码直接证明的内容标为“事实”。跨模块意图但缺少完整运行时证据的内容标为“推断”，部署配置或源码没有说明的内容标为“未知”。
+
+## 链路结论
+
+本地文件不会进入 `/chat` 的 JSON。前端先把二进制上传到 Agents 文件服务，取回 `responseBody.fileUrl`，再把这个 URL 写入执行计划中对应文件参数的 `input.value`。用户确认执行后，前端把更新后的整个 `plan_info` 发送给 `/chat`。Agents core 随后将 URL 放入 A2A `DataPart.data.inputs[].value`；Workflow adapter 最终把它转换成 Dify 的 `remote_url` 文件对象。
+
+```text
+本地 File
+  -> POST /kagent/sys/file/upload (multipart: file)
+  -> responseBody.fileUrl
+  -> plan_info[step].inputs[param].input.value
+  -> POST /chat, method=tasks/send, params.type=flow_run
+  -> A2A DataPart.data.inputs[].value
+  -> Workflow: inputs[name] = { transfer_method: "remote_url", url, type }
+```
+
+这条结论由下文逐段证据支持，不应简化成“invoke 接口直接接收 multipart”或“先上传到 Dify”。
+
+## 1. 表单字段如何触发上传
+
+### 事实
+
+- 规划消息从 `result.plan_info[].inputs[]` 生成表单字段；字段键优先使用 `input.input.key`，否则使用 `${step_id}_${input.name}`。文件选择器的允许类型来自 `input.allowed_file_types`。证据：`45eb4e94f0e1ebcbf99919cfa3a9acab87c0ccb2:app/components/message-types/PlanAgentTypeMessage.js:19-48`。
+- `type === "file"` 时，前端动态创建原生 `<input type="file">`。`allowed_file_types` 只被转换成 DOM `accept` 属性；选中文件后调用 `handleFileUpload(field, files)`。证据：`45eb4e94f0e1ebcbf99919cfa3a9acab87c0ccb2:app/components/message-types/PlanAgentInputField.js:107-121,123-160`。
+- 上传期间执行按钮禁用；禁用条件包括任意 `uploadingFiles` 为真。证据：`45eb4e94f0e1ebcbf99919cfa3a9acab87c0ccb2:app/components/message-types/PlanAgentSubmitButton.js:33-44`。
+
+### 推断
+
+- `accept` 只能约束文件选择器展示，不能作为可信类型校验；拖放、浏览器差异或手工请求都可能绕过。源码未在上传前检查 MIME、扩展名或文件内容。
+
+## 2. 上传 API、请求字段与返回标识
+
+### 事实
+
+- `useFileUpload` 从 `localStorage.token` 读取 token，构造 `FormData`，字段名固定为 `file`，并向 `${NEXT_PUBLIC_API_URL}/kagent/sys/file/upload` 发送 `POST`；请求带历史 `token` header，不手工设置 `Content-Type`。多个文件使用 `Promise.all` 并行上传。证据：`45eb4e94f0e1ebcbf99919cfa3a9acab87c0ccb2:app/hooks/useFileUpload.js:10-35,51-61`。
+- 前端要求 HTTP 成功且 JSON `errorCode === 0`，随后返回 `responseBody` 全部字段并附加本地 `originalFile`。证据：`45eb4e94f0e1ebcbf99919cfa3a9acab87c0ccb2:app/hooks/useFileUpload.js:34-48`。
+- 表单执行链只读取第一个上传结果的 `fileUrl`，其他服务端字段以及 `originalFile` 都不会写入执行计划。证据：`45eb4e94f0e1ebcbf99919cfa3a9acab87c0ccb2:app/components/message-types/PlanAgentFormContext.js:98-125`。
+- 服务端 endpoint 是 `POST /sys/file/upload`；结合全局 context path `/kagent`，对外路径即 `/kagent/sys/file/upload`。Controller 参数是 `MultipartFile file`，与前端字段一致。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/java/com/kingsware/aiam/manage/controller/system/FileToolsController.java:46-77`；`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/resources/application.yml:1-7`。
+- `responseBody` 的类型是 `AppResFileDto`，包含 `sid`、`fileName`、`fileOriginalName`、`fileUrl`、`fileSize`、`fileType`、引用字段、创建用户和时间字段。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/java/com/kingsware/aiam/manage/pojo/system/dto/AppResFileDto.java:12-32`。
+- 对当前表单链路而言，稳定注入执行参数的标识不是 `sid` 或存储 path，而是可下载 URL `responseBody.fileUrl`。服务端生成的 URL 形如 `<base><contextPath>/sys/file/download?path=<encoded storage path>`。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/java/com/kingsware/aiam/manage/controller/system/FileToolsController.java:234-257`。
+- Agents 内部统一上传工具也明确使用 multipart `file`，并只在 `errorCode === 0` 时读取 `responseBody.fileUrl`，与前端契约一致。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:shared/core/file_utils.py:72-93,121-152`。
+
+## 3. `fileUrl` 如何进入 `/chat` 的执行请求
+
+### 事实
+
+- 上传成功后，`fileUrl` 写入 `formData[fieldKey]`。构造提交数据时，前端复制 `result.plan_info`，找到同一输入项并把值写入 `input.input.value`；字符串会先 `trim()`。证据：`45eb4e94f0e1ebcbf99919cfa3a9acab87c0ccb2:app/components/message-types/PlanAgentFormContext.js:117-125,137-158`。
+- 前端提交的是 JSON-RPC 风格对象：`method = "tasks/send"`，`params.type = "flow_run"`，并携带 `conversation_id`、更新后的 `plan_info`、`flow_instance_id`、`message_id` 和本地 `uuid`。请求发送到 `${NEXT_PUBLIC_CHAT_API_URL}/chat`，header 为 `Content-Type: application/json` 和 `token`。证据：`45eb4e94f0e1ebcbf99919cfa3a9acab87c0ccb2:app/components/message-types/PlanAgentFormContext.js:137-173,175-199`。
+- `/chat` 接收 `A2ARequestModel`，先调用 `validate_token`；`tasks/send` 进入 `send()`。当 `params.type == "flow_run"` 时，服务端从客户端请求读取 `plan_info` 并传给 `plan_exec`。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:server/api_server.py:889-919,644-664`。
+- `plan_exec` 先把用户确认后的 `plan_info` 写入执行记录，再用 `trans_agent` 将其中各 step 转为具体 AgentCard，并提交 `FlowInstance`。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:server/utils/api_server_utils.py:273-315,317-358`。
+
+## 4. 最终 agent invoke payload
+
+### 事实
+
+- `trans_agent` 不替换文件 URL；它把每一步的 `inputs` 原样放进对应的 Workflow/RPA/Browser Use/Custom A2A AgentCard。Workflow 还附带 `apiKey`、`userId`，RPA/Browser Use 附带各自 `flow_id`。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:server/core/agent/utils.py:105-163,185-230`。
+- `AgentCardInFlow.get_payload()` 对非上一步输出的参数读取 `input.input.value`。文件值是 URL 时，`ParameterAdapter` 判断为 `url -> file` 并原样返回 URL。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:server/core/agent/base.py:83-91,118-162`；`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:server/core/agent/parameter_adapter.py:41-71`。
+- 通用 A2A DataPart 结构为：
+
+  ```json
+  {
+    "message": {
+      "role": "user",
+      "parts": [
+        {
+          "kind": "data",
+          "data": {
+            "inputs": [
+              {
+                "name": "<param>",
+                "type": "file",
+                "value": "<responseBody.fileUrl>",
+                "required": true,
+                "description": "..."
+              }
+            ],
+            "outputs": [],
+            "agent_request_params": {
+              "conversation_id": "...",
+              "flow_instance_id": "...",
+              "agent_id": "..."
+            }
+          }
+        }
+      ]
+    },
+    "configuration": {
+      "blocking": false,
+      "acceptedOutputModes": ["text/plain", "application/json"]
+    }
+  }
+  ```
+
+  构造代码证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:server/core/agent/base.py:88-186`。Workflow 再把 `api_key` 和 `user_id` 注入 `agent_request_params`：同文件 `189-198`。
+
+- Agent runner 把该对象构造成 `SendStreamingMessageRequest` 并调用 A2A client 的 `send_message_streaming`。发送前会转换特定 FastDFS HTTPS URL、移除空值，并把完整调用参数写入日志。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:server/core/agent/agent_runner.py:257-312`。
+- Workflow adapter 读取 `data.inputs[]`。对于 `type == "file"` 且 `value` 非空的项，把 URL 转成 Dify 输入：`{"transfer_method":"remote_url","url":fileUrl,"type":...}`；最终请求为 `POST /v1/workflows/run`，body 含 `inputs`、`response_mode`、`user`，Bearer token 使用 agent 的 `api_key`。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:a2a-server-workflow/src/server/dify_agent.py:193-198,219-287,375-405`。
+- RPA adapter 不做 Dify 文件对象转换，而是把 `inputs[].value` 直接变成 RPA `Param{n}Value`；因此文件 URL 仍作为参数值传给 RPA。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:a2a-server-rpa/core/rpa_base/rpa_client.py:185-221`。
+- Browser Use adapter同样把输入列表压成 `{name: value}` 后传给 Browser Use API，文件 URL 保持字符串。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:a2a-server-browser-use/core/browser_use_agent_executor.py:293-318,723-737`。
+
+### 推断
+
+- Ki-Buddy 要保持现有 Workflow/RPA/Browser Use 行为，应复用“先上传，执行参数保存 `fileUrl`”这一公共契约，而不是把本地路径、`sid` 或二进制直接放进 `flow_run`。
+- Custom A2A 会把通用输入列表压成 name/value map，因此自定义 agent 的文件参数也只会得到 URL 字符串；自定义 agent 是否接受 URL、是否需要签名或二次下载由其协议决定。转换证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:server/core/agent/base.py:233-274`。
+
+## 5. 身份与权限语义
+
+### 事实
+
+- 前端上传 hook 强制本地存在 token，并发送 `token` header；没有 token 时客户端直接报错。证据：`45eb4e94f0e1ebcbf99919cfa3a9acab87c0ccb2:app/hooks/useFileUpload.js:17-32`。
+- 但 Agents app 的生产配置把 `/sys/file/` 整段放入白名单；JWT filter 对白名单请求直接放行。因此上传、下载和删除接口在该配置下不要求 token，前端 header 不是服务端权限边界。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/resources/application-prod.yml:149-179`；`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/java/com/kingsware/aiam/manage/filter/JwtTokenFilter.java:61-79,89-100`。
+- 新文件记录的 `createUserId` 来自当前登录用户；请求没有登录上下文时写空字符串。当前 `/sys/file/*` 白名单请求即存在这种情况。上传 Controller 也没有设置 `referTable` 或 `referSid`，因此该链路没有把文件绑定到 conversation、flow、agent 或参数。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/java/com/kingsware/aiam/manage/service/system/impl/AppResFileServiceImpl.java:100-115,237-242`；`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/java/com/kingsware/aiam/manage/controller/system/FileToolsController.java:143-169`。
+- `/chat` 至少要求 `token` header 非空。是否远程验证 token 由 `TOKEN_VALIDATE_REMOTE` 控制；当前代码在该值为 `true`（默认值）时直接返回 token，只有为 false 时才调用远程验证。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:server/utils/api_server_utils.py:138-164`。
+- `flow_run` 使用客户端提交的 `plan_info` 构造 AgentCard；本次追踪到的 `flow_run -> plan_exec -> trans_agent` 路径没有重新查询用户对每个 `agentId` 的授权。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:server/api_server.py:644-664`；`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:server/utils/api_server_utils.py:287-315`；`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:server/core/agent/utils.py:120-236`。
+
+### 未知
+
+- 目标部署是否由 Higress、Caddy、WAF 或网络边界为 `/sys/file/*` 和 A2A 服务增加了额外认证、限流或 ACL；仓库内应用代码不能证明部署态策略。
+- `TOKEN_VALIDATE_REMOTE` 在 Ki-Buddy 对接的实际环境取值。
+- `flow_run` 前是否还有网关层对 `plan_info.agentId` 做权限复核。本文追踪的应用路径没有发现该复核，但不能据此断言所有部署均无复核。
+
+## 6. 大小、类型和内容校验
+
+### 事实
+
+- flow-design 没有上传大小检查；文件类型只通过 DOM `accept` 提示。证据：`45eb4e94f0e1ebcbf99919cfa3a9acab87c0ccb2:app/components/message-types/PlanAgentInputField.js:107-121,149-160`；`45eb4e94f0e1ebcbf99919cfa3a9acab87c0ccb2:app/hooks/useFileUpload.js:10-32`。
+- Agents app 的 production multipart 配置为单文件 500MB、单请求 500MB。仓库所带 Nginx 模板允许 1024MB，因此在这两层配置同时生效时，Spring 的 500MB 更严格。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/resources/application-prod.yml:105-108`；`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:docker/agents-nginx/default.conf.template:1-13`。
+- `/sys/file/upload` Controller 没有文件类型白名单或 MIME 校验；它依据原文件名后缀记录 `fileType`，对 txt/text/md 增加 UTF-8 BOM 后写入 OSS 或 FastDFS。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/java/com/kingsware/aiam/manage/controller/system/FileToolsController.java:75-107,118-169`。
+- Workflow adapter 将文件归类为 `document/image/audio/video/custom`，优先采用显式 metadata，否则依次回退 MIME、extension、filename 和 URL；这属于下游协议转换，不是上传准入校验。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:a2a-server-workflow/src/server/dify_agent.py:313-369,375-430`。
+
+### 未知
+
+- Higress/Caddy/对象存储的实际 body 大小、超时、病毒扫描、DLP 和文件后缀策略。
+- Dify、RPA、Browser Use 各 agent 对具体文件类型和大小的最终限制；这些限制可因已发布 agent 配置而不同。
+
+## 7. 生命周期、删除与审计
+
+### 事实
+
+- `app_res_file` 持久化模型只有文件标识、存储 path、原名、大小、类型、引用、创建用户和创建/更新时间，没有 TTL、过期时间或临时/已绑定状态。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/java/com/kingsware/aiam/manage/pojo/system/persistent/AppResFile.java:19-49`。
+- 上传 endpoint 会按“原文件名 + 大小”查找最近记录；命中时重新上传并更新原记录的存储 path，未命中时新建记录。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/java/com/kingsware/aiam/manage/controller/system/FileToolsController.java:109-169`；`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/java/com/kingsware/aiam/manage/service/system/impl/AppResFileServiceImpl.java:190-205`。
+- 文件删除接口是 `POST /sys/file/delete`，接收 storage `path`，直接删除 FastDFS 文件和数据库记录，没有 owner 校验。该路径也落在 `/sys/file/` 白名单内。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/java/com/kingsware/aiam/manage/controller/system/FileToolsController.java:357-363`；`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:app/agents-app/src/main/resources/application-prod.yml:149-163`。
+- flow-design 的表单上传链路没有调用服务端删除接口。`removeUploadedFile` 只移除 React hook 的本地数组；表单实际只消费 `fileUrl`。证据：`45eb4e94f0e1ebcbf99919cfa3a9acab87c0ccb2:app/hooks/useFileUpload.js:64-79`；`45eb4e94f0e1ebcbf99919cfa3a9acab87c0ccb2:app/components/message-types/PlanAgentFormContext.js:117-125`。
+- `/chat` 会记录收到的完整 request；`flow_run` 记录计划步数；远程 agent 执行前 `[AUDIT_AGENT_INPUT]` 会记录完整 `send_message_payload`，其中包含文件 URL，并可能包含 Workflow `api_key`。证据：`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:server/api_server.py:889-903,644-653`；`bed8ba415d2d34f98c65fceffefc1b4bfaba590e:server/core/agent/agent_runner.py:282-303`。
+
+### 推断
+
+- 用户选中文件但未提交、提交失败、替换文件或放弃会话时，已上传对象会继续存在；当前源码没有自动回收动作。由于模型没有 TTL，不能假设后台会自动清理。
+- `fileUrl` 是无签名的下载地址，且下载 endpoint 位于匿名白名单；得到 URL/path 的主体可以直接下载。Ki-Buddy 不应把它当作用户隔离凭据。
+- 按“同名 + 同大小”更新已有记录而不先删除旧 storage path，可能产生无法由数据库引用的旧对象；需要运行态存储检查才能确认实际泄漏规模。
+
+### 未知
+
+- 是否存在仓库外的定时清理任务、对象存储生命周期策略、杀毒/DLP 服务或集中审计脱敏规则。
+- 日志系统的保留期、访问权限，以及 `api_key`、文件 URL 是否在采集链路中脱敏。
+
+## 对 Ki-Buddy 集成的直接约束
+
+以下是由现有契约推导出的兼容要求，不代表 Agents 已具备安全文件域：
+
+1. 上传阶段使用 multipart `file` 调用 `/kagent/sys/file/upload`，成功条件为 `errorCode === 0`，保留 `responseBody.fileUrl`。
+2. 执行阶段把 `fileUrl` 写入对应 agent 输入值；不要把 Ki-Buddy 本地绝对路径暴露给 Agents，也不要把 `sid` 当作 invoke 值。
+3. 必须等待上传完成后才能允许执行；现有 flow-design 也是通过 `uploadingFiles` 禁用按钮。
+4. Ki-Buddy 自己需要定义草稿取消、失败、替换、会话删除时的文件回收策略。现有 Agents 接口没有 TTL/owner 语义，且删除接口按 path 操作，不适合作为可信的用户级资源 API。
+5. 对外展示前应明确 500MB 只是当前 Agents app 配置，不是跨所有网关和 agent 类型的统一保证。
+6. 文件 URL、agent `api_key` 和完整 invoke payload 可能进入日志；集成设计需要单独规定敏感字段脱敏和审计访问权限。

--- a/docs/architecture/research/agents-user-management-client-ui.md
+++ b/docs/architecture/research/agents-user-management-client-ui.md
@@ -1,0 +1,165 @@
+# AionUi v2.1.52 产品账户与 upstream 认证实现调研
+
+> 产品策略更新（2026-08-11）：本文对 AionPro 生产发布物的观察继续有效；其中“复用产品当前账户”的早期设计推论已被 ADR 0003 取代。Ki-Buddy 不使用 AionPro cloud account，而是直接登录 Agents 平台，并把 AionPro 的主进程身份边界、Core 用户投影和退出清理作为产品经验。
+
+## 结论
+
+用户安装的官网 AionUi v2.1.52 已经实现真实的桌面账户体系，并在首次启动或 session 失效时要求登录。桌面端包含账户页、用户 ID、邮箱和退出登录；登录使用浏览器 + PKCE，refresh token 存入系统钥匙串，access token 只保存在 Electron 主进程内存。refresh 支持 token 轮换，logout 会先请求 cloud session revoke，再清除本地 session。
+
+同一产品构建还固定以 `aionpro` identity mode 启动 AionCore：AionUi cloud user 被投影为 Core external user，主进程换取 Core session；退出或账号变化时撤销该用户的 Core session。这套能力已经提供可用于本地数据隔离的真实用户身份。
+
+公开仓库的 `v2.1.52` tag 与官网 v2.1.52 安装包不是同一套认证实现。公开 tag 的 Electron `AuthContext` 仍直接标记 authenticated 且 `user=null`；官网安装包则包含公开 tag 中不存在的 desktop auth、Account UI、`keytar`、Firebase 和 CoreUserBridge 代码。公开 workflow 和更新文案也明确区分 OSS AionUi build 与 AionPro build，并说明新版安装包由官网分发、需要登录。因公开资料没有给出官网安装包对应的私有 branch/commit，不能把公开 tag 的行为用于推断产品安装包，也不能反向声称已经定位产品源码 commit。
+
+这改变了 Agents MCP Adapter 的设计前提：产品不应新增第二套“本地当前用户”，也不应让 Adapter 自行保管 AionUi refresh token。仍未解决的是 AionUi cloud identity 与 Agents platform identity 的绑定，以及 Agents 是否提供可长期依赖的 token exchange、OAuth/OIDC、refresh 和 revocation contract。
+
+## 基线与方法
+
+### 官网产品发布物
+
+- 用户截图与实际安装路径：`/Applications/AionUi.app`。
+- `CFBundleShortVersionString`：`2.1.52`。
+- `app.asar`：`/Applications/AionUi.app/Contents/Resources/app.asar`。
+- `app.asar` SHA-256：`29c8eb4af1b248d4b831343d602c9c98058a54b6d9ac656acb12f6d1277aca97`。
+- 内置 Core：`/Applications/AionUi.app/Contents/Resources/bundled-aioncore/darwin-arm64/aioncore`。
+- Core `--version`：`aioncore 0.1.62`。
+- Core binary SHA-256：`56de1278e00c9861117f614f0f84dafebcb917f9aa45f9ccc0519b9a6f23ee3a`。
+- 只读解包目录：`/tmp/aionui-asar-analysis.mWnkEB/extracted`。
+
+发布物观察标为 **Observed**。解包结果可以证明用户实际安装的二进制包含哪些行为，但不能证明其私有源码 commit、服务端部署版本或所有线上错误路径。
+
+### 公开 upstream
+
+- remote：`git@github.com:iOfficeAI/AionUi.git`。
+- 2026-08-10 执行 `git fetch upstream --prune --tags` 后，`upstream/main` 为 `85627c80454e0a85e7b81a9dd8dc967900df2b05`。
+- 公开 `v2.1.52` tag 为 `7ebae30aaf33c03dd035b0621346c568b4eab897`。
+- 当前设计分支：`design/agents-mcp-productization`；没有 checkout、pull、commit 或 push。
+
+公开源码状态标为 **Implemented**；仓库中存在直接自动化测试时标为 **Tested**；找不到可发布 contract 或产品源码映射时标为 **Unknown**。
+
+## 产品 v2.1.52 的桌面认证
+
+### 登录入口与强制认证
+
+**Observed**：实际 renderer 通过 Electron auth IPC 获取 `authenticated` / `unauthenticated` 状态。desktop auth 不再走公开 tag 中的直接放行逻辑，而是调用 `getSession`、`login`、`logout`、`refresh` 和 `changed`。发布物包含 “Sign in to AionUi”、Account、User ID、邮箱、logout modal 等 UI；未认证页面与业务路由分离，首次登录前的引导使用静态资源，避免请求会返回 401 的业务 API。
+
+证据：
+
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/renderer/assets/index-fF3BtVt4.js:71`
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/renderer/assets/index-fF3BtVt4.js:7067`
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/renderer/assets/index-fF3BtVt4.js:8482`
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/renderer/assets/index-fF3BtVt4.js:8638`
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/main/index.js:37439-37502`
+
+renderer bundle 被打成极少数长行，因此其行号粒度较粗；主进程 bundle 保留了可读的模块边界与注释。
+
+### Browser login 与 PKCE
+
+**Observed**：桌面登录生成随机 `code_verifier`、S256 `code_challenge` 和 `state`，启动 loopback callback，然后打开 AionUi authorize 页面。callback token 与 `code_verifier` 被提交到自定义 `POST /account/login_by_token`。该流程使用 PKCE，但服务端接口不是从公开标准 metadata 发现的 OAuth/OIDC contract。
+
+相关 endpoint：
+
+- `/account/login_by_token`
+- `/account/account/refresh_access_token`
+- `/account/account/user_info`
+- `/account/account/logout`
+
+证据：
+
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/main/index.js:8260-8316`
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/main/index.js:8495-8668`
+
+**Unknown**：官网服务是否发布 OIDC discovery、JWKS、标准 token endpoint、scope/audience contract 或 RFC 7009 revocation contract。安装包只能证明客户端使用上述私有 endpoint。
+
+### Token 获取、存储与轮换
+
+**Observed**：
+
+- `CLIENT_ID` 为版本相关的 `aionui_desktop_${APP_VERSION}`；系统钥匙串使用稳定 account `refresh_token:${env}:aionui_desktop`，便于跨桌面版本读取同一产品 session。
+- refresh token 通过 `keytar` 保存，macOS 上对应系统钥匙串；`auth.enc` 只保存 schema、环境、client id、过期时间与用户摘要，不保存 token。
+- keytar 不可用时 session 只存在于内存，不以明文文件替代。
+- access token 只在 Electron 主进程内存中，普通 cloud API 请求自动添加 Bearer header。
+- access token 在过期前 60 秒刷新；401 会强制刷新并重试一次。
+- refresh response 若返回新 refresh token，则更新钥匙串；refresh 失败会清除整个 session。
+- HTTP debug logger 对 token、authorization、code verifier、password 和 cookie 做敏感字段过滤。
+
+证据：
+
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/main/index.js:7353-7488`
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/main/index.js:7508-7525`
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/main/index.js:7660-7735`
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/main/index.js:8495-8768`
+
+### Logout 与账号隔离
+
+**Observed**：logout 给 cloud revoke 最多 5 秒；无论服务端成功、失败或超时，客户端都会取消进行中的登录并清除 access token、refresh token、用户摘要和钥匙串记录。当前产品 UI 展示单个 active account；账号变化通过退出后重新登录完成，没有观察到并列保存多个可切换账号的 UI。
+
+证据：
+
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/main/index.js:8677-8704`
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/main/index.js:8558-8615`
+
+**Unknown**：cloud logout 是撤销单个 refresh token、整个设备 session 还是账户的所有 session；安装包没有公开服务端 contract。也未观察到账号列表、tenant/org selector 或多账号并存的安全存储 schema。
+
+## 产品 v2.1.52 与 AionCore 的身份投影
+
+**Observed / Core Implemented**：产品主进程固定设置 `CORE_IDENTITY_MODE = "aionpro"`。`CoreUserBridge` 将 cloud user id 作为 external user id，执行：
+
+1. `PUT /api/auth/internal/external-users/{external_user_id}` provision Core user；
+2. `POST /api/auth/internal/external-sessions` 换取 Core session；
+3. Core JWT 只保存在主进程内存，并为 renderer 写入 HttpOnly `aionui-session` Cookie；
+4. 账号变化或 logout 时调用 `POST /api/auth/internal/external-sessions/revoke`，清除 renderer 与配对 WebUI 的 Core session。
+
+internal endpoint 使用每次 Core 进程启动生成的 bootstrap secret，secret 和 Core JWT 都不通过 renderer IPC 暴露，也不持久化。
+
+发布物证据：
+
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/main/index.js:39388-39410`
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/main/index.js:44778-45145`
+- `/tmp/aionui-asar-analysis.mWnkEB/extracted/out/main/index.js:46662-46694`
+
+AionCore v0.1.62 与刷新后的 upstream `main@f0f4fbd1` 都包含对应 external-user/session/revoke contract；两者在 auth、external session、MCP 与 OAuth 相关路径没有功能差异。详细证据见 `docs/architecture/research/aioncore-auth-identity-foundations.md`。
+
+## 与公开 v2.1.52 tag 的差异
+
+公开 tag 的 `AuthContext` 在 Electron 环境中仍有以下行为：
+
+- `refresh()` 直接设置 authenticated，`user=null`；
+- desktop `login()` 直接返回成功；
+- desktop `logout()` 仍保持 authenticated。
+
+证据：
+
+- `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/context/AuthContext.tsx:51 @ v2.1.52`
+- `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/context/AuthContext.tsx:121-127 @ v2.1.52`
+- `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/context/AuthContext.tsx:152-157 @ v2.1.52`
+- `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/context/AuthContext.tsx:255-260 @ v2.1.52`
+
+这不是官网 v2.1.52 的产品行为。以下公开材料解释了两条发布线的存在：
+
+- workflow 注释写明 OSS `-final` build 引导用户到 AionPro 官网，AionPro 有自己的 release tags：`/Users/xli/AionUi/.github/workflows/_build-reusable.yml:34-38 @ v2.1.52`。
+- 中文更新文案写明新版需要登录，支持 Google 登录，安装包与更新由官网提供：`/Users/xli/AionUi/packages/desktop/src/renderer/services/i18n/locales/zh-CN/update.json:80-93 @ v2.1.52`。
+- 官网安装包的 package 依赖包含 `firebase`、`keytar`、`node-machine-id`，公开 tag 的 root package 不包含这些依赖。
+
+因此版本号只能证明产品版本，不能证明官网发布物与公开 tag 使用同一源码树。
+
+## 对 Agents MCP Adapter 的直接约束
+
+1. **复用产品当前账户作为本地身份入口。** Core `CurrentUser.id` 已由 cloud user 投影产生，可作为 inventory、catalog cache、task、结果文件与审计记录的第一层隔离键。
+2. **不新增第二套本地用户系统。** 仍需定义 `AgentsIdentityBinding`，把 AionUi cloud user、Core user、Agents stable subject 与 tenant/org 显式绑定。
+3. **Adapter 不接触 AionUi refresh token。** refresh token 继续只由 Electron 主进程和系统钥匙串持有；renderer、AionCore 与 stdio Adapter 都不能读取它。
+4. **不能把 AionUi 私有 auth endpoint 称为稳定 OAuth/OIDC contract。** 产品已实现 PKCE、refresh rotation 与 cloud logout，但公开 discovery、claims、audience、revocation 语义仍是 Unknown。
+5. **不能直接把 AionUi access token 发送给 Agents。** 只有在 issuer/audience 与 Agents 验证 contract 被双方明确发布后才可复用；优先考虑由受信任后端执行 token exchange，向客户端签发短时、Agents-audience 的调用凭证。
+6. **统一退出链路。** AionUi logout、Core external-session revoke、Adapter 停止、active invocation 取消、按用户缓存清除与 Agents credential 失效必须形成显式状态机；各远端步骤失败时保留可审计的待处理状态。
+7. **MCP server OAuth 与产品账户是不同身份域。** AionCore 现有 MCP OAuth 不能代替 Agents 平台用户认证；其 SQLite token 路径当前也未证明真实加密，不适合保存 AionUi cloud refresh token。
+
+## 仍需平台 contract 回答的问题
+
+- Agents 是否接受 AionUi cloud identity，还是要求独立登录。
+- 是否提供稳定的 token exchange/on-behalf-of endpoint，以及 subject、tenant/org、scope、audience 与 expiry contract。
+- 是否提供 refresh、rotation、logout/revocation、account disable 与 tenant membership change 的通知或查询机制。
+- catalog 和 invoke 是否按同一主体与 tenant 执行授权，错误是否能区分 unauthenticated、forbidden、tenant mismatch 与 credential expired。
+- Bridge 当前的私有 JWT/registry/environment token 路径何时退出，是否允许没有终端用户凭证的内部 token 继续访问用户 catalog。
+
+## 验证说明
+
+本次只读检查用户实际安装的官网 v2.1.52、公开 `v2.1.52` tag、刷新后的 AionUi upstream `main` 与 AionCore upstream `main`。没有执行登录 E2E、修改安装包、切换分支、commit 或 push。发布物行为标为 Observed；服务端语义与私有源码映射无法由安装包证明的部分均标为 Unknown。

--- a/docs/architecture/research/aioncore-auth-identity-foundations.md
+++ b/docs/architecture/research/aioncore-auth-identity-foundations.md
@@ -1,0 +1,154 @@
+# AionCore 发布版与 upstream 认证、身份基础设施调研
+
+> 产品策略更新（2026-08-11）：本文关于 AionPro 与 AionCore 的事实结论继续有效；“复用 AionPro 当前账户作为 Ki-Buddy 身份入口”的早期设计推论已被 ADR 0003 取代。Ki-Buddy 直接使用 Agents 平台账户登录，只借鉴 AionPro 将外部产品身份投影为 Core 用户的协作方式。
+
+## 结论
+
+AionUi 官网 v2.1.52 已内置 AionCore v0.1.62，并以 `aionpro` identity mode 运行。桌面主进程把已登录的 AionUi cloud account 投影为 AionCore external user，再通过 bootstrap-secret 保护的 internal endpoint 换取 Core session；退出或切换账号时撤销该 external user 的 Core session。用户截图中的桌面账户并非 WebUI 本地 admin，也不是 `system_default_user`。
+
+AionCore v0.1.62 与本次刷新后的 upstream `main` 都具备可供 Agents MCP Adapter 产品化复用的本地身份基础设施：认证中间件产出稳定的 `CurrentUser.id`，MCP server 配置与 MCP OAuth token 均按该用户 ID 隔离；AionPro external session 可以建立和撤销投影到 Core 的用户会话，撤销时会清理 WebSocket、Team、Channel 与 conversation runtime。v0.1.62 到 upstream `main` 的认证、external session、MCP、OAuth 相关路径没有功能改动。
+
+这些能力解决的是 **AionUi/AionCore 本地身份与资源隔离**，不能替代 **Agents 平台认证 contract**。AionCore 的 MCP OAuth client 只有在远端服务提供标准 OAuth/OIDC discovery、authorization endpoint、token endpoint 和 refresh grant 时才能工作；Agents 平台当前没有发布这些 contract。
+
+另有一个阻止直接复用的安全缺口：MCP OAuth 数据模型要求调用方加密 token，但当前 `McpOAuthService` 将 authorization/refresh 响应中的 token 原样交给 SQLite repository，composition root 也没有传入 encryption key。因此不能把现有 MCP OAuth token repository 直接用于 Agents credential。
+
+## 调研基线
+
+- 调研时间：2026-08-10。
+- upstream remote：`git@github.com:iOfficeAI/AionCore.git`。
+- upstream 默认分支：`main`。
+- 2026-08-10 执行 `git fetch upstream --prune --tags` 后，远端最新提交为 `f0f4fbd1234a039861f2b3e857cd821337c37672`。
+- 用户安装的官网 AionUi v2.1.52 内置 `aioncore 0.1.62`；对应 upstream tag 为 `v0.1.62`，commit `35707c0a249964227c1b227b34b93e2bcf0d08f8`。
+- 实际发布物：`/Applications/AionUi.app/Contents/Resources/app.asar`，SHA-256 `29c8eb4af1b248d4b831343d602c9c98058a54b6d9ac656acb12f6d1277aca97`；内置 Core binary SHA-256 `56de1278e00c9861117f614f0f84dafebcb917f9aa45f9ccc0519b9a6f23ee3a`。
+- `/Users/xli/AionCore` 当前分支：`product/main`，HEAD `5d66f83408e731299a8abe06173fff960c6b6655`。
+- 当前分支相对 upstream `main` 为左侧 26、右侧 18，已经分叉。
+- 正文使用 `git show <ref>:<path>`、`git diff v0.1.62..upstream/main` 和实际发布物的只读解包结果交叉检查；没有 checkout、pull 或修改 AionCore 工作区。
+- 本次没有执行测试。文中的 **Tested** 仅表示 upstream commit 中存在相关测试源码。
+
+## 能力矩阵
+
+| 能力                             | 状态                         | 产品判断                                                                                                                                       |
+| -------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| 本地用户 session                 | Implemented / Tested         | `/login` 签发 Core JWT 并设置 session Cookie；认证中间件向业务路由提供 `CurrentUser`。                                                         |
+| Core JWT refresh                 | Implemented / Tested         | `/api/auth/refresh` 校验当前 JWT、active user 与 `session_generation` 后签发新 JWT；这是 Core 私有 session refresh，不是 OAuth refresh token。 |
+| 当前 token logout                | Implemented / Tested         | `/logout` 将当前 JWT 加入 blacklist 并清除 Cookie。                                                                                            |
+| AionPro external user/session    | Implemented / Tested         | bootstrap-secret 保护的内部接口负责外部用户投影、Cookie session exchange 与 session revoke。                                                   |
+| 官网桌面账号到 Core 的身份投影   | Released / artifact verified | v2.1.52 主进程固定使用 `aionpro` mode；以 cloud user id provision Core user，Core JWT 仅在主进程内存与 HttpOnly Cookie 中使用。                |
+| 跨模块 session revoke            | Implemented / Tested         | revoke 会使旧 generation 失效，并断开 WebSocket、停止 Team session、关闭 Channel、终止 conversation runtime。                                  |
+| MCP 配置用户隔离                 | Implemented / Tested         | MCP routes 从 `CurrentUser` 取得 user ID，service/repository 的 CRUD 均以 user ID 查询。                                                       |
+| MCP OAuth 用户隔离               | Implemented / Tested         | OAuth pending state 与 token repository 以 `(user_id, server_url)` 隔离。                                                                      |
+| MCP OAuth discovery/PKCE/refresh | Implemented / 部分 Tested    | 支持 RFC 8414/OIDC discovery fallback、Authorization Code + PKCE 和标准 refresh grant。是否可用取决于远端 server contract。                    |
+| MCP OAuth provider revocation    | Unknown                      | logout 只删除本地 token，没有调用远端 revocation endpoint。                                                                                    |
+| MCP OAuth token 加密             | 未实现                       | 模型要求调用方加密，但 service 直接存储 token，composition root 没有注入 encryption key。                                                      |
+
+## 身份与会话边界
+
+### 官网 v2.1.52 的实际桌面身份路径
+
+官网安装包中的桌面主进程固定设置 `CORE_IDENTITY_MODE = "aionpro"`，并明确把开源嵌入版的 `--local` / `system_default_user` 与 AionPro 产品模式分开。`CoreUserBridge` 在 AionUi cloud account 认证成功后执行以下流程：
+
+1. `PUT /api/auth/internal/external-users/{external_user_id}`，以 cloud user id 幂等 provision `user_type=aionpro` 的 Core user；
+2. `POST /api/auth/internal/external-sessions`，换取 Core session Cookie；
+3. Core JWT 只保存在主进程内存，并为 renderer 安装 HttpOnly `aionui-session` Cookie；
+4. 退出或账号变化时调用 `POST /api/auth/internal/external-sessions/revoke`，清除主进程 token、renderer Cookie 和配对 WebUI session。
+
+发布物证据来自上述 SHA-256 对应的 `app.asar` 只读解包：`out/main/index.js:39394-39410`、`out/main/index.js:44783-45145`。对应 Core endpoint 与测试同时存在于 v0.1.62 和 upstream `main`：
+
+- `/Users/xli/AionCore/crates/aionui-auth/src/routes.rs:250-435 @ v0.1.62 / f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-auth/tests/route_tests.rs:836-1045 @ v0.1.62 / f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-app/tests/session_revoke_cleanup_e2e.rs:1-190 @ v0.1.62 / f0f4fbd1`
+
+这条路径已经提供真实的桌面用户与 Core `CurrentUser.id`，无需再设计第二套本地用户登录。它仍然没有建立 AionUi cloud account 与 Agents platform user/tenant 的认证关系。
+
+### AionCore 自身的 session contract
+
+AionCore 有两种认证身份模式：普通 `UserSession` 与 `AionPro`。普通模式允许用户名密码登录；AionPro 模式通过内部 external-user/session 接口把外部身份投影到 Core 用户。内部接口由 bootstrap secret 保护，external session exchange 设置 Core session Cookie：
+
+- `/Users/xli/AionCore/crates/aionui-auth/src/routes.rs:250-260 @ f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-auth/src/routes.rs:269-320 @ f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-auth/src/routes.rs:362-407 @ f0f4fbd1`
+
+`POST /api/auth/refresh` 不是 OAuth `refresh_token` grant。请求 body 带旧 Core JWT；服务校验签名、active user 与 `session_generation`，再签发一个新 Core JWT：
+
+- `/Users/xli/AionCore/crates/aionui-auth/src/routes.rs:774-818 @ f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-api-types/src/auth.rs:54-69 @ f0f4fbd1`
+
+普通 logout 只 blacklist 当前 token 并清 Cookie。external-session revoke 则提升该用户的 session generation，并触发产品级清理 hook：
+
+- `/Users/xli/AionCore/crates/aionui-auth/src/routes.rs:522-534 @ f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-auth/src/routes.rs:410-435 @ f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-app/src/router/routes.rs:200-240 @ f0f4fbd1`
+
+这套机制适合承担“某个 AionUi/Core 用户已退出或被撤销后，停止其 Adapter session 与 active invocation”的本地控制面。它不能撤销 Agents 平台 token，除非 Agents 平台另行提供服务端 revoke contract。
+
+## MCP 用户隔离
+
+所有 MCP routes 都要求调用方应用认证中间件。handler 从 `CurrentUser` 取得 user ID，再把它传给配置 service；OAuth status/login/logout/authenticated 同样以 user ID 为作用域：
+
+- `/Users/xli/AionCore/crates/aionui-mcp/src/routes.rs:60-112 @ f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-mcp/src/routes.rs:285-336 @ f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-mcp/src/service.rs:50-174 @ f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-db/migrations/030_user_scope.sql:268-301 @ f0f4fbd1`
+
+因此发布版与 upstream AionCore 都已经证明 `CurrentUser.id` 可以作为本地 MCP inventory 与 credential 的隔离键。Agents MCP Adapter 不需要另造本地“当前用户 ID”；需要新增的是 AionUi cloud identity、Agents stable subject、tenant/org 与 Core user 的显式绑定。
+
+## MCP OAuth 的可复用范围
+
+`McpOAuthService` 已实现以下 OAuth client 行为：
+
+- pending login state 按 `(user_id, oauth_state)` 隔离；
+- 优先读取 RFC 8414 metadata，失败后读取 OIDC discovery；
+- Authorization Code + PKCE；
+- token expiry 前五分钟使用标准 refresh grant；
+- refresh response 若没有新 refresh token，则保留旧值。
+
+证据：
+
+- `/Users/xli/AionCore/crates/aionui-mcp/src/oauth_service.rs:65-104 @ f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-mcp/src/oauth_service.rs:164-190 @ f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-mcp/src/oauth_service.rs:272-313 @ f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-mcp/src/oauth_service.rs:432-499 @ f0f4fbd1`
+
+logout 的语义仅是删除本地记录，没有读取 discovery metadata 中的 revocation endpoint，也没有把 token 发给远端撤销：
+
+- `/Users/xli/AionCore/crates/aionui-mcp/src/oauth_service.rs:141-156 @ f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-mcp/src/routes.rs:311-323 @ f0f4fbd1`
+
+即使未来 Agents 平台提供标准 OAuth，产品需求仍需明确 provider-side revocation、账号切换时旧 token 撤销、离线过期以及远端不可达时的行为。
+
+## Token 存储安全缺口
+
+`OAuthTokenRow` 注释写明 access/refresh token 应加密，并由调用方处理加解密：
+
+- `/Users/xli/AionCore/crates/aionui-db/src/models/oauth_token.rs:4-23 @ f0f4fbd1`
+
+实际 service 在 authorization-code exchange 和 refresh 后把 token secret 原样传给 repository。`build_mcp_state` 只构造 repository 与 HTTP client，`McpOAuthService::new` 也只接收这两项，没有 encryption key 或 secret store：
+
+- `/Users/xli/AionCore/crates/aionui-mcp/src/oauth_service.rs:70-84 @ f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-mcp/src/oauth_service.rs:464-499 @ f0f4fbd1`
+- `/Users/xli/AionCore/crates/aionui-app/src/router/state.rs:522-532 @ f0f4fbd1`
+
+AionCore 其他模块已经使用 `derive_encryption_key` 与 AES-256-GCM helper 保护 provider、remote agent 和 channel credential，说明基础加密能力存在；但在 MCP OAuth 路径接入之前，不能声称 token 已加密保存。
+
+## 对 Agents MCP Adapter 的设计约束
+
+1. 使用 AionCore `CurrentUser.id` 作为本地 inventory、credential、catalog cache、task 与结果文件元数据的第一层隔离键；这个 ID 已由官网桌面账号投影产生。
+2. 单独定义 `AgentsIdentityBinding`：AionUi cloud user、Core user 与 Agents stable subject、tenant/org 的绑定不能从 username 或任一 JWT `sub` 推导。
+3. AionUi cloud refresh token 继续只由桌面主进程和系统钥匙串持有；renderer、AionCore 与 stdio Adapter 都不能取得它。Agents 调用凭证应由主进程或受信任 backend 按需提供。
+4. 不在 Core SQLite MCP OAuth repository 保存 AionUi cloud refresh token；该路径当前没有真实加密。若 Agents 采用独立 OAuth，也必须先补齐加密或改用系统凭据存储。
+5. AionUi logout 触发的 cloud revoke 与 Core external-session revoke 必须停止该用户的 Adapter process、active invocation 与缓存；是否同时撤销 Agents token 取决于 Agents 平台 contract。
+6. 不把 AionCore `/api/auth/refresh` 描述为 Agents refresh 或 OAuth refresh；两个 token 生命周期必须分别建模。
+7. AionCore MCP OAuth client 只有在 Agents 发布 discovery、PKCE、refresh、revocation 与稳定 identity claims 后，才可成为首选登录实现。
+
+## 尚未解决的问题
+
+- 官网 AionUi v2.1.52 已获得真实 cloud user，并投影为 Core `CurrentUser`；公开 AionUi tag/main 仍缺少这部分产品源码，不能以公开 renderer 的旧 `AuthContext` 代表官网安装包。
+- Agents 平台是否接受 AionUi cloud access token，或提供 token exchange/on-behalf-of；当前 Agents 仓库没有发布对应 contract。
+- 如果 Agents 不能复用 AionUi cloud identity，是否接受第二次登录带来的账号映射与退出一致性成本。
+- Agents stable subject、tenant/org、scope/audience 与账号切换 contract。
+- Agents provider-side revoke 与 Core session revoke 的事务顺序、失败重试和审计证据。
+- token 加密密钥的生命周期、系统钥匙串集成、备份/恢复与用户切换策略。
+
+## 验证说明
+
+本次刷新了 AionCore upstream refs，并只读检查官网 v2.1.52 发布物、v0.1.62 tag 与远端最新 `f0f4fbd1`；没有运行 AionCore 测试套件。已核对认证 routes、API types、session revoke hook、MCP routes/service、OAuth service、SQLite repository/model 与 composition root。`Tested` 仍只表示仓库存在相关自动化测试源码；发布物身份路径标记为 artifact verified，不代表执行了登录 E2E。

--- a/docs/architecture/research/ki-buddy-current-account-isolation.md
+++ b/docs/architecture/research/ki-buddy-current-account-isolation.md
@@ -1,0 +1,160 @@
+# Ki-Buddy 当前账号隔离能力核查
+
+## 结论
+
+当前 Ki-Buddy **不具备**按“Agents 部署 + Agents 用户”隔离本地工作历史的完整能力。
+
+固定版本的 Ki-Core 已经提供较完整的 Core User 隔离原语：conversation、message、artifact、Team、task、mailbox、自动创建的 workspace 等服务都能以 `CurrentUser.id` 作为访问边界，并且有跨用户访问测试。但 Ki-Buddy 桌面端当前以 `--local` 启动 Ki-Core，Core 会跳过认证并把每个请求都视为 `system_default_user`；桌面 renderer 同样把认证状态直接设为已登录且 `user = null`。因此这些底层原语没有在当前桌面产品中形成真实的账号边界。
+
+此外，当前实现没有 Agents `base_url` 身份维度，部分 renderer `localStorage`、内存缓存、上传文件与直接本地文件路径也没有用户命名空间。仅把 Agents 登录页和 token 接入现有客户端，并不能自动获得端到端账号隔离。
+
+## 核查基线
+
+- Ki-Buddy 工作树：`design/agents-mcp-productization`，核查时 HEAD 为 `3e35a15dd84864e666b76c7900876108cad122d4`。
+- 产品清单固定 Ki-Core 为 `ki-core-v0.1.0` / `209e6844d39bac0762c61e198c1ba3a007f9dd2e`，其上游 AionCore 基线为 `v0.1.59` / `815e61ed9bbe942339347dc1e69ddce176cded76`。证据：`/Users/xli/AionUi/ki-buddy-product.json:62-69`。
+- Ki-Core 的结论均来自固定提交 `209e6844…`，没有使用 AionPro 私有发布物替代当前 Ki-Buddy 行为。
+- 本次是静态源码和已有测试核查，没有运行两个真实 Agents 账号的桌面端切换测试；当前代码也没有可执行的桌面账号切换路径。
+
+## 能力矩阵
+
+| 范围                                 | Ki-Core 固定版本的原语                                    | Ki-Buddy 当前实际行为                                                                        | 当前是否满足“部署 + 用户”隔离 |
+| ------------------------------------ | --------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------- |
+| 桌面登录身份                         | 支持 `Local`、`WebUi`、`AionPro` 三种 identity mode       | 桌面端不认证，`user = null`，始终视为已登录                                                  | 否                            |
+| Agents 部署身份                      | 无内建 Agents deployment 维度                             | 没有 Agents `base_url` 登录或身份映射                                                        | 否                            |
+| conversation / message / artifact    | handler 将 `CurrentUser.id` 传入 service；有跨用户测试    | 所有请求的 `CurrentUser.id` 都是 `system_default_user`                                       | 否；仅有未启用的底层原语      |
+| Team / task / mailbox                | Team handler 全部使用 `CurrentUser.id`；有跨用户测试      | Team UI 回退到 `system_default_user`                                                         | 否；仅有未启用的底层原语      |
+| 自动 workspace                       | Ki-Core 能按 Core User 建立不同目录                       | 当前只会使用默认用户目录                                                                     | 否                            |
+| 用户选择的本地 workspace / 文件      | Project ref 能校验 user；部分直接路径允许访问主机文件系统 | 当前没有用户边界；同一 OS 用户选择的目录天然共享                                             | 否                            |
+| upload / 临时结果                    | 有 managed upload root 和 conversation 子目录             | upload 路径不含 user，上传 handler 不提取 `CurrentUser`                                      | 否                            |
+| renderer `localStorage` / 内存 cache | 不属于 Ki-Core                                            | 多数 key 按 project、workspace、team 或固定名称，而非账号；conversation store 是模块全局状态 | 否                            |
+| 退出 / 切换账号                      | 非 local mode 有认证与 session 原语                       | Electron 中不显示退出入口，`logout()` 仍保持 authenticated                                   | 否                            |
+
+## 1. 桌面端当前没有真实登录身份
+
+`AuthProvider.refresh()` 在 Electron 环境中直接设置 `authenticated`，同时把 `user` 设为 `null`；`login()` 直接返回成功；`logout()` 清空 `user` 后仍把状态设为 `authenticated`。证据：
+
+- `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/context/AuthContext.tsx:51-52`
+- `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/context/AuthContext.tsx:121-127`
+- `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/context/AuthContext.tsx:152-157`
+- `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/context/AuthContext.tsx:255-260`
+
+侧边栏只在非 Electron 的 WebUI 环境显示退出入口。证据：`/Users/xli/AionUi/packages/desktop/src/renderer/components/layout/Sider/index.tsx:31-38`。
+
+当前 login contract 只有 `username`、`password`、`remember`，没有 Agents `base_url` 或部署标识。证据：`/Users/xli/AionUi/packages/desktop/src/renderer/hooks/context/AuthContext.tsx:16-20`。因此开源仓库中的 WebUI 登录页不能视为当前 Ki-Buddy 桌面账号体系。
+
+固定 Ki-Core 在非 local mode 已有 session revoke hook：可以按用户断开 WebSocket，停止 Team session、conversation runtime、channel session 与 file watch，而不会在此路径删除持久历史。证据：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-app/src/router/routes.rs:192-248`。这是账号切换可复用的运行时清理原语，但当前 Ki-Buddy 桌面端没有启用它。
+
+## 2. Ki-Buddy 强制以 local mode 启动 Ki-Core
+
+桌面主进程为所有启动构造同一个应用 data directory，并通过 `BackendLifecycleManager.start()` 启动 Core。证据：
+
+- `/Users/xli/AionUi/packages/desktop/src/index.ts:195-203`
+- `/Users/xli/AionUi/packages/desktop/src/index.ts:765-775`
+- `/Users/xli/AionUi/packages/desktop/src/process/utils/utils.ts:92-102`
+
+`BackendLifecycleManager` 构造参数时固定传入 `local: true`，随后 `buildSpawnArgs()` 添加 `--local`。没有传入非 local 的 `--identity-mode`。证据：
+
+- `/Users/xli/AionUi/packages/web-host/src/backend-launcher.ts:196-215`
+- `/Users/xli/AionUi/packages/web-host/src/backend-launcher.ts:658-667`
+
+固定 Ki-Core 明确定义 `--local` 为“跳过认证并使用 `system_default_user`”；环境解析还会让 `--local` 覆盖 identity mode。证据：
+
+- `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-app/src/cli.rs:40-46`
+- `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-app/src/bootstrap/environment.rs:45-61`
+
+认证中间件在 local mode 不验证 JWT，直接注入固定的 `CurrentUser { id: "system_default_user", ... }`。证据：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-auth/src/middleware.rs:57-65,91-100`。
+
+这意味着当前 SQLite 中虽然存在 `user_id` 字段，所有桌面业务数据仍归到同一个本地默认用户；表中有列不等于产品已具备账号隔离。
+
+## 3. conversation、message、artifact 的底层原语存在，但当前未启用
+
+固定 Ki-Core 的 conversation routes 从 `CurrentUser` 取 `user.id`，并把它传给创建、列表、读取、修改、删除、message 与 artifact service：
+
+- `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-conversation/src/routes.rs:137-175`
+- `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-conversation/src/routes.rs:179-244`
+- `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-conversation/src/routes.rs:257-295`
+
+已有测试证明另一个 Core User 不能读取 owner 的 message，响应不会泄露 message id 或内容。证据：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-app/tests/message_e2e.rs:290-318`。
+
+Ki-Buddy renderer 获取历史时请求 `/api/conversations`，没有自行提供用户标识；身份完全取决于 Core 注入的 `CurrentUser`。证据：
+
+- `/Users/xli/AionUi/packages/desktop/src/common/adapter/ipcBridge.ts:1204-1233`
+- `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts:161-178`
+
+由于当前 Core 运行在 local mode，这些请求全部读取 `system_default_user` 的同一份历史。
+
+## 4. Team、task、mailbox 的底层原语存在，但当前仍是单用户
+
+固定 Ki-Core 的 Team routes 将 `CurrentUser.id` 用于 team 创建、列表、读取、删除、run state、mailbox 和 task：
+
+- `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-team/src/routes.rs:127-168`
+- `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-team/src/routes.rs:196-220`
+
+跨用户测试证明另一个用户的 Team 列表为空，并且按已知 team id 访问、发消息或操作 session 均返回 `404`。证据：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-app/tests/team_e2e.rs:478-546`。
+
+Ki-Buddy Team UI 在 `AuthContext.user` 为空时明确回退到 `system_default_user`，列表的 SWR key 也只使用这个值。证据：`/Users/xli/AionUi/packages/desktop/src/renderer/pages/team/hooks/useTeamList.ts:11-18`。创建 Team 同样回退到该用户；虽然 renderer 参数中有 `user_id`，HTTP body mapper 没有把它发送给 Core，实际 owner 仍由后端 `CurrentUser` 决定。证据：
+
+- `/Users/xli/AionUi/packages/desktop/src/renderer/pages/team/components/TeamCreateModal.tsx:95-127`
+- `/Users/xli/AionUi/packages/desktop/src/common/adapter/ipcBridge.ts:2072-2083`
+
+因此 task 与 mailbox 虽然通过 team ownership 间接隔离，当前所有 Team 仍属于同一个默认用户。
+
+## 5. workspace、文件与结果目录只有部分多用户原语
+
+固定 Ki-Core 已测试自动创建的 conversation workspace 使用 `conversations/users/{user_dir}/…`，两个 Core User 会得到不同目录。证据：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-app/tests/conversation_e2e.rs:1225-1284`。
+
+Project file ref 的 resolve 路径会使用调用者 `user_id`；但 `Upload` 只校验文件位于全局 managed upload root，`Local` 则允许访问用户通过主机文件选择器选到的任意本地文件。证据：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-project/src/chat_files.rs:65-82,83-124`。
+
+上传路径目前不具备用户命名空间：upload handler 不提取 `CurrentUser`，只传入文件名和可选 `conversation_id`；服务把文件写到系统临时目录下的 `aionui/{conversation_id|general}`。证据：
+
+- `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-file/src/routes.rs:523-537`
+- `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-file/src/service.rs:719-765`
+
+部分旧 file endpoints（metadata、read、image base64）也不提取 `CurrentUser`；不能把整个文件面视为已经按账号隔离。证据：
+
+- `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-file/src/routes.rs:187-208`
+- `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-file/src/routes.rs:540-549`
+
+用户显式选择的外部 workspace 是同一 OS 用户可访问的真实目录。即使未来 conversation 记录按账号隐藏，也不能声称这些目录内容在操作系统层面互相不可见；产品验收需要把“应用内历史不可见”和“本机文件权限隔离”分开。
+
+## 6. renderer 状态不是按账号命名
+
+已有一项安全处理：WebUI 退出时会删除所有 `preview-ui:` key，因为预览状态按 project/workspace 保存并可能含文件内容。它采用“退出时全删”，不是“按账号保留、换回账号恢复”。证据：
+
+- `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/context/AuthContext.tsx:53-80`
+- `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/Preview/context/previewScope.ts:28-52,64-74`
+
+其他持久 UI 状态也没有账号维度，例如：
+
+- 最近 workspace 使用固定 key `aionui:recent-workspaces`：`/Users/xli/AionUi/packages/desktop/src/renderer/components/workspace/recentWorkspaces.ts:7-23`。
+- Team 状态只按 `team_id`：`/Users/xli/AionUi/packages/desktop/src/renderer/pages/team/utils/teamStorage.ts:7-15`。
+- cron 未读状态使用固定 key `aionui_cron_unread`：`/Users/xli/AionUi/packages/desktop/src/renderer/pages/cron/useCronJobs.ts:274-302`。
+- conversation 分组折叠和 workspace 展开状态使用固定 key：`/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useConversations.ts:18-29,142-160`。
+
+conversation sidebar store 还是模块级单例：`conversationsState`、generating/unread sets 与初始化标记不以用户为 key，而且初始化只执行一次。证据：`/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts:128-141,272-288`。未来直接增加账号切换而不重置或重建这些 store，会在切换瞬间保留旧账号状态，并可能继续接收旧 runtime 的事件。
+
+## 7. “Agents 部署 + Agents 用户”比现有 Core User 多一个维度
+
+固定 Ki-Core 的 external user 唯一性是 `(user_type, external_user_id)`，没有 deployment/base URL 列。证据：
+
+- `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-db/migrations/030_user_scope.sql:172-173`
+- `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-db/src/repository/sqlite_user.rs:179-187`
+
+如果两个 Agents 部署都存在相同用户 ID，直接把 Agents 用户 ID 当作 `external_user_id` 会合并为同一个 Core User。产品化必须让本地身份键包含规范化 deployment identity，例如把 `(normalized_base_url, agents_user_id)` 映射成稳定且无碰撞的 Core external identity，或者扩展 Core schema；当前代码没有这层映射。
+
+Ki-Core 还包含“第一个 external user 接管 `system_default_user` 历史与文件”的升级原语。证据：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-auth/src/service.rs:25-33,62-105`。这不能不经产品决定就直接用于 Ki-Buddy：在允许多个 Agents 部署时，第一次登录哪个部署、哪个账号，不应偶然决定全部既有本地历史的归属。
+
+## 对产品设计的约束
+
+AionPro 生产版证明了这些 Core User 原语可以由桌面产品真正启用：闭源桌面模块先建立产品登录身份，再由主进程把外部用户投影为 Core 用户、换取只供本地 Core 使用的 session，并在退出或账户变化时撤销 Core session。完整发布物与 Core 证据见 [AionUi v2.1.52 产品账户与 upstream 认证实现调研](./agents-user-management-client-ui.md) 和 [AionCore 发布版与 upstream 认证、身份基础设施调研](./aioncore-auth-identity-foundations.md)。
+
+Ki-Buddy 应借鉴的是这条“产品身份 → Core 用户 → 本地资源作用域”的协作方式，不是 AionPro cloud account、私有 endpoint 或闭源代码。Ki-Buddy 的外部身份源是 Agents 平台，身份键还必须包含 Agents deployment。ADR 0003 决定近期借用当前 Core 只接受的 `Aionpro` external user type，等它无法满足 Agents 用户或权限产品需求时再通用化。
+
+在实现之前，不能把“当前已具备账号隔离”作为前提。需要显式设计并验收以下内容：
+
+1. 建立稳定的本地身份映射：`(normalized Agents base_url, stable Agents user id) -> local/Core user id`。
+2. 改变 Ki-Buddy 桌面端与 Ki-Core 的身份连接方式，停止把业务请求统一注入为 `system_default_user`；具体采用 Ki-Core external identity/session，还是由 Ki-Buddy 自己维护本地 namespace，仍需 ADR 决定。
+3. 逐类迁移或隔离 conversation、message、artifact、Team、task、mailbox、cron、assistant/provider/MCP 配置、自动 workspace、upload、结果文件和 renderer cache；不能只处理侧边栏列表。
+4. 账号切换必须有运行时屏障：停止旧账号 conversation/Team/Adapter、撤销事件订阅、清空内存 store，再载入新账号数据。
+5. ADR 0003 已将首个公开版本定义为干净安装且首次启动强制 Agents 登录；仅本地开发数据库允许首个 Agents 账号按现有 Core 行为接管 `system_default_user` 历史，不形成公开产品迁移 contract。
+6. 验收至少覆盖两个 Agents 部署中相同用户 ID、同一部署两个用户、退出后离线重启、运行中切换、崩溃恢复、直接已知资源 ID 越权访问，以及 renderer 瞬时残留。


### PR DESCRIPTION
# Pull Request

## 说明

本 PR 在开始实现前，记录 Agents MCP Adapter 的产品化设计。

主要内容：

- 在 `CONTEXT.md` 中补充 Agents 集成领域语言；
- 用 9 份主题 ADR 记录模块所有权、身份投影、catalog 发现、standalone 与 Team 执行、invocation 一致性、文件传输、安全责任和打包发布验证等难以逆转的决定；
- 增加 Agents 认证 contract、文件上传链路、AionPro 账户体验、AionCore 身份基础设施以及 Ki-Buddy 当前账号隔离能力的研究材料；
- 将具体产品行为和验收场景保留在 Spec #14 与实施 tickets 中，避免每个产品选择都生成独立 ADR。

本 PR 不改变应用运行行为。

## 关联 Issue

- 关联 #14

## 变更类型

- [ ] `fix` — Bug 修复
- [ ] `feat` — 新功能
- [ ] `perf` — 性能改进
- [ ] `refactor` — 代码重构
- [ ] Breaking change — 不兼容变更
- [x] `docs` — 文档更新

## 原子 PR 检查

- [x] 本 PR 只包含一项不可继续独立拆分的文档变更
- [x] PR 标题符合 Conventional Commit 格式：`<type>(<scope>): <subject>`

## 本地检查

- [x] 使用指定文件的 `bunx oxfmt --write` 格式化，并通过 `just push` 的 format-check
- [x] `bun run lint -- --quiet`：0 个错误；仓库存量 warnings 仍然存在
- [x] `bunx tsc --noEmit`：通过
- [x] `bun run test`：425 个 test files 通过、1 个跳过；3672 个测试通过、5 个跳过
- [x] i18n validation：通过；仓库存量缺失 key 和未知 key warnings 仍然存在
- [ ] 新增或修改的界面文案使用 i18n key：不适用，本 PR 仅修改文档

## 运行时验证

- [ ] macOS：不适用，本 PR 仅修改文档
- [ ] Windows：不适用，本 PR 仅修改文档
- [ ] Linux：不适用，本 PR 仅修改文档
- [x] 已完成变更自查

## 截图

不适用，本 PR 仅修改文档。

## 其他说明

`just push` 已在当前提交上成功完成。测试进程输出了一条仓库存量 `MaxListenersExceededWarning`，但全部测试通过，命令退出码为 0。

Spec #14 已单独更新，其 ADR 编号范围和安全决定引用与合并后的文件保持一致。
