### PR TITLE
feat(auth): complete Ki-Buddy session lifecycle

### DIFF
--- a/packages/desktop/src/common/platform/kiBuddyAuth.ts
+++ b/packages/desktop/src/common/platform/kiBuddyAuth.ts
@@ -2,4 +2,5 @@ export const KI_BUDDY_AUTH_CHANNELS = {
   getSession: 'ki-buddy-auth:get-session',
   login: 'ki-buddy-auth:login',
   logout: 'ki-buddy-auth:logout',
+  sessionInvalidated: 'ki-buddy-auth:session-invalidated',
 } as const;

--- a/packages/desktop/src/common/types/platform/kiBuddyAuth.ts
+++ b/packages/desktop/src/common/types/platform/kiBuddyAuth.ts
@@ -37,4 +37,5 @@ export type KiBuddyAuthApi = {
   getSession: () => Promise<KiBuddyAuthSession>;
   login: (request: KiBuddyLoginRequest) => Promise<KiBuddyLoginResult>;
   logout: () => Promise<KiBuddyAuthSession>;
+  onSessionInvalidated: (listener: () => void) => () => void;
 };

--- a/packages/desktop/src/preload/main.ts
+++ b/packages/desktop/src/preload/main.ts
@@ -28,6 +28,11 @@ const kiBuddyAuthCapability =
           login: (request: Parameters<KiBuddyAuthApi['login']>[0]) =>
             ipcRenderer.invoke(KI_BUDDY_AUTH_CHANNELS.login, request),
           logout: () => ipcRenderer.invoke(KI_BUDDY_AUTH_CHANNELS.logout),
+          onSessionInvalidated: (listener: () => void) => {
+            const handler = () => listener();
+            ipcRenderer.on(KI_BUDDY_AUTH_CHANNELS.sessionInvalidated, handler);
+            return () => ipcRenderer.off(KI_BUDDY_AUTH_CHANNELS.sessionInvalidated, handler);
+          },
         } satisfies KiBuddyAuthApi,
         ...(coreCsrfToken ? { kiBuddyCoreTransport: { csrfToken: coreCsrfToken } } : {}),
       }

--- a/packages/desktop/src/process/ki-buddy/AgentsAuthService.ts
+++ b/packages/desktop/src/process/ki-buddy/AgentsAuthService.ts
@@ -32,7 +32,13 @@ type AgentsAuthServiceDependencies = {
   credentialStore: AgentsCredentialStore;
   fetch: typeof fetch;
   getCoreBaseUrl: () => string;
+  onSessionInvalidated?: () => void;
+  scheduleSessionValidation?: (validate: () => Promise<void>) => () => void;
   setCoreSessionCookie: (setCookieHeader: string) => Promise<void>;
+};
+
+type AgentsSessionReference = AgentsAccountIdentity & {
+  generation: number;
 };
 
 type AgentsIdentity = {
@@ -46,6 +52,7 @@ type AgentsIdentity = {
 };
 
 type AgentsLoginBody = AgentsIdentity & { token: string };
+type AuthenticatedKiBuddySession = Extract<KiBuddyAuthSession, { status: 'authenticated' }>;
 
 type CoreSessionProjection = {
   setCookieHeader: string;
@@ -161,9 +168,14 @@ function isCoreRevokeResponse(body: unknown): boolean {
 
 /** Owns the Ki-Buddy Agents session and its projected Core user session. */
 export class AgentsAuthService {
+  private activeCredential: StoredAgentsSession | null = null;
   private activeIdentity: AgentsAccountIdentity | null = null;
   private session: KiBuddyAuthSession = { status: 'unauthenticated', user: null };
+  private sessionAbortController: AbortController | null = null;
   private restoreAttempted = false;
+  private sessionGeneration = 0;
+  private sessionValidationPendingGeneration: number | null = null;
+  private stopSessionValidation: (() => void) | null = null;
 
   /** Creates the service with explicit network, credential, and Core-session dependencies. */
   constructor(private readonly dependencies: AgentsAuthServiceDependencies) {}
@@ -215,9 +227,7 @@ export class AgentsAuthService {
     const coreProjection = await this.establishCoreSession(stored.baseUrl, identity);
     if (coreProjection.success) {
       try {
-        await this.dependencies.setCoreSessionCookie(coreProjection.projection.setCookieHeader);
-        this.activeIdentity = { baseUrl: stored.baseUrl, userId: stored.userId };
-        this.session = { status: 'authenticated', user: coreProjection.projection.user };
+        await this.activateSession(stored, coreProjection.projection);
       } catch {
         await this.deactivateIdentity({ baseUrl: stored.baseUrl, userId: stored.userId });
         this.session = { status: 'unauthenticated', user: null, cleanupRequired: true };
@@ -293,11 +303,11 @@ export class AgentsAuthService {
     }
 
     try {
-      await this.dependencies.setCoreSessionCookie(coreProjection.projection.setCookieHeader);
-      this.activeIdentity = { baseUrl, userId: agentsUser.userId };
-      this.session = { status: 'authenticated', user: coreProjection.projection.user };
-      this.restoreAttempted = true;
-      return { success: true, session: this.session };
+      const session = await this.activateSession(
+        { baseUrl, token: agentsUser.token, userId: agentsUser.userId },
+        coreProjection.projection
+      );
+      return { success: true, session };
     } catch {
       await this.deactivateIdentity(nextIdentity);
       return { success: false, code: 'serverError', shouldClearCache: true };
@@ -312,8 +322,102 @@ export class AgentsAuthService {
     return this.session;
   }
 
+  /** Sends an authenticated request only to the active Agents deployment. */
+  async fetchAuthenticated(path: string, init: RequestInit = {}): Promise<Response> {
+    const credential = this.activeCredential;
+    const generation = this.sessionGeneration;
+    if (!credential) throw new Error('No active Agents session');
+    if (!path.startsWith('/') || path.startsWith('//')) {
+      throw new Error('Authenticated Agents requests require a deployment-relative path');
+    }
+
+    const headers = new Headers(init.headers);
+    headers.set('Authorization', `Bearer ${credential.token}`);
+    const sessionSignal = this.sessionAbortController?.signal;
+    const signal =
+      init.signal && sessionSignal ? AbortSignal.any([init.signal, sessionSignal]) : (sessionSignal ?? init.signal);
+    const response = await this.dependencies.agentsFetch(`${credential.baseUrl}${path}`, {
+      ...init,
+      headers,
+      redirect: 'manual',
+      signal,
+    });
+    if (response.status === 401 || response.status === 403) {
+      await this.invalidateSessionIfCurrent({
+        baseUrl: credential.baseUrl,
+        generation,
+        userId: credential.userId,
+      });
+    }
+    return response;
+  }
+
+  /** Ends the active local session when a bound Agents request reports authentication loss. */
+  private async invalidateSessionIfCurrent(reference: AgentsSessionReference): Promise<boolean> {
+    const baseUrl = normalizeAgentsBaseUrl(reference.baseUrl);
+    const activeIdentity = this.activeIdentity;
+    if (
+      reference.generation !== this.sessionGeneration ||
+      !baseUrl ||
+      !activeIdentity ||
+      !this.isSameIdentity(activeIdentity, { baseUrl, userId: reference.userId })
+    ) {
+      return false;
+    }
+
+    const cleanupError = await this.deactivateIdentity(activeIdentity);
+    this.session = { status: 'unauthenticated', user: null, cleanupRequired: true };
+    this.dependencies.onSessionInvalidated?.();
+    if (cleanupError) throw cleanupError;
+    return true;
+  }
+
   private isSameIdentity(left: AgentsAccountIdentity, right: AgentsAccountIdentity): boolean {
     return left.baseUrl === right.baseUrl && left.userId === right.userId;
+  }
+
+  private async activateSession(
+    credential: StoredAgentsSession,
+    projection: CoreSessionProjection
+  ): Promise<AuthenticatedKiBuddySession> {
+    await this.dependencies.setCoreSessionCookie(projection.setCookieHeader);
+    this.sessionGeneration += 1;
+    this.sessionAbortController = new AbortController();
+    this.activeCredential = credential;
+    this.activeIdentity = { baseUrl: credential.baseUrl, userId: credential.userId };
+    const session: AuthenticatedKiBuddySession = { status: 'authenticated', user: projection.user };
+    this.session = session;
+    this.restoreAttempted = true;
+    this.startSessionValidation();
+    return session;
+  }
+
+  private startSessionValidation(): void {
+    this.stopSessionValidation?.();
+    this.stopSessionValidation =
+      this.dependencies.scheduleSessionValidation?.(async () => {
+        if (this.sessionValidationPendingGeneration !== null) return;
+        const credential = this.activeCredential;
+        if (!credential) return;
+        const generation = this.sessionGeneration;
+        this.sessionValidationPendingGeneration = generation;
+        try {
+          const response = await this.fetchAuthenticated('/kagent/system/user/validateToken', { method: 'POST' });
+          if (!response.ok) return;
+          const identity = parseAgentsIdentity(await readJson(response));
+          if (!identity || identity.userId !== credential.userId) {
+            await this.invalidateSessionIfCurrent({
+              baseUrl: credential.baseUrl,
+              generation,
+              userId: credential.userId,
+            });
+          }
+        } finally {
+          if (this.sessionValidationPendingGeneration === generation) {
+            this.sessionValidationPendingGeneration = null;
+          }
+        }
+      }) ?? null;
   }
 
   private async resolveExistingIdentity(): Promise<AgentsAccountIdentity | null> {
@@ -346,6 +450,12 @@ export class AgentsAuthService {
 
   private async deactivateIdentity(identity: AgentsAccountIdentity | null): Promise<unknown> {
     let cleanupError: unknown;
+    this.sessionGeneration += 1;
+    this.sessionAbortController?.abort();
+    this.sessionAbortController = null;
+    this.stopSessionValidation?.();
+    this.stopSessionValidation = null;
+    this.sessionValidationPendingGeneration = null;
     try {
       await this.dependencies.credentialStore.clear();
     } catch (error) {
@@ -358,6 +468,7 @@ export class AgentsAuthService {
         cleanupError ??= error;
       }
     }
+    this.activeCredential = null;
     this.activeIdentity = null;
     this.session = { status: 'unauthenticated', user: null };
     this.restoreAttempted = true;

--- a/packages/desktop/src/process/ki-buddy/CredentialStore.ts
+++ b/packages/desktop/src/process/ki-buddy/CredentialStore.ts
@@ -1,20 +1,23 @@
 import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
+import { normalizeAgentsBaseUrl } from '@/common/platform/ki-buddy';
 import type { AgentsCredentialStore, StoredAgentsSession } from './AgentsAuthService';
 
-const CREDENTIAL_METADATA_SCHEMA_VERSION = 1;
+const CREDENTIAL_METADATA_SCHEMA_VERSION = 2;
+const LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION = 1;
 const DEFAULT_KEYTAR_SERVICE = 'Ki-Buddy Agents';
-const KEYTAR_ACCOUNT = 'agents-session';
+const LEGACY_KEYTAR_ACCOUNT = 'agents-session';
 const STORAGE_UNAVAILABLE_MESSAGE = 'secure operating-system credential storage is unavailable';
 
 type CredentialMetadata = {
-  schemaVersion: typeof CREDENTIAL_METADATA_SCHEMA_VERSION;
+  schemaVersion: typeof CREDENTIAL_METADATA_SCHEMA_VERSION | typeof LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION;
   baseUrl: string;
   userId: string;
 };
 
 type KeytarApi = {
+  findCredentials: (service: string) => Promise<Array<{ account: string; password: string }>>;
   getPassword: (service: string, account: string) => Promise<string | null>;
   setPassword: (service: string, account: string, password: string) => Promise<void>;
   deletePassword: (service: string, account: string) => Promise<boolean>;
@@ -34,6 +37,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function isKeytarApi(value: unknown): value is KeytarApi {
   return (
     isRecord(value) &&
+    typeof value.findCredentials === 'function' &&
     typeof value.getPassword === 'function' &&
     typeof value.setPassword === 'function' &&
     typeof value.deletePassword === 'function'
@@ -72,24 +76,45 @@ function resolveStorageNamespace(userDataPath: string, configuredNamespace: stri
 
 function parseMetadata(value: unknown): CredentialMetadata | null {
   if (!isRecord(value)) return null;
+  const baseUrl = normalizeAgentsBaseUrl(value.baseUrl);
   if (
-    value.schemaVersion !== CREDENTIAL_METADATA_SCHEMA_VERSION ||
-    typeof value.baseUrl !== 'string' ||
-    value.baseUrl.trim() === '' ||
+    (value.schemaVersion !== CREDENTIAL_METADATA_SCHEMA_VERSION &&
+      value.schemaVersion !== LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION) ||
+    !baseUrl ||
+    value.baseUrl !== baseUrl ||
     typeof value.userId !== 'string' ||
-    value.userId.trim() === ''
+    value.userId.trim() === '' ||
+    value.userId !== value.userId.trim()
   ) {
     return null;
   }
   return {
-    schemaVersion: CREDENTIAL_METADATA_SCHEMA_VERSION,
-    baseUrl: value.baseUrl,
+    schemaVersion: value.schemaVersion,
+    baseUrl,
     userId: value.userId,
   };
 }
 
+function credentialAccount(metadata: CredentialMetadata): string {
+  if (metadata.schemaVersion === LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION) return LEGACY_KEYTAR_ACCOUNT;
+  const identityDigest = createHash('sha256')
+    .update(JSON.stringify([metadata.baseUrl, metadata.userId]), 'utf8')
+    .digest('hex');
+  return `agents-session-v2:${identityDigest}`;
+}
+
+function createMetadata(session: StoredAgentsSession): CredentialMetadata {
+  const baseUrl = normalizeAgentsBaseUrl(session.baseUrl);
+  const userId = session.userId.trim();
+  if (!baseUrl || baseUrl !== session.baseUrl || !userId || userId !== session.userId) {
+    throw new Error('Agents credential identity must use a normalized deployment URL and stable user identifier');
+  }
+  return { schemaVersion: CREDENTIAL_METADATA_SCHEMA_VERSION, baseUrl, userId };
+}
+
 /** Persists Agents tokens in the operating-system credential manager and non-sensitive identity metadata on disk. */
 export class KeytarCredentialStore implements AgentsCredentialStore {
+  private readonly cleanupTombstonePath: string;
   private readonly metadataPath: string;
   private readonly loadKeytar: () => Promise<KeytarApi>;
   private readonly service: string;
@@ -97,6 +122,7 @@ export class KeytarCredentialStore implements AgentsCredentialStore {
   /** Creates a credential store scoped to the current app profile and optional test namespace. */
   constructor(userDataPath: string, options: KeytarCredentialStoreOptions = {}) {
     this.metadataPath = path.join(userDataPath, 'ki-buddy', 'agents-session.json');
+    this.cleanupTombstonePath = path.join(userDataPath, 'ki-buddy', 'agents-session.cleanup-pending');
     this.loadKeytar = options.loadKeytar ?? loadSystemKeytar;
     this.service = keytarService(
       resolveStorageNamespace(userDataPath, options.storageNamespace ?? process.env.AIONUI_AUTH_STORAGE_NAMESPACE)
@@ -105,13 +131,17 @@ export class KeytarCredentialStore implements AgentsCredentialStore {
 
   /** Loads identity metadata first and resolves its token from the operating-system credential manager. */
   async load(): Promise<StoredAgentsSession | null> {
+    if (await this.hasCleanupTombstone()) {
+      await this.clear();
+      return null;
+    }
     const metadata = await this.readMetadata();
     if (!metadata) return null;
 
     const keytar = await this.requireKeytar();
     let token: string | null;
     try {
-      token = await keytar.getPassword(this.service, KEYTAR_ACCOUNT);
+      token = await keytar.getPassword(this.service, credentialAccount(metadata));
     } catch (error) {
       console.warn('[Ki-Buddy Auth] Failed to load the Agents token from keytar', error);
       throw error;
@@ -119,19 +149,27 @@ export class KeytarCredentialStore implements AgentsCredentialStore {
     if (typeof token !== 'string' || token.trim() === '') {
       return null;
     }
-    return { baseUrl: metadata.baseUrl, token, userId: metadata.userId };
+    const stored = { baseUrl: metadata.baseUrl, token, userId: metadata.userId };
+    if (metadata.schemaVersion === LEGACY_CREDENTIAL_METADATA_SCHEMA_VERSION) await this.save(stored);
+    return stored;
   }
 
   /** Saves the token before atomically writing metadata, rolling the credential back if the file write fails. */
   async save(session: StoredAgentsSession): Promise<void> {
     const keytar = await this.requireKeytar();
-    const metadata: CredentialMetadata = {
-      schemaVersion: CREDENTIAL_METADATA_SCHEMA_VERSION,
-      baseUrl: session.baseUrl,
-      userId: session.userId,
-    };
+    const metadata = createMetadata(session);
+    const nextAccount = credentialAccount(metadata);
+    const previousMetadata = await this.readMetadata();
+    const previousAccount = previousMetadata ? credentialAccount(previousMetadata) : LEGACY_KEYTAR_ACCOUNT;
+    const accountsToRemove = new Set([LEGACY_KEYTAR_ACCOUNT, previousAccount]);
+    const existingCredentials = await keytar.findCredentials(this.service);
+    existingCredentials.forEach(({ account }) => {
+      if (account.startsWith('agents-session-v2:')) accountsToRemove.add(account);
+    });
+    const previousToken =
+      previousAccount === nextAccount ? await keytar.getPassword(this.service, previousAccount) : null;
     try {
-      await keytar.setPassword(this.service, KEYTAR_ACCOUNT, session.token);
+      await keytar.setPassword(this.service, nextAccount, session.token);
     } catch (error) {
       console.warn('[Ki-Buddy Auth] Failed to save the Agents token to keytar', error);
       throw error;
@@ -146,31 +184,84 @@ export class KeytarCredentialStore implements AgentsCredentialStore {
     } catch (error) {
       console.warn('[Ki-Buddy Auth] Failed to save Agents session metadata', error);
       await unlink(temporaryPath).catch(() => {});
-      await keytar.deletePassword(this.service, KEYTAR_ACCOUNT).catch((cleanupError: unknown) => {
+      await keytar.deletePassword(this.service, nextAccount).catch((cleanupError: unknown) => {
         console.warn('[Ki-Buddy Auth] Failed to roll back the Agents token from keytar', cleanupError);
         return false;
       });
+      if (previousToken) {
+        await keytar.setPassword(this.service, previousAccount, previousToken).catch((cleanupError: unknown) => {
+          console.warn('[Ki-Buddy Auth] Failed to restore the previous Agents token in keytar', cleanupError);
+        });
+      }
       throw error;
     }
+    const removalResults = await Promise.allSettled(
+      [...accountsToRemove]
+        .filter((account) => account !== nextAccount)
+        .map((account) => keytar.deletePassword(this.service, account))
+    );
+    const failedRemoval = removalResults.find((result) => result.status === 'rejected');
+    if (failedRemoval?.status === 'rejected') {
+      console.warn('[Ki-Buddy Auth] Failed to remove a previous Agents token from keytar', failedRemoval.reason);
+      throw failedRemoval.reason;
+    }
+    await unlink(this.cleanupTombstonePath).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== 'ENOENT') throw error;
+    });
   }
 
   /** Removes both local identity metadata and the corresponding operating-system credential. */
   async clear(): Promise<void> {
-    let cleanupError: unknown;
-    await unlink(this.metadataPath).catch((error: NodeJS.ErrnoException) => {
-      if (error.code !== 'ENOENT') {
-        console.warn('[Ki-Buddy Auth] Failed to clear Agents session metadata', error);
-        cleanupError = error;
+    let credentialCleanupError: unknown;
+    let metadata: CredentialMetadata | null = null;
+    try {
+      metadata = await this.readMetadata();
+    } catch (error) {
+      console.warn('[Ki-Buddy Auth] Failed to read Agents session metadata during cleanup', error);
+    }
+    try {
+      await this.writeCleanupTombstone();
+    } catch (error) {
+      console.warn('[Ki-Buddy Auth] Failed to mark Agents credential cleanup as pending', error);
+      try {
+        await unlink(this.metadataPath);
+      } catch (metadataError) {
+        if ((metadataError as NodeJS.ErrnoException).code !== 'ENOENT') {
+          credentialCleanupError = metadataError;
+        }
       }
-    });
+    }
     try {
       const keytar = await this.requireKeytar();
-      await keytar.deletePassword(this.service, KEYTAR_ACCOUNT);
+      const accounts = new Set([LEGACY_KEYTAR_ACCOUNT]);
+      if (metadata) accounts.add(credentialAccount(metadata));
+      try {
+        const credentials = await keytar.findCredentials(this.service);
+        credentials.forEach(({ account }) => {
+          if (account.startsWith('agents-session-v2:')) accounts.add(account);
+        });
+      } catch (error) {
+        credentialCleanupError ??= error;
+      }
+      const deletionResults = await Promise.allSettled(
+        [...accounts].map((account) => keytar.deletePassword(this.service, account))
+      );
+      const failedDeletion = deletionResults.find((result) => result.status === 'rejected');
+      if (failedDeletion?.status === 'rejected') {
+        credentialCleanupError ??= failedDeletion.reason;
+      }
     } catch (error) {
       console.warn('[Ki-Buddy Auth] Failed to clear the Agents token from keytar', error);
-      cleanupError ??= error;
+      credentialCleanupError ??= error;
     }
-    if (cleanupError) throw cleanupError;
+    if (credentialCleanupError) throw credentialCleanupError;
+
+    const fileCleanupResults = await Promise.allSettled([unlink(this.metadataPath), unlink(this.cleanupTombstonePath)]);
+    const failedFileCleanup = fileCleanupResults.find(
+      (result) => result.status === 'rejected' && (result.reason as NodeJS.ErrnoException).code !== 'ENOENT'
+    );
+    const fileCleanupError = failedFileCleanup?.status === 'rejected' ? failedFileCleanup.reason : null;
+    if (fileCleanupError) throw fileCleanupError;
   }
 
   private async readMetadata(): Promise<CredentialMetadata | null> {
@@ -178,13 +269,36 @@ export class KeytarCredentialStore implements AgentsCredentialStore {
     try {
       contents = await readFile(this.metadataPath, 'utf8');
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      if (['ENOENT', 'ENOTDIR'].includes((error as NodeJS.ErrnoException).code ?? '')) return null;
       throw error;
     }
     try {
       return parseMetadata(JSON.parse(contents) as unknown);
     } catch {
       return null;
+    }
+  }
+
+  private async hasCleanupTombstone(): Promise<boolean> {
+    try {
+      await readFile(this.cleanupTombstonePath, 'utf8');
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+      throw error;
+    }
+  }
+
+  private async writeCleanupTombstone(): Promise<void> {
+    const directory = path.dirname(this.cleanupTombstonePath);
+    const temporaryPath = `${this.cleanupTombstonePath}.${process.pid}.tmp`;
+    try {
+      await mkdir(directory, { recursive: true });
+      await writeFile(temporaryPath, JSON.stringify({ schemaVersion: 1 }), { mode: 0o600 });
+      await rename(temporaryPath, this.cleanupTombstonePath);
+    } catch (error) {
+      await unlink(temporaryPath).catch(() => {});
+      throw error;
     }
   }
 

--- a/packages/desktop/src/process/ki-buddy/authBridge.ts
+++ b/packages/desktop/src/process/ki-buddy/authBridge.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain, session } from 'electron';
+import { app, BrowserWindow, ipcMain, session } from 'electron';
 import { KI_BUDDY_AUTH_CHANNELS } from '@/common/platform/kiBuddyAuth';
 import type { KiBuddyLoginRequest, KiBuddyLoginResult } from '@/common/types/platform/kiBuddyAuth';
 import { AgentsAuthService } from './AgentsAuthService';
@@ -14,6 +14,7 @@ type RegisterKiBuddyAuthOptions = {
 
 const CORE_SESSION_COOKIE = 'aionui-session';
 const CORE_CSRF_COOKIE = 'aionui-csrf-token';
+const SESSION_VALIDATION_INTERVAL_MS = 60_000;
 
 function isLoginRequest(value: unknown): value is KiBuddyLoginRequest {
   if (typeof value !== 'object' || value === null) return false;
@@ -21,6 +22,20 @@ function isLoginRequest(value: unknown): value is KiBuddyLoginRequest {
   return (
     typeof record.baseUrl === 'string' && typeof record.loginName === 'string' && typeof record.password === 'string'
   );
+}
+
+function notifySessionInvalidated(): void {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) window.webContents.send(KI_BUDDY_AUTH_CHANNELS.sessionInvalidated);
+  }
+}
+
+function scheduleSessionValidation(validate: () => Promise<void>): () => void {
+  const timer = setInterval(() => {
+    void validate().catch(() => console.warn('[Ki-Buddy Auth] Periodic token validation failed'));
+  }, SESSION_VALIDATION_INTERVAL_MS);
+  timer.unref();
+  return () => clearInterval(timer);
 }
 
 async function setCoreSessionCookie(
@@ -86,6 +101,8 @@ export function registerKiBuddyAuthBridge(options: RegisterKiBuddyAuthOptions): 
     credentialStore: new KeytarCredentialStore(app.getPath('userData')),
     fetch,
     getCoreBaseUrl: options.getCoreBaseUrl,
+    onSessionInvalidated: notifySessionInvalidated,
+    scheduleSessionValidation,
     setCoreSessionCookie: (header) => setCoreSessionCookie(options.getCoreBaseUrl(), options.coreTransport, header),
   });
 

--- a/packages/desktop/src/process/ki-buddy/index.ts
+++ b/packages/desktop/src/process/ki-buddy/index.ts
@@ -11,6 +11,7 @@ import {
   resolveLanguagePreference,
 } from '@/common/platform/ki-buddy';
 import { registerKiBuddyAuthBridge } from './authBridge';
+import type { AgentsAuthService } from './AgentsAuthService';
 import { createKiBuddyCoreAuthOptions, type KiBuddyCoreAuthOptions } from './bootstrap';
 import { resolveKiBuddyCoreDataPath } from './coreDataPath';
 import { KiBuddyMainCoreTransport } from './KiBuddyMainCoreTransport';
@@ -20,7 +21,7 @@ export type KiBuddyRuntime = {
   coreAuthOptions: KiBuddyCoreAuthOptions;
   coreTransportChannel: typeof KI_BUDDY_CORE_TRANSPORT_CHANNEL;
   productIdentity: typeof KI_BUDDY_PRODUCT_RUNTIME;
-  registerAuthBridge: (getCoreBaseUrl: () => string) => void;
+  registerAuthBridge: (getCoreBaseUrl: () => string) => AgentsAuthService;
   resolveDataPath: (dataPath: string) => string;
   resolveLanguage: (savedLanguage: string | null | undefined, systemLanguage: string | null) => SupportedLanguage;
 };
@@ -46,13 +47,12 @@ export function createKiBuddyRuntime(options: {
     coreAuthOptions,
     coreTransportChannel: KI_BUDDY_CORE_TRANSPORT_CHANNEL,
     productIdentity: KI_BUDDY_PRODUCT_RUNTIME,
-    registerAuthBridge: (getCoreBaseUrl) => {
+    registerAuthBridge: (getCoreBaseUrl) =>
       registerKiBuddyAuthBridge({
         bootstrapSecret: coreAuthOptions.bootstrapSecret,
         coreTransport,
         getCoreBaseUrl,
-      });
-    },
+      }),
     resolveDataPath: resolveKiBuddyCoreDataPath,
     resolveLanguage: (savedLanguage, systemLanguage) =>
       resolveLanguagePreference({

--- a/packages/desktop/src/renderer/pages/ki-buddy/Auth/KiBuddyAuthProvider.tsx
+++ b/packages/desktop/src/renderer/pages/ki-buddy/Auth/KiBuddyAuthProvider.tsx
@@ -40,7 +40,7 @@ const KiBuddyAuthContext = createContext<KiBuddyAuthContextValue | undefined>(un
 const KiBuddyAuthContextBridge: React.FC<
   React.PropsWithChildren<{ adapter: KiBuddyAuthAdapter; profile: KiBuddyAgentsProfile | null }>
 > = ({ adapter, children, profile }) => {
-  const { login: authenticate, user } = useAuth();
+  const { login: authenticate, refresh, user } = useAuth();
   const accountSwitchBarrier = useMemo(() => createKiBuddyAccountSwitchBarrier(() => window.location.reload()), []);
   const login = useCallback(
     (params: KiBuddyLoginParams) => adapter.login(params, authenticate),
@@ -49,6 +49,7 @@ const KiBuddyAuthContextBridge: React.FC<
   const value = useMemo(() => ({ login, profile }), [login, profile]);
 
   useEffect(() => accountSwitchBarrier.observe(user?.id ?? null), [accountSwitchBarrier, user?.id]);
+  useEffect(() => adapter.subscribeToSessionInvalidation(() => void refresh()), [adapter, refresh]);
 
   return <KiBuddyAuthContext.Provider value={value}>{children}</KiBuddyAuthContext.Provider>;
 };

--- a/packages/desktop/src/renderer/pages/ki-buddy/Auth/kiBuddyAuthAdapter.ts
+++ b/packages/desktop/src/renderer/pages/ki-buddy/Auth/kiBuddyAuthAdapter.ts
@@ -29,6 +29,7 @@ export type KiBuddyAuthAdapter = {
     params: KiBuddyLoginParams,
     authenticate: AuthHandlers<string>['login']
   ) => Promise<KiBuddyRendererLoginResult>;
+  subscribeToSessionInvalidation: (listener: () => void) => () => void;
 };
 
 /** Creates the renderer adapter for Ki-Buddy's main-process owned authentication. */
@@ -129,6 +130,10 @@ export function createKiBuddyAuthAdapter(options: {
           }
         },
       };
+    },
+    subscribeToSessionInvalidation: (listener) => {
+      const subscribe = getKiBuddyRendererRuntime()?.authApi.onSessionInvalidated;
+      return typeof subscribe === 'function' ? subscribe(listener) : () => {};
     },
   };
 }

--- a/tests/e2e/features/remote/ki-buddy-auth.e2e.ts
+++ b/tests/e2e/features/remote/ki-buddy-auth.e2e.ts
@@ -1,5 +1,6 @@
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
+import os from 'node:os';
 import { test, expect } from '../../fixtures';
 
 type CoreCurrentUserResponse = {
@@ -54,11 +55,18 @@ const COMMON_USER_FIELDS = {
   roles: [{ name: 'member' }],
 };
 
-async function startFakeAgentsServer(options: { invalidLoginAttempts?: number } = {}): Promise<{
+async function startFakeAgentsServer(
+  options: { invalidLoginAttempts?: number; repeatFirstUser?: boolean } = {}
+): Promise<{
   baseUrl: string;
   close: () => Promise<void>;
+  expireToken: (token: string) => void;
+  getValidationRequestCount: () => number;
+  restoreToken: (token: string) => void;
 }> {
+  const expiredTokens = new Set<string>();
   let loginAttempts = 0;
+  let validationRequestCount = 0;
   const invalidLoginAttempts = options.invalidLoginAttempts ?? 0;
   const server = http.createServer((request, response) => {
     const isLogin = request.method === 'POST' && request.url === '/kagent/login';
@@ -75,11 +83,17 @@ async function startFakeAgentsServer(options: { invalidLoginAttempts?: number } 
       return;
     }
 
+    if (isValidation) validationRequestCount += 1;
     const user = isLogin
-      ? AGENTS_USERS[Math.min(loginAttempts - invalidLoginAttempts - 1, 1)]
+      ? AGENTS_USERS[options.repeatFirstUser ? 0 : Math.min(loginAttempts - invalidLoginAttempts - 1, 1)]
       : findUserByToken(request.headers.authorization);
     if (!user) {
       response.writeHead(401).end();
+      return;
+    }
+    if (isValidation && expiredTokens.has(user.token)) {
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify({ errorCode: 401, responseBody: null }));
       return;
     }
 
@@ -103,6 +117,9 @@ async function startFakeAgentsServer(options: { invalidLoginAttempts?: number } 
   return {
     baseUrl: `http://127.0.0.1:${port}`,
     close: () => new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve()))),
+    expireToken: (token) => expiredTokens.add(token),
+    getValidationRequestCount: () => validationRequestCount,
+    restoreToken: (token) => expiredTokens.delete(token),
   };
 }
 
@@ -123,9 +140,87 @@ async function readCoreCurrentUser(page: import('@playwright/test').Page): Promi
   });
 }
 
+async function createCoreConversation(page: import('@playwright/test').Page, name: string): Promise<string> {
+  return page.evaluate(
+    async ({ conversationName, workspace }) => {
+      const port = (window as Window & { __backendPort?: number }).__backendPort;
+      if (!port) throw new Error('Ki-Core backend port is unavailable in the renderer');
+      const baseUrl = `http://127.0.0.1:${port}`;
+      const assistantsResponse = await fetch(`${baseUrl}/api/assistants`, { credentials: 'include' });
+      if (!assistantsResponse.ok) {
+        throw new Error(`GET /api/assistants failed with status ${assistantsResponse.status}`);
+      }
+      const assistantsBody = (await assistantsResponse.json()) as { data?: Array<{ id?: string }> };
+      const assistantId = assistantsBody.data?.find((assistant) => assistant.id)?.id;
+      if (!assistantId) throw new Error('Ki-Buddy E2E requires at least one Core assistant');
+      const csrfToken = window.electronAPI?.kiBuddyCoreTransport?.csrfToken;
+      if (!csrfToken) throw new Error('Ki-Buddy Core CSRF token is unavailable in the renderer');
+
+      const response = await fetch(`${baseUrl}/api/conversations`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', 'x-csrf-token': csrfToken },
+        body: JSON.stringify({
+          name: conversationName,
+          assistant: { id: assistantId },
+          extra: { workspace, custom_workspace: true, session_mode: 'default' },
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`POST /api/conversations failed with status ${response.status}: ${await response.text()}`);
+      }
+      const body = (await response.json()) as { data?: { id?: string } };
+      if (!body.data?.id) throw new Error('POST /api/conversations returned no conversation id');
+      return body.data.id;
+    },
+    { conversationName: name, workspace: os.tmpdir() }
+  );
+}
+
+async function readCoreConversationStatus(
+  page: import('@playwright/test').Page,
+  conversationId: string
+): Promise<number> {
+  return page.evaluate(async (id) => {
+    const port = (window as Window & { __backendPort?: number }).__backendPort;
+    if (!port) throw new Error('Ki-Core backend port is unavailable in the renderer');
+    const response = await fetch(`http://127.0.0.1:${port}/api/conversations/${encodeURIComponent(id)}`, {
+      credentials: 'include',
+    });
+    return response.status;
+  }, conversationId);
+}
+
+async function deleteCoreConversation(page: import('@playwright/test').Page, conversationId: string): Promise<void> {
+  await page.evaluate(async (id) => {
+    const port = (window as Window & { __backendPort?: number }).__backendPort;
+    if (!port) return;
+    const csrfToken = window.electronAPI?.kiBuddyCoreTransport?.csrfToken;
+    if (!csrfToken) return;
+    await fetch(`http://127.0.0.1:${port}/api/conversations/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+      credentials: 'include',
+      headers: { 'x-csrf-token': csrfToken },
+    }).catch(() => undefined);
+  }, conversationId);
+}
+
+async function waitForLoginSuccess(page: import('@playwright/test').Page): Promise<void> {
+  try {
+    await expect(page.locator('input[autocomplete="username"]')).toHaveCount(0, { timeout: 30_000 });
+  } catch (error) {
+    const session = await page.evaluate(() => window.electronAPI?.kiBuddyAuth?.getSession()).catch(() => null);
+    const visibleText = (await page.locator('body').innerText()).slice(0, 2_000);
+    throw new Error(
+      `Ki-Buddy login did not leave the login form. Session: ${JSON.stringify(session)}. Visible text: ${visibleText}`,
+      { cause: error }
+    );
+  }
+}
+
 test.describe('Ki-Buddy packaged Agents authentication', () => {
   test.skip(process.env.E2E_PACKAGED !== '1', 'This acceptance seam requires the packaged Electron application.');
-  test.setTimeout(120_000);
+  test.setTimeout(240_000);
 
   test('rejects invalid Agents credentials without creating a Core user', async ({ page }) => {
     const agents = await startFakeAgentsServer({ invalidLoginAttempts: 1 });
@@ -274,6 +369,68 @@ test.describe('Ki-Buddy packaged Agents authentication', () => {
         });
       await expect(page.locator('input[autocomplete="username"]')).toHaveCount(0);
     } finally {
+      await page.evaluate(() => window.electronAPI?.kiBuddyAuth?.logout()).catch(() => undefined);
+      await agents.close();
+    }
+  });
+
+  test('ends the active session after trusted token expiry and preserves Core history', async ({
+    isolatedPackagedPage: page,
+  }) => {
+    const agents = await startFakeAgentsServer({ repeatFirstUser: true });
+    let conversationId: string | null = null;
+
+    try {
+      await page
+        .locator('#ki-buddy-opening-guide-title, input[autocomplete="username"]')
+        .first()
+        .waitFor({ state: 'visible', timeout: 30_000 });
+      const skipGuide = page.getByRole('button', { name: /^(跳过|Skip)$/i });
+      if (await skipGuide.isVisible().catch(() => false)) await skipGuide.click();
+      await page.locator('input[autocomplete="username"]').waitFor({ state: 'visible', timeout: 30_000 });
+      await fillLoginForm(page, { baseUrl: agents.baseUrl, username: AGENTS_USER_A.userName });
+      await page.getByRole('button', { name: /^(登录|Sign In)$/i }).click();
+
+      await waitForLoginSuccess(page);
+      const initialCoreUser = await readCoreCurrentUser(page);
+      expect(initialCoreUser).toMatchObject({
+        status: 200,
+        body: { user: { id: expect.any(String), username: AGENTS_USER_A.userName } },
+      });
+      conversationId = await createCoreConversation(page, `E2E trusted auth expiry ${Date.now()}`);
+      expect(await readCoreConversationStatus(page, conversationId)).toBe(200);
+
+      const validationCountBeforeExpiry = agents.getValidationRequestCount();
+      agents.expireToken(AGENTS_USER_A.token);
+      await expect
+        .poll(() => agents.getValidationRequestCount(), {
+          timeout: 75_000,
+          message: 'Waiting for the packaged main process to validate the active Agents token',
+        })
+        .toBeGreaterThan(validationCountBeforeExpiry);
+
+      await page.locator('input[autocomplete="username"]').waitFor({ state: 'visible', timeout: 30_000 });
+      expect((await readCoreCurrentUser(page)).status).toBe(401);
+      expect(await readCoreConversationStatus(page, conversationId)).toBe(401);
+
+      agents.restoreToken(AGENTS_USER_A.token);
+      await fillLoginForm(page, { baseUrl: agents.baseUrl, username: AGENTS_USER_A.userName });
+      await page.getByRole('button', { name: /^(登录|Sign In)$/i }).click();
+
+      await waitForLoginSuccess(page);
+      expect(await readCoreCurrentUser(page)).toMatchObject({
+        status: 200,
+        body: {
+          user: {
+            id: initialCoreUser.body.user?.id,
+            username: AGENTS_USER_A.userName,
+          },
+        },
+      });
+      expect(await readCoreConversationStatus(page, conversationId)).toBe(200);
+      await expect(page.locator(`#c-${conversationId}`)).toBeVisible({ timeout: 30_000 });
+    } finally {
+      if (conversationId) await deleteCoreConversation(page, conversationId).catch(() => undefined);
       await page.evaluate(() => window.electronAPI?.kiBuddyAuth?.logout()).catch(() => undefined);
       await agents.close();
     }

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -20,6 +20,7 @@ import os from 'os';
 
 type Fixtures = {
   electronApp: ElectronApplication;
+  isolatedPackagedPage: Page;
   page: Page;
 };
 
@@ -202,18 +203,26 @@ function shouldUsePackagedMode(): boolean {
   return !!process.env.CI;
 }
 
+function createE2EEnvironment(userDataDir: string, stateFile: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    AIONUI_EXTENSIONS_PATH:
+      process.env.AIONUI_EXTENSIONS_PATH || path.join(path.resolve(__dirname, '../..'), 'examples'),
+    AIONUI_EXTENSION_STATES_FILE: process.env.AIONUI_EXTENSION_STATES_FILE || stateFile,
+    AIONUI_DISABLE_AUTO_UPDATE: '1',
+    AIONUI_DISABLE_DEVTOOLS: '1',
+    AIONUI_E2E_TEST: '1',
+    AIONUI_E2E_USER_DATA_DIR: userDataDir,
+    AIONUI_CDP_PORT: process.env.AIONUI_CDP_PORT || '9230',
+  };
+}
+
 async function launchApp(): Promise<ElectronApplication> {
   const projectRoot = path.resolve(__dirname, '../..');
   const usePackaged = shouldUsePackagedMode();
 
   const commonEnv = {
-    ...process.env,
-    AIONUI_EXTENSIONS_PATH: process.env.AIONUI_EXTENSIONS_PATH || path.join(projectRoot, 'examples'),
-    AIONUI_EXTENSION_STATES_FILE: process.env.AIONUI_EXTENSION_STATES_FILE || e2eStateFile,
-    AIONUI_DISABLE_AUTO_UPDATE: '1',
-    AIONUI_DISABLE_DEVTOOLS: '1',
-    AIONUI_E2E_TEST: '1',
-    AIONUI_E2E_USER_DATA_DIR: process.env.AIONUI_E2E_USER_DATA_DIR || e2eUserDataDir,
+    ...createE2EEnvironment(process.env.AIONUI_E2E_USER_DATA_DIR || e2eUserDataDir, e2eStateFile),
     /**
      * 以前这里设 '0' 把 CDP 整个关掉，因为那时开 CDP 等于开 Chromium 的应用级
      * remote-debugging-port —— 无认证地暴露每个 WebContents，还会在多实例间抢端口，
@@ -302,6 +311,42 @@ export const test = base.extend<Fixtures>({
     }
 
     await use(app);
+  },
+
+  // Process-lifecycle acceptance scenarios use their own packaged app and
+  // disposable userData, matching the repository's existing isolated-Electron
+  // suites. This keeps timers, Core memory, credentials, and database state
+  // independent from the shared singleton used by ordinary E2E tests.
+  // eslint-disable-next-line no-empty-pattern
+  isolatedPackagedPage: async ({}, use) => {
+    const packaged = resolvePackagedApp();
+    if (!packaged) {
+      throw new Error(
+        'Isolated packaged E2E: could not find packaged app under out/. ' +
+          'Run `node scripts/build-with-builder.js auto --<platform> --pack-only` first.'
+      );
+    }
+    const sandboxDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aionui-e2e-isolated-packaged-'));
+    const launchArgs = process.platform === 'linux' && process.env.CI ? ['--no-sandbox'] : [];
+    const isolatedApp = await electron.launch({
+      executablePath: packaged.executablePath,
+      args: launchArgs,
+      cwd: packaged.cwd,
+      env: {
+        ...createE2EEnvironment(sandboxDir, path.join(sandboxDir, 'extension-states.json')),
+        AIONUI_CDP_PORT: '0',
+        AIONUI_EXTENSION_STATES_FILE: path.join(sandboxDir, 'extension-states.json'),
+        NODE_ENV: 'production',
+      },
+      timeout: 60_000,
+    });
+
+    try {
+      await use(await resolveMainWindow(isolatedApp));
+    } finally {
+      await isolatedApp.close().catch(() => undefined);
+      fs.rmSync(sandboxDir, { recursive: true, force: true });
+    }
   },
 
   page: async ({ electronApp }, use, testInfo: TestInfo) => {

--- a/tests/unit/bootstrap/recoverCorruptedDatabasePreload.test.ts
+++ b/tests/unit/bootstrap/recoverCorruptedDatabasePreload.test.ts
@@ -67,6 +67,7 @@ describe('recover corrupted database preload bridge', () => {
             getSession: () => Promise<unknown>;
             login: (request: { baseUrl: string; loginName: string; password: string }) => Promise<unknown>;
             logout: () => Promise<unknown>;
+            onSessionInvalidated: (listener: () => void) => () => void;
           };
           kiBuddyCoreTransport?: { csrfToken: string };
         }
@@ -80,10 +81,17 @@ describe('recover corrupted database preload bridge', () => {
     await electronApi?.kiBuddyAuth?.getSession();
     await electronApi?.kiBuddyAuth?.login(request);
     await electronApi?.kiBuddyAuth?.logout();
+    const invalidated = vi.fn();
+    const unsubscribe = electronApi?.kiBuddyAuth?.onSessionInvalidated(invalidated);
+    const subscription = on.mock.calls.find(([channel]) => channel === 'ki-buddy-auth:session-invalidated');
+    subscription?.[1]();
+    unsubscribe?.();
 
     expect(invoke).toHaveBeenCalledWith('ki-buddy-auth:get-session');
     expect(invoke).toHaveBeenCalledWith('ki-buddy-auth:login', request);
     expect(invoke).toHaveBeenCalledWith('ki-buddy-auth:logout');
+    expect(invalidated).toHaveBeenCalledOnce();
+    expect(off).toHaveBeenCalledWith('ki-buddy-auth:session-invalidated', subscription?.[1]);
     expect(electronApi?.kiBuddyCoreTransport).toEqual({ csrfToken: 'core-csrf-token' });
   });
 

--- a/tests/unit/process/ki-buddy/AgentsAuthService.test.ts
+++ b/tests/unit/process/ki-buddy/AgentsAuthService.test.ts
@@ -14,6 +14,7 @@ const saveSessionMock = vi.fn();
 const clearSessionMock = vi.fn();
 const setCoreCookieMock = vi.fn();
 const clearCoreCookieMock = vi.fn();
+const sessionInvalidatedMock = vi.fn();
 
 describe('AgentsAuthService', () => {
   beforeEach(() => {
@@ -23,6 +24,7 @@ describe('AgentsAuthService', () => {
     clearSessionMock.mockReset();
     setCoreCookieMock.mockReset();
     clearCoreCookieMock.mockReset();
+    sessionInvalidatedMock.mockReset();
   });
 
   it('projects the verified Agents identity and returns the resulting Core user', async () => {
@@ -148,6 +150,80 @@ describe('AgentsAuthService', () => {
       userId: 'agents-user-42',
     });
     expect(setCoreCookieMock).toHaveBeenCalledWith('aionui_session=core-token; HttpOnly; Path=/; SameSite=Lax');
+  });
+
+  it('projects the same Agents identity back to the same Core user after local logout and login', async () => {
+    const agentsLoginResponse = () =>
+      new Response(
+        JSON.stringify({
+          errorCode: 0,
+          responseBody: {
+            uuid: 'agents-user-42',
+            userName: 'agents-user@example.com',
+            token: 'agents-token',
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    const coreProjectionResponse = () =>
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            user_id: 'core-user-42',
+            user_type: 'aionpro',
+            external_user_id: 'opaque-external-id',
+            session_generation: 1,
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    const coreSessionResponse = () =>
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: { user: { id: 'core-user-42', username: 'agents-user@example.com' }, session_generation: 1 },
+        }),
+        { status: 200, headers: { 'set-cookie': 'aionui-session=core-token; HttpOnly' } }
+      );
+    fetchMock
+      .mockResolvedValueOnce(agentsLoginResponse())
+      .mockResolvedValueOnce(coreProjectionResponse())
+      .mockResolvedValueOnce(coreSessionResponse())
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true, data: { user_id: 'core-user-42', session_generation: 2 } }), {
+          status: 200,
+        })
+      )
+      .mockResolvedValueOnce(agentsLoginResponse())
+      .mockResolvedValueOnce(coreProjectionResponse())
+      .mockResolvedValueOnce(coreSessionResponse());
+    const service = new AgentsAuthService({
+      agentsFetch: fetchMock,
+      bootstrapSecret: 'bootstrap-secret',
+      clearCoreSession: clearCoreCookieMock,
+      credentialStore: {
+        load: loadSessionMock,
+        save: saveSessionMock,
+        clear: clearSessionMock,
+      },
+      fetch: fetchMock,
+      getCoreBaseUrl: () => 'http://127.0.0.1:39123',
+      setCoreSessionCookie: setCoreCookieMock,
+    });
+    const credentials = {
+      baseUrl: 'https://agents.example.com',
+      loginName: 'agents-user@example.com',
+      password: 'password',
+    };
+
+    const firstLogin = await service.login(credentials);
+    await service.logout();
+    const secondLogin = await service.login(credentials);
+
+    expect(firstLogin).toMatchObject({ success: true, session: { user: { id: 'core-user-42' } } });
+    expect(secondLogin).toMatchObject({ success: true, session: { user: { id: 'core-user-42' } } });
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(fetchMock.mock.calls[5]?.[0]);
   });
 
   it('validates a saved Agents token before restoring its Core user', async () => {
@@ -786,6 +862,397 @@ describe('AgentsAuthService', () => {
       body: expect.stringContaining('agents-v1-'),
     });
     expect(fetchMock.mock.calls[0]?.[0]).not.toContain('agents.example.com');
+  });
+
+  it.each([
+    ['HTTP authentication rejection', () => new Response(null, { status: 401 })],
+    [
+      'Agents error envelope',
+      () =>
+        new Response(JSON.stringify({ errorCode: 401, responseBody: null }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ],
+    [
+      'malformed success envelope',
+      () =>
+        new Response(JSON.stringify({ errorCode: 0, responseBody: null }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ],
+    [
+      'different Agents identity',
+      () =>
+        new Response(
+          JSON.stringify({
+            errorCode: 0,
+            responseBody: { uuid: 'different-agents-user', userName: 'other@example.com' },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        ),
+    ],
+  ])('ends the active local session after %s during token validation', async (_scenario, validationResponse) => {
+    let validateSession: (() => Promise<void>) | undefined;
+    const stopValidation = vi.fn();
+    loadSessionMock.mockResolvedValue({
+      baseUrl: 'https://agents.example.com',
+      token: 'saved-agents-token',
+      userId: 'agents-user-42',
+    });
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            errorCode: 0,
+            responseBody: { uuid: 'agents-user-42', userName: 'agents-user@example.com' },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              user_id: 'core-user-42',
+              user_type: 'aionpro',
+              external_user_id: 'opaque-external-id',
+              session_generation: 1,
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: { user: { id: 'core-user-42', username: 'agents-user@example.com' }, session_generation: 1 },
+          }),
+          { status: 200, headers: { 'set-cookie': 'aionui-session=restored-core-token; HttpOnly' } }
+        )
+      )
+      .mockResolvedValueOnce(validationResponse())
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true, data: { user_id: 'core-user-42', session_generation: 2 } }), {
+          status: 200,
+        })
+      );
+    const service = new AgentsAuthService({
+      agentsFetch: fetchMock,
+      bootstrapSecret: 'bootstrap-secret',
+      clearCoreSession: clearCoreCookieMock,
+      credentialStore: {
+        load: loadSessionMock,
+        save: saveSessionMock,
+        clear: clearSessionMock,
+      },
+      fetch: fetchMock,
+      getCoreBaseUrl: () => 'http://127.0.0.1:39123',
+      onSessionInvalidated: sessionInvalidatedMock,
+      scheduleSessionValidation: (validate) => {
+        validateSession = validate;
+        return stopValidation;
+      },
+      setCoreSessionCookie: setCoreCookieMock,
+    });
+    await service.getSession();
+
+    await validateSession?.();
+
+    expect(clearSessionMock).toHaveBeenCalledOnce();
+    expect(clearCoreCookieMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[3]?.[0]).toBe('https://agents.example.com/kagent/system/user/validateToken');
+    expect(fetchMock.mock.calls[3]?.[1]).toMatchObject({ method: 'POST', redirect: 'manual' });
+    const validationHeaders = new Headers(fetchMock.mock.calls[3]?.[1]?.headers);
+    expect(validationHeaders.get('Authorization')).toBe('Bearer saved-agents-token');
+    expect(fetchMock.mock.calls[4]?.[0]).toBe('http://127.0.0.1:39123/api/auth/internal/external-sessions/revoke');
+    expect(sessionInvalidatedMock).toHaveBeenCalledOnce();
+    expect(stopValidation).toHaveBeenCalledOnce();
+    await expect(service.getSession()).resolves.toEqual({
+      status: 'unauthenticated',
+      user: null,
+      cleanupRequired: true,
+    });
+  });
+
+  it.each([
+    ['server failure', () => Promise.resolve(new Response(null, { status: 503 }))],
+    ['network failure', () => Promise.reject(new Error('Agents deployment unavailable'))],
+  ])('keeps the active local session after a token validation %s', async (_scenario, validationRequest) => {
+    let validateSession: (() => Promise<void>) | undefined;
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            errorCode: 0,
+            responseBody: {
+              uuid: 'agents-user-42',
+              userName: 'agents-user@example.com',
+              token: 'agents-token',
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              user_id: 'core-user-42',
+              user_type: 'aionpro',
+              external_user_id: 'opaque-external-id',
+              session_generation: 1,
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: { user: { id: 'core-user-42', username: 'agents-user@example.com' }, session_generation: 1 },
+          }),
+          { status: 200, headers: { 'set-cookie': 'aionui-session=core-token; HttpOnly' } }
+        )
+      )
+      .mockImplementationOnce(validationRequest);
+    const service = new AgentsAuthService({
+      agentsFetch: fetchMock,
+      bootstrapSecret: 'bootstrap-secret',
+      clearCoreSession: clearCoreCookieMock,
+      credentialStore: {
+        load: loadSessionMock,
+        save: saveSessionMock,
+        clear: clearSessionMock,
+      },
+      fetch: fetchMock,
+      getCoreBaseUrl: () => 'http://127.0.0.1:39123',
+      onSessionInvalidated: sessionInvalidatedMock,
+      scheduleSessionValidation: (validate) => {
+        validateSession = validate;
+        return vi.fn();
+      },
+      setCoreSessionCookie: setCoreCookieMock,
+    });
+    await service.login({
+      baseUrl: 'https://agents.example.com',
+      loginName: 'agents-user@example.com',
+      password: 'secret',
+    });
+
+    await validateSession?.().catch(() => undefined);
+
+    await expect(service.getSession()).resolves.toMatchObject({
+      status: 'authenticated',
+      user: { id: 'core-user-42' },
+    });
+    expect(clearSessionMock).not.toHaveBeenCalled();
+    expect(sessionInvalidatedMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores a delayed authentication failure from the session that was logged out', async () => {
+    let validateSession: (() => Promise<void>) | undefined;
+    let oldValidationSignal: AbortSignal | null | undefined;
+    let resolveOldValidation: ((response: Response) => void) | undefined;
+    const oldValidation = new Promise<Response>((resolve) => {
+      resolveOldValidation = resolve;
+    });
+    loadSessionMock.mockResolvedValue({
+      baseUrl: 'https://agents.example.com',
+      token: 'saved-agents-token',
+      userId: 'agents-user-42',
+    });
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            errorCode: 0,
+            responseBody: { uuid: 'agents-user-42', userName: 'agents-user@example.com' },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              user_id: 'core-user-42',
+              user_type: 'aionpro',
+              external_user_id: 'opaque-external-id',
+              session_generation: 1,
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: { user: { id: 'core-user-42', username: 'agents-user@example.com' }, session_generation: 1 },
+          }),
+          { status: 200, headers: { 'set-cookie': 'aionui-session=restored-core-token; HttpOnly' } }
+        )
+      )
+      .mockImplementationOnce((_input, init) => {
+        oldValidationSignal = init?.signal;
+        return oldValidation;
+      })
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true, data: { user_id: 'core-user-42', session_generation: 2 } }), {
+          status: 200,
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            errorCode: 0,
+            responseBody: {
+              uuid: 'agents-user-42',
+              userName: 'agents-user@example.com',
+              token: 'new-agents-token',
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              user_id: 'core-user-42',
+              user_type: 'aionpro',
+              external_user_id: 'opaque-external-id',
+              session_generation: 3,
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: { user: { id: 'core-user-42', username: 'agents-user@example.com' }, session_generation: 3 },
+          }),
+          { status: 200, headers: { 'set-cookie': 'aionui-session=new-core-token; HttpOnly' } }
+        )
+      );
+    const service = new AgentsAuthService({
+      agentsFetch: fetchMock,
+      bootstrapSecret: 'bootstrap-secret',
+      clearCoreSession: clearCoreCookieMock,
+      credentialStore: {
+        load: loadSessionMock,
+        save: saveSessionMock,
+        clear: clearSessionMock,
+      },
+      fetch: fetchMock,
+      getCoreBaseUrl: () => 'http://127.0.0.1:39123',
+      onSessionInvalidated: sessionInvalidatedMock,
+      scheduleSessionValidation: (validate) => {
+        validateSession = validate;
+        return vi.fn();
+      },
+      setCoreSessionCookie: setCoreCookieMock,
+    });
+    await service.getSession();
+    const oldValidationRequest = validateSession?.();
+    await service.logout();
+    expect(oldValidationSignal?.aborted).toBe(true);
+    const loginResult = await service.login({
+      baseUrl: 'https://agents.example.com',
+      loginName: 'agents-user@example.com',
+      password: 'secret',
+    });
+
+    resolveOldValidation?.(
+      new Response(JSON.stringify({ errorCode: 401, responseBody: null }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    await oldValidationRequest;
+
+    expect(loginResult.success).toBe(true);
+    expect(clearSessionMock).toHaveBeenCalledOnce();
+    expect(sessionInvalidatedMock).not.toHaveBeenCalled();
+    await expect(service.getSession()).resolves.toMatchObject({
+      status: 'authenticated',
+      user: { id: 'core-user-42' },
+    });
+  });
+
+  it('keeps the active session for untrusted targets and non-authentication failures', async () => {
+    loadSessionMock.mockResolvedValue({
+      baseUrl: 'https://agents.example.com',
+      token: 'saved-agents-token',
+      userId: 'agents-user-42',
+    });
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            errorCode: 0,
+            responseBody: { uuid: 'agents-user-42', userName: 'agents-user@example.com' },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              user_id: 'core-user-42',
+              user_type: 'aionpro',
+              external_user_id: 'opaque-external-id',
+              session_generation: 1,
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: { user: { id: 'core-user-42', username: 'agents-user@example.com' }, session_generation: 1 },
+          }),
+          { status: 200, headers: { 'set-cookie': 'aionui-session=restored-core-token; HttpOnly' } }
+        )
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 500 }));
+    const service = new AgentsAuthService({
+      agentsFetch: fetchMock,
+      bootstrapSecret: 'bootstrap-secret',
+      clearCoreSession: clearCoreCookieMock,
+      credentialStore: {
+        load: loadSessionMock,
+        save: saveSessionMock,
+        clear: clearSessionMock,
+      },
+      fetch: fetchMock,
+      getCoreBaseUrl: () => 'http://127.0.0.1:39123',
+      onSessionInvalidated: sessionInvalidatedMock,
+      setCoreSessionCookie: setCoreCookieMock,
+    });
+    await service.getSession();
+
+    await expect(service.fetchAuthenticated('https://unexpected.example.net/catalog')).rejects.toThrow('relative path');
+    await expect(service.fetchAuthenticated('/kagent/bridge/catalog')).resolves.toMatchObject({ status: 500 });
+
+    expect(clearSessionMock).not.toHaveBeenCalled();
+    expect(sessionInvalidatedMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect((await service.getSession()).status).toBe('authenticated');
   });
 
   it('clears the Core runtime before reporting a credential cleanup failure', async () => {

--- a/tests/unit/process/ki-buddy/CredentialStore.test.ts
+++ b/tests/unit/process/ki-buddy/CredentialStore.test.ts
@@ -12,6 +12,7 @@ import { KeytarCredentialStore } from '@/process/ki-buddy/CredentialStore';
 
 const keytarMock = {
   deletePassword: vi.fn<(service: string, account: string) => Promise<boolean>>(),
+  findCredentials: vi.fn<(service: string) => Promise<Array<{ account: string; password: string }>>>(),
   getPassword: vi.fn<(service: string, account: string) => Promise<string | null>>(),
   setPassword: vi.fn<(service: string, account: string, password: string) => Promise<void>>(),
 };
@@ -26,6 +27,8 @@ describe('KeytarCredentialStore', () => {
     keytarMock.deletePassword.mockResolvedValue(true);
     keytarMock.getPassword.mockReset();
     keytarMock.getPassword.mockResolvedValue('agents-fixed-token');
+    keytarMock.findCredentials.mockReset();
+    keytarMock.findCredentials.mockResolvedValue([]);
     keytarMock.setPassword.mockReset();
     keytarMock.setPassword.mockResolvedValue(undefined);
   });
@@ -47,13 +50,13 @@ describe('KeytarCredentialStore', () => {
 
     expect(keytarMock.setPassword).toHaveBeenCalledWith(
       expect.stringMatching(/^Ki-Buddy Agents \(profile-[a-f0-9]{16}\)$/),
-      'agents-session',
+      expect.stringMatching(/^agents-session-v2:[a-f0-9]{64}$/),
       'agents-fixed-token'
     );
     const metadataPath = path.join(userDataPath, 'ki-buddy', 'agents-session.json');
     const metadata = await readFile(metadataPath, 'utf8');
     expect(JSON.parse(metadata)).toEqual({
-      schemaVersion: 1,
+      schemaVersion: 2,
       baseUrl: 'https://agents.example.com',
       userId: 'agents-user-42',
     });
@@ -76,7 +79,76 @@ describe('KeytarCredentialStore', () => {
 
     await expect(store.load()).resolves.toEqual(saved);
 
-    expect(keytarMock.getPassword).toHaveBeenCalledWith(service, 'agents-session');
+    expect(keytarMock.getPassword).toHaveBeenCalledWith(
+      service,
+      expect.stringMatching(/^agents-session-v2:[a-f0-9]{64}$/)
+    );
+  });
+
+  it('restores credentials written by the issue 15 storage format', async () => {
+    const metadataDirectory = path.join(userDataPath, 'ki-buddy');
+    await mkdir(metadataDirectory, { recursive: true });
+    await writeFile(
+      path.join(metadataDirectory, 'agents-session.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        baseUrl: 'https://agents.example.com',
+        userId: 'agents-user-42',
+      })
+    );
+    const store = createStore();
+
+    await expect(store.load()).resolves.toEqual({
+      baseUrl: 'https://agents.example.com',
+      token: 'agents-fixed-token',
+      userId: 'agents-user-42',
+    });
+    expect(keytarMock.getPassword).toHaveBeenCalledWith(expect.any(String), 'agents-session');
+    expect(keytarMock.setPassword).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringMatching(/^agents-session-v2:[a-f0-9]{64}$/),
+      'agents-fixed-token'
+    );
+    expect(keytarMock.deletePassword).toHaveBeenCalledWith(expect.any(String), 'agents-session');
+  });
+
+  it('uses different operating-system credential accounts for each deployment and Agents user', async () => {
+    const store = createStore();
+
+    await store.save({
+      baseUrl: 'https://agents.example.com',
+      token: 'first-token',
+      userId: 'agents-user-a',
+    });
+    await store.save({
+      baseUrl: 'https://agents.example.com',
+      token: 'second-token',
+      userId: 'agents-user-b',
+    });
+    await store.save({
+      baseUrl: 'https://other-agents.example.com',
+      token: 'third-token',
+      userId: 'agents-user-b',
+    });
+
+    const accounts = keytarMock.setPassword.mock.calls.map(([, account]) => account);
+    expect(new Set(accounts)).toHaveProperty('size', 3);
+    expect(keytarMock.deletePassword).toHaveBeenCalledWith(expect.any(String), accounts[0]);
+    expect(keytarMock.deletePassword).toHaveBeenCalledWith(expect.any(String), accounts[1]);
+  });
+
+  it('removes orphaned identity credentials before making a new account current', async () => {
+    const orphanedAccount = `agents-session-v2:${'b'.repeat(64)}`;
+    keytarMock.findCredentials.mockResolvedValue([{ account: orphanedAccount, password: 'orphaned-token' }]);
+    const store = createStore();
+
+    await store.save({
+      baseUrl: 'https://agents.example.com',
+      token: 'current-token',
+      userId: 'current-user',
+    });
+
+    expect(keytarMock.deletePassword).toHaveBeenCalledWith(expect.any(String), orphanedAccount);
   });
 
   it('fails closed without writing metadata when keytar is unavailable', async () => {
@@ -110,7 +182,7 @@ describe('KeytarCredentialStore', () => {
 
     expect(keytarMock.deletePassword).toHaveBeenCalledWith(
       expect.stringMatching(/^Ki-Buddy Agents \(profile-[a-f0-9]{16}\)$/),
-      'agents-session'
+      expect.stringMatching(/^agents-session-v2:[a-f0-9]{64}$/)
     );
   });
 
@@ -129,7 +201,10 @@ describe('KeytarCredentialStore', () => {
     await expect(readFile(path.join(userDataPath, 'ki-buddy', 'agents-session.json'))).rejects.toMatchObject({
       code: 'ENOENT',
     });
-    expect(keytarMock.deletePassword).toHaveBeenCalledWith(service, 'agents-session');
+    expect(keytarMock.deletePassword).toHaveBeenCalledWith(
+      service,
+      expect.stringMatching(/^agents-session-v2:[a-f0-9]{64}$/)
+    );
   });
 
   it('isolates test credentials with the configured storage namespace', async () => {
@@ -143,7 +218,7 @@ describe('KeytarCredentialStore', () => {
 
     expect(keytarMock.setPassword).toHaveBeenCalledWith(
       'Ki-Buddy Agents (smoke-001)',
-      'agents-session',
+      expect.stringMatching(/^agents-session-v2:[a-f0-9]{64}$/),
       'agents-fixed-token'
     );
   });
@@ -198,7 +273,23 @@ describe('KeytarCredentialStore', () => {
     );
   });
 
-  it('reports keytar cleanup failures after removing metadata', async () => {
+  it('clears identity-bound credentials even when session metadata is damaged', async () => {
+    const metadataDirectory = path.join(userDataPath, 'ki-buddy');
+    await mkdir(metadataDirectory, { recursive: true });
+    await writeFile(path.join(metadataDirectory, 'agents-session.json'), '{invalid json');
+    keytarMock.findCredentials.mockResolvedValue([
+      { account: `agents-session-v2:${'a'.repeat(64)}`, password: 'must-not-be-logged' },
+      { account: 'unrelated-account', password: 'unrelated-password' },
+    ]);
+    const store = createStore();
+
+    await store.clear();
+
+    expect(keytarMock.deletePassword).toHaveBeenCalledWith(expect.any(String), `agents-session-v2:${'a'.repeat(64)}`);
+    expect(keytarMock.deletePassword).not.toHaveBeenCalledWith(expect.any(String), 'unrelated-account');
+  });
+
+  it('preserves metadata when keytar cleanup fails so a later startup can retry', async () => {
     const store = createStore();
     await store.save({
       baseUrl: 'https://agents.example.com',
@@ -208,9 +299,111 @@ describe('KeytarCredentialStore', () => {
     keytarMock.deletePassword.mockRejectedValueOnce(new Error('keychain denied deletion'));
 
     await expect(store.clear()).rejects.toThrow('keychain denied deletion');
+    await expect(readFile(path.join(userDataPath, 'ki-buddy', 'agents-session.cleanup-pending'), 'utf8')).resolves.toBe(
+      '{"schemaVersion":1}'
+    );
+  });
+
+  it('prevents credential recovery when the cleanup marker and keytar deletion both fail', async () => {
+    const store = createStore();
+    await store.save({
+      baseUrl: 'https://agents.example.com',
+      token: 'agents-fixed-token',
+      userId: 'agents-user-42',
+    });
+    const metadataPath = path.join(userDataPath, 'ki-buddy', 'agents-session.json');
+    const cleanupTombstonePath = path.join(userDataPath, 'ki-buddy', 'agents-session.cleanup-pending');
+    const account = keytarMock.setPassword.mock.calls[0]?.[1];
+    if (!account) throw new Error('credential account was not recorded');
+    await mkdir(cleanupTombstonePath);
+    keytarMock.findCredentials.mockResolvedValue([{ account, password: 'agents-fixed-token' }]);
+    keytarMock.deletePassword.mockImplementation(async (_service, candidate) => {
+      if (candidate === account) throw new Error('keychain denied deletion');
+      return true;
+    });
+
+    await expect(store.clear()).rejects.toThrow('keychain denied deletion');
+    await expect(readFile(metadataPath)).rejects.toMatchObject({ code: 'ENOENT' });
+
+    await rm(cleanupTombstonePath, { recursive: true, force: true });
+    keytarMock.getPassword.mockClear();
+    await expect(createStore().load()).resolves.toBeNull();
+    expect(keytarMock.getPassword).not.toHaveBeenCalled();
+  });
+
+  it('can retry identity-bound credential cleanup after a keytar failure', async () => {
+    const store = createStore();
+    await store.save({
+      baseUrl: 'https://agents.example.com',
+      token: 'agents-fixed-token',
+      userId: 'agents-user-42',
+    });
+    const account = keytarMock.setPassword.mock.calls[0]?.[1];
+    if (!account) throw new Error('credential account was not recorded');
+    keytarMock.findCredentials.mockResolvedValue([{ account, password: 'agents-fixed-token' }]);
+    keytarMock.deletePassword.mockImplementation(async (_service, candidate) => {
+      if (candidate === account) throw new Error('keychain denied deletion');
+      return true;
+    });
+
+    await expect(store.clear()).rejects.toThrow('keychain denied deletion');
+
+    keytarMock.deletePassword.mockResolvedValue(true);
+    await expect(createStore().load()).resolves.toBeNull();
+    expect(keytarMock.deletePassword.mock.calls.filter(([, candidate]) => candidate === account)).toHaveLength(2);
     await expect(readFile(path.join(userDataPath, 'ki-buddy', 'agents-session.json'))).rejects.toMatchObject({
       code: 'ENOENT',
     });
+  });
+
+  it('retries cleanup on startup when damaged metadata and keytar deletion fail together', async () => {
+    const metadataDirectory = path.join(userDataPath, 'ki-buddy');
+    const account = `agents-session-v2:${'a'.repeat(64)}`;
+    await mkdir(metadataDirectory, { recursive: true });
+    await writeFile(path.join(metadataDirectory, 'agents-session.json'), '{invalid json');
+    keytarMock.findCredentials.mockResolvedValue([{ account, password: 'must-not-be-logged' }]);
+    keytarMock.deletePassword.mockImplementation(async (_service, candidate) => {
+      if (candidate === account) throw new Error('keychain denied deletion');
+      return true;
+    });
+    const store = createStore();
+
+    await expect(store.clear()).rejects.toThrow('keychain denied deletion');
+
+    keytarMock.deletePassword.mockResolvedValue(true);
+    await expect(createStore().load()).resolves.toBeNull();
+    expect(keytarMock.deletePassword.mock.calls.filter(([, candidate]) => candidate === account)).toHaveLength(2);
+    await expect(readFile(path.join(metadataDirectory, 'agents-session.cleanup-pending'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it('removes a stale cleanup tombstone after a new login saves credentials', async () => {
+    const store = createStore();
+    const initial = {
+      baseUrl: 'https://agents.example.com',
+      token: 'old-agents-token',
+      userId: 'agents-user-42',
+    };
+    await store.save(initial);
+    const account = keytarMock.setPassword.mock.calls[0]?.[1];
+    if (!account) throw new Error('credential account was not recorded');
+    keytarMock.findCredentials.mockResolvedValue([{ account, password: initial.token }]);
+    keytarMock.deletePassword.mockImplementation(async (_service, candidate) => {
+      if (candidate === account) throw new Error('keychain denied deletion');
+      return true;
+    });
+    await expect(store.clear()).rejects.toThrow('keychain denied deletion');
+
+    keytarMock.deletePassword.mockResolvedValue(true);
+    keytarMock.getPassword.mockResolvedValue('new-agents-token');
+    const replacement = { ...initial, token: 'new-agents-token' };
+    await store.save(replacement);
+
+    await expect(createStore().load()).resolves.toEqual(replacement);
+    await expect(readFile(path.join(userDataPath, 'ki-buddy', 'agents-session.cleanup-pending'))).rejects.toMatchObject(
+      { code: 'ENOENT' }
+    );
   });
 
   function createStore(storageNamespace?: string): KeytarCredentialStore {

--- a/tests/unit/process/ki-buddy/authBridge.test.ts
+++ b/tests/unit/process/ki-buddy/authBridge.test.ts
@@ -10,6 +10,7 @@ const electronMock = vi.hoisted(() => ({
   agentsFetch: vi.fn(),
   fromPartition: vi.fn(),
   handlers: new Map<string, (...args: unknown[]) => Promise<unknown>>(),
+  sendToRenderer: vi.fn(),
   removeCookie: vi.fn(),
   setCertificateVerifyProc: vi.fn(),
   setCookie: vi.fn(),
@@ -23,6 +24,9 @@ const credentialStoreMock = vi.hoisted(() => ({
 
 vi.mock('electron', () => ({
   app: { getPath: vi.fn(() => '/tmp/ki-buddy-auth-test') },
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => [{ isDestroyed: () => false, webContents: { send: electronMock.sendToRenderer } }]),
+  },
   ipcMain: {
     handle: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
       electronMock.handlers.set(channel, handler);
@@ -100,12 +104,12 @@ function registerBridgeWithSuccessfulLogin() {
     );
   electronMock.agentsFetch.mockImplementation(fetchMock);
   vi.stubGlobal('fetch', fetchMock);
-  registerKiBuddyAuthBridge({
+  const authService = registerKiBuddyAuthBridge({
     bootstrapSecret: 'bootstrap-secret',
     coreTransport,
     getCoreBaseUrl: () => 'http://127.0.0.1:39123',
   });
-  return { coreTransport, fetchMock };
+  return { authService, coreTransport, fetchMock };
 }
 
 describe('Ki-Buddy authentication IPC bridge', () => {
@@ -122,6 +126,7 @@ describe('Ki-Buddy authentication IPC bridge', () => {
     electronMock.setCookie.mockReset();
     electronMock.removeCookie.mockResolvedValue(undefined);
     electronMock.setCookie.mockResolvedValue(undefined);
+    electronMock.sendToRenderer.mockReset();
     credentialStoreMock.clear.mockReset();
     credentialStoreMock.load.mockReset();
     credentialStoreMock.save.mockReset();
@@ -183,6 +188,26 @@ describe('Ki-Buddy authentication IPC bridge', () => {
 
     expect(credentialStoreMock.clear).toHaveBeenCalledOnce();
     expect(coreTransport.getHeaders({ method: 'GET' })).not.toHaveProperty('Authorization');
+  });
+
+  it('notifies the renderer after a trusted Agents authentication failure ends the active session', async () => {
+    const service = registerBridgeWithSuccessfulLogin();
+    const loginHandler = electronMock.handlers.get('ki-buddy-auth:login');
+    await loginHandler?.(null, {
+      baseUrl: 'https://agents.example.com',
+      loginName: 'agents-user@example.com',
+      password: 'password',
+    });
+    service.fetchMock.mockReset();
+    service.fetchMock.mockResolvedValueOnce(new Response(null, { status: 401 })).mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true, data: { user_id: 'core-user-42', session_generation: 1 } }), {
+        status: 200,
+      })
+    );
+
+    await service.authService.fetchAuthenticated('/kagent/bridge/catalog');
+
+    expect(electronMock.sendToRenderer).toHaveBeenCalledWith('ki-buddy-auth:session-invalidated');
   });
 
   it('rejects malformed login IPC requests before making a network request', async () => {

--- a/tests/unit/renderer/ki-buddy/KiBuddyAuthProvider.dom.test.tsx
+++ b/tests/unit/renderer/ki-buddy/KiBuddyAuthProvider.dom.test.tsx
@@ -18,6 +18,8 @@ import { installKiBuddyRendererCoreTransport } from '@/renderer/pages/ki-buddy/A
 const getSessionMock = vi.fn();
 const loginMock = vi.fn();
 const logoutMock = vi.fn();
+const onSessionInvalidatedMock = vi.fn();
+let sessionInvalidatedListener: (() => void) | undefined;
 
 const ProductProbe: React.FC = () => {
   const auth = useAuth();
@@ -53,12 +55,21 @@ describe('Ki-Buddy product authentication context', () => {
     getSessionMock.mockReset();
     loginMock.mockReset();
     logoutMock.mockReset();
+    onSessionInvalidatedMock.mockReset();
+    sessionInvalidatedListener = undefined;
+    onSessionInvalidatedMock.mockImplementation((listener: () => void) => {
+      sessionInvalidatedListener = listener;
+      return () => {
+        sessionInvalidatedListener = undefined;
+      };
+    });
     window.electronAPI = {
       ...window.electronAPI,
       kiBuddyAuth: {
         getSession: getSessionMock,
         login: loginMock,
         logout: logoutMock,
+        onSessionInvalidated: onSessionInvalidatedMock,
       },
     };
     configService.reset();
@@ -195,6 +206,40 @@ describe('Ki-Buddy product authentication context', () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
     expect(screen.getByLabelText('auth-status')).toHaveTextContent('authenticated');
     expect(logoutMock).not.toHaveBeenCalled();
+  });
+
+  it('returns to the login state when main reports a trusted Agents authentication failure', async () => {
+    getSessionMock
+      .mockResolvedValueOnce({
+        status: 'authenticated',
+        user: {
+          id: 'core-user-42',
+          username: 'agents-user@example.com',
+          agents: {
+            userId: 'agents-user-42',
+            username: 'agents-user@example.com',
+            displayName: 'Agents User',
+            roles: [],
+            deploymentUrl: 'https://agents.example.com',
+          },
+        },
+      })
+      .mockResolvedValueOnce({ status: 'unauthenticated', user: null, cleanupRequired: true });
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <KiBuddyAuthProvider>
+          <ProductProbe />
+        </KiBuddyAuthProvider>
+      </SWRConfig>
+    );
+    await waitFor(() => expect(screen.getByLabelText('auth-status')).toHaveTextContent('authenticated'));
+
+    sessionInvalidatedListener?.();
+
+    await waitFor(() => expect(screen.getByLabelText('auth-status')).toHaveTextContent('unauthenticated'));
+    expect(screen.getByLabelText('core-user')).toHaveTextContent('null');
+    expect(screen.getByLabelText('agents-profile')).toHaveTextContent('null');
   });
 
   it('preserves ordinary AionUi desktop authentication when the product capability is absent', async () => {


### PR DESCRIPTION
# Pull Request

## 变更说明

完成 issue #15 已建立的 Ki-Buddy Agents 登录会话生命周期。

- 将 active token 写入操作系统凭据存储，并按规范化 Agents 部署地址和用户标识隔离。
- 应用重启时验证已保存的会话；验证成功后恢复原 Ki-Core 用户，验证失败时安全清理凭据。
- 使用期间收到可信认证失效响应后结束本地会话并返回登录页，不删除该账号的工作历史。
- 退出或认证失效时停止定时任务和在途认证请求、清除本地凭据，并防止旧请求结束之后重新登录的会话。
- 增加相互隔离的 Electron packaged E2E，验证运行期间 token 到期、同账号重新登录和 conversation 历史恢复。

## 关联 Issue

- Closes #16

## 变更类型

- [ ] `fix` — Bug 修复（非破坏性变更）
- [x] `feat` — 新功能（非破坏性变更）
- [ ] `perf` — 性能改进
- [ ] `refactor` — 代码重构（不改变行为）
- [ ] Breaking change（会破坏现有兼容性的修复或功能）
- [ ] `docs` — 文档更新

## 原子 PR 检查（Rule 1）

- [x] 此 PR 只包含一个不可继续独立拆分的功能
- [x] PR 标题符合 Conventional Commit 格式：`<type>(<scope>): <subject>`（英文）

## 本地检查（Rule 3）

- [x] `bun run format` — 格式检查通过
- [x] `bun run lint` — 无 lint error（存在 876 个 warning）
- [x] `bunx tsc --noEmit` — 无类型错误
- [x] `bunx vitest run` — 453 个测试文件、3850 项测试通过；1 个文件、5 项测试跳过
- [x] i18n 校验通过（`bun run i18n:types`、`node scripts/check-i18n.js`）
- [x] 新增或修改的用户可见文本使用 i18n key（本次没有新增用户可见文本）

## Runtime 验证

- [x] 已在 macOS 验证
- [ ] 已在 Windows 验证
- [ ] 已在 Linux 验证
- [x] 已完成代码自审

## 截图

不适用。本次变更只影响认证会话生命周期，没有修改界面。

## 其他说明

- macOS arm64 packaged application 已重新构建成功，本地使用 ad-hoc signature。
- Electron packaged E2E 共 3 项通过，其中包括生产环境 60 秒 active-token 定时验证路径；fake Agents 返回可信的 `200 + errorCode: 401` 响应。
- Vitest 输出了一次 `MaxListenersExceededWarning`，测试套件仍正常完成并返回成功状态。
