### PR TITLE
feat(ki-buddy): preserve client state across account switches

### DIFF
--- a/docs/adr/0003-project-agents-identity-into-core-user.md
+++ b/docs/adr/0003-project-agents-identity-into-core-user.md
@@ -14,16 +14,32 @@ Ki-Buddy 近期只支持一个当前部署和一个 active 账户。密码只用
 
 Ki-Buddy 的主进程凭据、Agents 登录、Core 用户投影和 IPC 注册集中在 `process/ki-buddy/`，renderer 登录与首次介绍集中在 `renderer/pages/ki-buddy/`。这是为降低上游 AionUi 更新冲突而保留的产品结构例外；通用入口只负责装配产品模块，不承载产品认证流程。renderer 只能通过 preload 暴露的 `kiBuddyAuth` capability 判断并调用该产品能力，不能用通用 Electron 环境作为产品标识。
 
+## 账号切换的数据边界
+
+Ki-Buddy 只把认证会话和 Core user scope 中的持久业务数据归属于 Agents 平台账户。renderer `localStorage`、`sessionStorage`、Preview tab 和应用内浏览器属于当前客户端安装，不建立 Agents 账号 namespace，也不在退出、切换账号或切换部署时枚举、删除、保存或恢复这些数据。
+
+账号 A 退出后登录账号 B 时，Ki-Buddy 撤销旧凭证与 Core session，停止旧账号受管进程和本地等待，并清除 SWR、订阅、模块级 cache 等账号相关内存状态。不同的非空 Core user id 触发 renderer 整页 reload；conversation、Team、task、自动 workspace 和结果引用依靠 Core user scope 隔离。重新登录账号 A 后，由相同 Core 用户恢复 A 的持久业务数据，不通过 renderer Web Storage 快照恢复。
+
+Web Storage 中保留的 route、搜索、Explorer、Team UI、草稿、最近 workspace、file/diff tab 和 Core resource id 只用于恢复客户端工作界面，不能作为业务授权依据。读取或修改 Core 资源时仍使用当前 Core session 重新鉴权，项目 workspace 继续由操作系统文件权限约束。应用内浏览器的 tab 元数据及固定 Electron partition `persist:aionui-browser` 中的 Cookie、站点存储和 cache 也与 Agents 账号无关，只能由用户主动执行浏览器数据清理。
+
+该边界与 AionUi v2.1.54 生产客户端的 OAuth 账号切换一致：Core user scope 隔离并恢复持久业务数据，renderer reload 清除旧账号内存，desktop logout 不扫描 renderer Web Storage，也不清应用内浏览器 partition。详细数据分类与生产包证据见 [Ki-Buddy 账号切换数据分类与 AionUi v2.1.54 对照](../architecture/research/ki-buddy-account-cache-classification.md)。
+
 ## Considered Options
 
 - Ki-Buddy 自建账户再映射 Agents 用户：会形成第二个身份源和权限配置入口。
 - 近期修改 Ki-Core 建设通用 external identity：领域含义更准确，但会增加上游内核维护成本。
 - 每个账户使用独立 data directory：物理隔离明确，但会分离全部本地配置并要求切换时重启 Core。
+- 按已知 key 清理 renderer Web Storage：key 清单会随功能变化失真，也会把浏览器、布局、草稿和 workspace 等客户端状态误判为账号数据。
+- 按 Agents 账号保存并恢复 Web Storage 快照：重复建立 Core 已有的账号恢复机制，并把客户端工作状态错误改成账号资产。
+- 退出时清空全部 Web Storage 或浏览器 partition：可以消除残留引用，但会破坏桌面客户端跨账号保留本地工作界面和浏览器登录态的产品行为。
 
 ## Consequences
 
 - 首次使用先显示 Ki-Buddy 产品 onboarding，随后强制 Agents 登录。干净安装在 onboarding 完成前不存在可恢复的账号会话；onboarding 本身不触发登录、Core User 投影或工作历史创建。未登录不能进入业务界面或创建 conversation、Team、task 或 workspace 历史。Ki-Buddy 使用版本固定的专属 Core 数据目录，不认领预发布 `system_default_user` 数据，也不建设公开产品迁移流程。
-- conversation、Team、自动 workspace、renderer cache 和运行时状态必须按 deployment 与用户隔离。退出或切换账号只隐藏并停止旧账户状态，不删除其工作历史。
+- conversation、Team、自动 workspace 等持久业务数据必须按 deployment 与 Core 用户隔离。renderer 的账号相关内存状态在账号变化时销毁；renderer Web Storage 属于客户端工作状态，不随 Agents 账号切换清理或建立账号 namespace。
 - 修改 `base_url`、退出、认证失效或切换账号时，必须停止旧账户 Adapter 与本地等待，清除 token、catalog cache 和临时敏感状态；这不表示远端执行已取消。
-- 首发允许固定有效期 token 到期后重新登录。主动退出清除本地凭证、renderer 业务缓存和 Core 投影会话，但不复制或调用 Agents 私有 logout/OAuth 接口。Bridge 自动续期是高优先级后续需求，完成后不设置绝对会话上限；Agents 服务端 logout/revocation 是更远期需求。
+- 首发允许固定有效期 token 到期后重新登录。主动退出清除本地凭证、renderer 的账号相关内存状态和 Core 投影会话，但不删除 renderer Web Storage，也不复制或调用 Agents 私有 logout/OAuth 接口。Bridge 自动续期是高优先级后续需求，完成后不设置绝对会话上限；Agents 服务端 logout/revocation 是更远期需求。
 - Agents token 与 Core session 的签发方、受众和用途不同，不能合并成一种凭证。
+- A→退出→B→退出→A 的验收必须同时证明：Core 业务数据按稳定用户标识隔离并恢复，renderer 账号相关内存已销毁，Web Storage 与真实 browser tab 保持不变。
+- 同一操作系统用户登录 Ki-Buddy 的另一个 Agents 账号后，可能看到上一个账号留下的客户端 route、搜索、草稿或 Preview 外观；这是本机客户端状态共享的既定语义。任何残留 Core 资源引用都必须在当前 Core 用户下重新鉴权，不能据此读取旧账号业务数据。
+- AionUi WebUI 的通用 logout 清理行为保持原样；Ki-Buddy 产品认证路径必须显式选择保留 renderer Web Storage，不能把该产品规则写成所有产品的默认行为。

--- a/docs/architecture/research/ki-buddy-account-cache-classification.md
+++ b/docs/architecture/research/ki-buddy-account-cache-classification.md
@@ -1,0 +1,403 @@
+# Ki-Buddy 账号切换数据分类与 AionUi v2.1.54 对照
+
+## 结论
+
+Ki-Buddy 的账号切换不能按“浏览器缓存”或“所有客户端缓存”统一处理。当前数据应按下面四类管理：
+
+| 分类            | 定义                                                       | 切换 Agents 账号时的处理                                                   |
+| --------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Agents 账号相关 | credential、Core session，以及由当前身份授权访问的业务记录 | credential/session 随账号替换；业务数据由 Core `CurrentUser.id` 隔离并恢复 |
+| 客户端账号无关  | 属于当前安装、OS 用户或客户端功能，不以 Agents 身份为边界  | 保留，不清理                                                               |
+| 客户端工作状态  | renderer Web Storage 中的 route、Preview、草稿和最近资源   | 属于当前安装，不随 Agents 账号切换清理；不能作为业务授权依据               |
+| 临时运行状态    | 单次 renderer 生命周期中的请求、订阅和模块级内存           | 停止旧请求；Core user id 变化后 reload，不做跨账号内存恢复                 |
+
+最重要的边界如下：
+
+1. 应用内浏览器是客户端功能。它的 Cookie、站点存储、HTTP cache、HTTP auth cache 使用固定的 Electron 持久化 partition `persist:aionui-browser`，与 Agents 账号无关，账号切换不能调用 `clearBrowserData`。
+2. `preview-ui:<scope>` 中的 browser、file、diff 与编辑 tab 都是客户端工作状态。Agents 账号切换不删除或重写这条记录；其中引用的 Core 资源仍须按当前 user 重新鉴权。
+3. 用户选择的本地目录、最近目录、workspace 活动、展开状态和文件预览都由当前 OS 用户的客户端持有，不归某个 Agents 账号独占。Core project 记录和业务访问权仍按 `CurrentUser.id` 隔离。
+4. conversation、Team、task、mailbox、cron、自动 workspace 等持久业务数据已经由固定 Ki-Core 的 `CurrentUser.id` 隔离；renderer 的 SWR、订阅和模块级内存由账号变化后的 reload 销毁，Web Storage 保持不变。
+5. Issue 17 最终复用生产客户端的边界：Core user scope 负责持久业务数据，renderer reload 负责内存隔离，renderer Web Storage 视为当前安装的客户端状态，不建立 Agents 账号 namespace，也不在 logout/switch 时清理。
+6. AionUi v2.1.54 生产客户端包含一套不在公开 tag 同名 `AuthContext` 中的 AionUi Cloud OAuth 登录体系。它用云端稳定 user id 投影 Core user，logout 后登录另一个 OAuth 用户时以 Core user id 变化触发 renderer 整页 reload；desktop logout 不扫描或删除 renderer `localStorage`，也不清 `persist:aionui-browser`。公开 tag 中的 desktop auth stub 不能代表生产包行为。
+
+## 核查范围与证据基线
+
+- 研究开始时固定的 AionUi 基线（当前功能分支的 merge-base）：`ab4f57fce`。本文把该基线之后的认证改动单独标为“当前工作树实现”，不把它当作既有发布行为。
+- 固定 Ki-Core：`ki-buddy-product.json` 中的 `209e6844d39bac0762c61e198c1ba3a007f9dd2e`；Core 结论引用该固定提交，不使用其他分支的后续行为。
+- AionUi v2.1.54 tag：`982a6013c76171afa2865e933334299cf39f11e7`。该 tag 仅用于公开源码基线；生产包额外包含 AionPro/AionUi Cloud OAuth 模块，不能用 tag 中的 desktop auth stub 替代生产包分析。
+- 本机生产客户端：`/Applications/AionUi.app`，版本 2.1.54；只读解包目录为 `/private/tmp/aionui-v2.1.54.GdSdoN/app`。`package.json` 声明 `version: 2.1.54` 与 `aioncoreVersion: v0.1.65`，应用内置 manifest 同样声明 Core v0.1.65。证据：`/private/tmp/aionui-v2.1.54.GdSdoN/app/package.json:1-4,147`、`/Applications/AionUi.app/Contents/Resources/bundled-aioncore/darwin-arm64/manifest.json:1-12`。
+- 生产 OAuth 与账号切换行为直接引用解包后的 `out/main/index.js` 和 renderer chunks；Core 数据归属、首次认领与 session generation 使用与生产包 manifest 对应的 AionCore `v0.1.65` 源码交叉核对。
+- 生产 OAuth 部分来自源码、tag 和已解包发布物的静态核查；文末另列当前工作树实现的自动化验证结果。
+
+## 1. Agents 身份、credential 与 Core session
+
+### 1.1 主进程中的账号相关状态
+
+当前 Ki-Buddy 将规范化 Agents `baseUrl` 和稳定 Agents user id 做 SHA-256，形成 `agents-v1-...` external identity；这使不同部署中的相同 user id 不会映射到同一个 Core user。证据：`/Users/xli/AionUi/packages/desktop/src/process/ki-buddy/AgentsAuthService.ts:89-94,109-130`。
+
+| 数据                                                                                         | 物理位置/生命周期                                      | 分类                  | 账号切换行为                                                |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------ | --------------------- | ----------------------------------------------------------- |
+| Agents access token                                                                          | OS keychain，service/account 由 `CredentialStore` 管理 | Agents 账号相关、敏感 | 当前只保留一个 active credential；换账号前删除旧 credential |
+| session metadata（部署 URL、user、keychain account）                                         | `userData/ki-buddy/agents-session.json`                | Agents 账号相关       | 与 token 同步保存/删除；不能放 renderer storage             |
+| active credential、identity、session、validation timer、request abort controller、generation | `AgentsAuthService` 模块实例内存                       | Agents 账号相关/临时  | 切换时停止验证、abort 旧请求、清空 active state             |
+| Core session/CSRF Cookie                                                                     | Electron `session.defaultSession`                      | Agents 账号相关       | 换账号时撤销旧 Core projection 并替换 Cookie                |
+
+`CredentialStore` 的 metadata 路径和 tombstone 处理见 `/Users/xli/AionUi/packages/desktop/src/process/ki-buddy/CredentialStore.ts:7-17,70-75,123-128`；保存新账号时会枚举并删除此前的 `agents-session-v2:*` credential，清理时删除全部 Ki-Buddy session credential，见同文件 `:158-207,213-265`。
+
+`AgentsAuthService` 持有 active credential/session、AbortController、generation 和验证循环，见 `/Users/xli/AionUi/packages/desktop/src/process/ki-buddy/AgentsAuthService.ts:169-178`。激活 session 时会替换请求 generation 和 abort controller，见同文件 `:379-389`；deactivate 会 abort 请求、停止验证、清 credential、撤销 Core projection 并清 Cookie，见同文件 `:451-480`。因此这些内存对象属于账号相关的运行中状态，不能在 B 账号下继续使用 A 的对象。
+
+Core auth Cookie 通过 `session.defaultSession` 写入，见 `/Users/xli/AionUi/packages/desktop/src/process/ki-buddy/authBridge.ts:15-17,41-92`。这与应用内浏览器的 named partition 是两个不同 Electron session，不能因为都叫 Cookie 就一起清理。
+
+### 1.2 账号切换不是删除历史
+
+Core external-session revoke 的作用是提升 session generation、断开 WebSocket，并停止该用户的 Team、channel、conversation runtime、file/office watch；它没有删除该用户的持久历史。证据：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-app/src/router/routes.rs:192-248`。
+
+Issue 17 选择把账号恢复边界放在 Core：对话历史、Team、项目等持久业务数据由相同 Core user id 恢复；renderer 的 route、搜索、队列、展开状态、file/diff tab 等属于客户端状态，保持原值但不得绕过 Core 当前用户鉴权。退出不能删除 Core 中的账号历史，也不能删除用户显式选择的本地目录。
+
+### 1.3 磁盘与 Chromium profile 数据
+
+除 renderer Web Storage 外，客户端还在 `userData`、Core data dir、OS keychain 和 Chromium partition 中持久化数据。账号切换不能只检查 `localStorage`。
+
+| 位置/容器                                                                        | 主要内容                                                                   | 分类与处理                                                                                     |
+| -------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| OS keychain + `userData/ki-buddy/agents-session.json`                            | 当前 Agents token 与非敏感 identity metadata                               | 当前账号 credential；切换时替换，不能保存多个 active token                                     |
+| `userData/aionui/ki-buddy-core-v1`                                               | Ki-Buddy 专属 Core DB、自动 workspace 与 Core 管理文件                     | 混合的多用户容器；业务行和自动 workspace 由 `CurrentUser.id`/user dir 隔离，切换时保留整个目录 |
+| Electron `defaultSession`                                                        | renderer origin 的 Web Storage、Core auth/CSRF Cookie、普通 Electron cache | 混合容器；只替换 Core auth Cookie，renderer Web Storage 作为客户端状态保留                     |
+| `persist:aionui-browser`                                                         | 应用内浏览器的第三方站点 Cookie、storage、cache、HTTP auth cache           | 客户端账号无关；只由用户主动“清除浏览数据”处理                                                 |
+| `persist:ext-settings-<tabId>`                                                   | extension settings webview 的站点 session                                  | 客户端/extension 状态；没有证据表明它属于 Agents 账号，普通换号不清                            |
+| `userData/config/aionui-config.txt`、`.aionui-env`                               | window bounds、目录配置及 legacy config                                    | 混合/兼容容器；window/目录配置是客户端级，legacy 业务字段不能自动认领给新 Agents 用户          |
+| legacy `aionui-chat*.txt`、`aionui-chat-history/`、`assistants/`、`skills/`      | 旧 Electron-managed 历史与迁移源                                           | legacy/quarantine；当前账号切换不读取、不删除，迁移需单独定义 owner                            |
+| `analytics.json`、`gpu.config.json`、`cdp.config.json`、update diagnostics、logs | 安装标识、硬件恢复、调试/更新状态、日志                                    | 客户端级或运维数据；不随 Agents 账号切换                                                       |
+| 用户显式选择的 workspace 路径                                                    | userData 之外的真实 OS 文件/目录                                           | OS 用户资源；不删除、不移动、不因换号撤销权限                                                  |
+
+Ki-Buddy Core data namespace 见 `/Users/xli/AionUi/packages/desktop/src/process/ki-buddy/coreDataPath.ts:3-12` 及 `/Users/xli/AionUi/packages/desktop/src/index.ts:188-192,259-265`。legacy 文件布局见 `/Users/xli/AionUi/packages/desktop/src/process/utils/initStorage.ts:38-46,237-306,427-454`；window bounds 写入 `ProcessConfig` 见 `/Users/xli/AionUi/packages/desktop/src/index.ts:547,871`。安装级 JSON/config 文件见 `/Users/xli/AionUi/packages/desktop/src/process/utils/analyticsId.ts:11-32`、`/Users/xli/AionUi/packages/desktop/src/process/utils/gpuRecovery.ts:9-40`、`/Users/xli/AionUi/packages/desktop/src/process/utils/configureChromium.ts:93-186`。
+
+## 2. renderer 持久化数据清单
+
+### 2.1 `localStorage`
+
+#### 客户端持有的工作状态
+
+| key / prefix                                                                                                                                   | 内容                                                      | 依据                                                                                                                                    |
+| ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `aionui:recent-workspaces`                                                                                                                     | 最近打开的 workspace 路径与活动信息                       | `/Users/xli/AionUi/packages/desktop/src/renderer/components/workspace/recentWorkspaces.ts:7-23`                                         |
+| `aionui_workspace_expansion`                                                                                                                   | workspace 路径展开状态                                    | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useWorkspaceExpansionState.ts:3-26`            |
+| `aionui_workspace_update_time`                                                                                                                 | workspace 路径到最近活动时间的映射                        | `/Users/xli/AionUi/packages/desktop/src/renderer/utils/workspace/workspaceHistory.ts:7-37`                                              |
+| `conversation.historySearch.recentKeywords`                                                                                                    | 对话搜索关键词历史                                        | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx:27,154,232`            |
+| `aionui_cron_unread`                                                                                                                           | 未读 cron conversation ids                                | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/cron/useCronJobs.ts:275-302`                                                     |
+| `team-pinned-ids`                                                                                                                              | 固定的 Team ids                                           | `/Users/xli/AionUi/packages/desktop/src/renderer/components/layout/Sider/TeamSiderSection.tsx:25,55-68`                                 |
+| `team-view-mode-`、`team-member-colors-`、`team-active-slot-`、`team-assistant-order-`、`team-pending-permissions-`、`team-activity-controls-` | 按 Team id 保存的视图、成员、权限与活动控制               | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/team/utils/teamStorage.ts:7-15,25-36`                                            |
+| `project-panel-collapse:`                                                                                                                      | 按 project id 保存的面板折叠状态                          | `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/ui/useProjectPanelCollapse.ts:32,40,91`                                          |
+| `workspace-preference-`                                                                                                                        | workspace 折叠偏好                                        | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/hooks/useWorkspaceCollapse.ts:46,90,124`                            |
+| `explorer-ui:<projectId>`                                                                                                                      | Explorer expanded/selected/current path                   | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/explorer/explorerStore.ts:55-75,85-105`                             |
+| `preview-ui:<scope>` 中非 browser tabs                                                                                                         | 文件路径、文件/office 预览、text edit、diff 及 active tab | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/Preview/context/PreviewContext.tsx:188-217,222-286,408-417,477-495` |
+
+这些 key 可能包含之前使用 Agents 账号时产生的资源 id、路径、搜索内容或工作上下文，但产品 owner 是当前客户端安装。切换账号时保留；读取其中的 conversation、Team、project 或 file ref 时，仍必须经过当前 Core user scope 鉴权，不能把本地 key 当作访问许可。
+
+#### 客户端账号无关
+
+| key                                                                                                         | 内容                                               | 依据                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `i18nextLng`                                                                                                | UI 语言提示                                        | `/Users/xli/AionUi/packages/desktop/src/renderer/services/i18n/languageHint.ts:1-16`                                                                                                                                                                                                                                                                                                                                                               |
+| `__aionui_theme`                                                                                            | 启动阶段快速应用主题                               | `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/system/useTheme.ts:18-33,69-79`                                                                                                                                                                                                                                                                                                                                                             |
+| `ki-buddy.login.successfulDeployments_v1`                                                                   | 曾成功连接的部署 URL；不含 token、用户名或 user id | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/ki-buddy/deploymentHistory.ts:1-65`                                                                                                                                                                                                                                                                                                                                                         |
+| `ki-buddy.onboarding.openingGuideSeen_v1`                                                                   | 本机产品引导已读                                   | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/ki-buddy/Onboarding/storage.ts:1-17`                                                                                                                                                                                                                                                                                                                                                        |
+| `aionui_agent_browser_first_use_notified`                                                                   | 本机浏览器控制首次提示已读                         | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/Preview/browser/firstUseNotice.ts:24-60`                                                                                                                                                                                                                                                                                                                                       |
+| `workspace-open-preference`                                                                                 | 使用哪种本机工具打开目录                           | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/WorkspaceOpenButton.tsx:61-101`                                                                                                                                                                                                                                                                                                                          |
+| `chat-preview-width-px`、`chat-workspace-width-px`、`preview-panel-split-ratio`、`chat-preview-split-ratio` | 客户端布局尺寸                                     | `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/ui/useProjectPreviewRegionWidth.tsx:36-47`、`/Users/xli/AionUi/packages/desktop/src/renderer/hooks/ui/useProjectExplorerColumnWidth.tsx:32-43`、`/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx:298-305`、`/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx:106-139` |
+| `grouped-history-collapsed-sections`、`team-section-expanded`                                               | 通用区域折叠偏好，不包含资源 id                    | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useConversations.ts:18-29,153-160`、`/Users/xli/AionUi/packages/desktop/src/renderer/components/layout/Sider/TeamSiderSection.tsx:49-53`                                                                                                                                                                                                                  |
+| `aionui.emoji.recent`                                                                                       | 本机最近 emoji                                     | `/Users/xli/AionUi/packages/desktop/src/renderer/components/chat/EmojiPicker.tsx:462-481`                                                                                                                                                                                                                                                                                                                                                          |
+| `update.includePrerelease`、`aionui.migration-invite-shown`、`aionui.gpuAutoDisableNoticeAckAt`             | 更新、迁移提示、GPU 能力提示                       | key 的读写点位于 renderer update/migration/GPU notice 组件，含义均为当前安装级偏好                                                                                                                                                                                                                                                                                                                                                                 |
+
+这些 key 不应因 Agents logout 或切换而清理。`aionui.sttStreamUnsupported` 保存按 provider/base URL/model 组合得到的客户端能力判断，原则上也属于本机能力缓存；如果未来 provider 配置本身按账号隔离，则该 key 需改为账号维度或去除可识别 endpoint，而不是在每次账号切换时全删。证据：`/Users/xli/AionUi/packages/desktop/src/renderer/services/speech/speechStreamPolicy.ts:12,84-127`。
+
+#### 需要明确授权边界的客户端状态
+
+| key                             | 客户端含义                                         | 授权边界                                             |
+| ------------------------------- | -------------------------------------------------- | ---------------------------------------------------- |
+| `preview-ui:<scope>`            | browser tab 与 file/diff/tab 内容保存在同一个 JSON | 整体保留；资源内容重新访问时由当前 Core session 鉴权 |
+| `aionui:web-fs-picker:last-dir` | 当前 OS 用户最近使用的本地目录                     | 保留；不能据此获得超出 OS/Core 授权的访问权          |
+
+`aionui:web-fs-picker:last-dir` 的定义与更新见 `/Users/xli/AionUi/packages/desktop/src/renderer/components/workspace/webFsPicker.tsx:26,75,96`。
+
+#### WebUI/旧路径，不属于 Ki-Buddy 客户端偏好
+
+`rememberMe`、`rememberedUsername`、`rememberedPassword` 由 WebUI 登录页读写，其中 username/password 虽经前端变换仍是账号 credential 数据，见 `/Users/xli/AionUi/packages/desktop/src/renderer/pages/login/index.tsx:15-17,68-75,154-160`。Ki-Buddy 桌面登录不使用这组 key；它们不能因此被分类成客户端账号无关，也不应交给 Ki-Buddy 清理。若同一 renderer 形态需要支持 WebUI logout，应继续由 WebUI 认证 contract 显式处理。
+
+`/Users/xli/AionUi/packages/desktop/src/common/config/storageKeys.ts:16-28` 还声明了一组旧 storage 常量；当前 renderer 没有找到业务读写点，本文不把“只有常量、无读写”的名称计为实际缓存。
+
+### 2.2 `sessionStorage`
+
+| key / prefix                                                                           | 内容                                                             | 分类           | 依据                                                                                                                                                                                                           |
+| -------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `acp_initial_message_<conversationId>`                                                 | 初始消息和文件引用                                               | 客户端工作状态 | `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/chat/useInitialMessage.ts:12-31,48-69`                                                                                                                  |
+| `aionrs_initial_message_<conversationId>`、`aionrs_initial_processed_<conversationId>` | 初始消息及是否已处理                                             | 客户端工作状态 | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/platforms/aionrs/AionrsSendBox.tsx:350-372`                                                                                                |
+| `conversation-command-queue/<conversationId>`                                          | 待发送命令、文本与文件引用                                       | 客户端工作状态 | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts:82-100,236-291`                                                                                   |
+| `guid.openAssistantEditorIntent`                                                       | 待打开的 assistant id                                            | 客户端工作状态 | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentRepairPage.tsx:68-81`、`/Users/xli/AionUi/packages/desktop/src/renderer/pages/settings/AssistantSettings/index.tsx:185-216` |
+| `aion:last-non-settings-path`                                                          | 最近非 Settings route，可能是 `/conversation/:id` 或 `/team/:id` | 客户端工作状态 | `/Users/xli/AionUi/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx:187-206`、`/Users/xli/AionUi/packages/desktop/src/renderer/components/layout/Layout.tsx:153-165`                         |
+| `AcpE2EStreamInjector` 使用的注入 key                                                  | E2E 流式事件注入                                                 | 临时/测试      | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/platforms/acp/AcpE2EStreamInjector.tsx:98`                                                                                                 |
+
+`sessionStorage` 与 `localStorage` 一样由当前客户端页面持有，不作为 Agents 账号边界。A→B 时可以保留上述状态，但所有资源 id 和文件引用必须在当前 Core user 下重新校验。
+
+### 2.3 当前工作树的处理
+
+当前工作树不再包含 `accountStorage.ts`、`ki-buddy:active-account:*` 或 `ki-buddy:account-storage:*`。Ki-Buddy 的认证 adapter 只清 SWR、注册的 runtime state 和账号相关 config cache，并通过策略参数跳过通用 WebUI 的 renderer storage 清理。
+
+因此 `preview-ui:*`、recent workspace、Explorer、Team UI、route、草稿和客户端偏好在 logout、A→B、B→A 时都保持原值。Core user id 变化仍触发整页 reload，以销毁旧账号的 renderer 内存和订阅。
+
+## 3. renderer 内存、SWR 与运行中状态
+
+### 3.1 SWR 是混合的全局 cache
+
+renderer 根部只有一个没有账号 namespace 的 `SWRConfig`，所有业务 hook 共用同一默认 cache。账号清理通过 `useSWRConfig().cache` 遍历当前 cache 的全部 key，证据：`/Users/xli/AionUi/packages/desktop/src/renderer/main.tsx:265-290`、`/Users/xli/AionUi/packages/desktop/src/renderer/hooks/context/AuthContext.tsx:108-112,307-319`。
+
+这个 Map 同时保存：
+
+- Agents 账号相关资源：conversation、Team、assistant、project/explorer、draft、provider/config 等；
+- 客户端账号无关状态：例如 `system.dir.info`、`cdp.status`、agent logo 等。
+
+因此 SWR 属于“混合需拆分”。当前 `clearAccountState` 遍历并删除整个 SWR cache，见 `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/context/AuthContext.tsx:108-112,307-319`。这种方式能避免账号数据瞬时残留，但也会让客户端级查询重新请求。近期可以保留全清作为安全屏障；长期应给账号资源 key 加 account namespace，或把客户端 query 放到独立 cache。
+
+### 3.2 模块级 Map/Set/store
+
+下表只列与账号切换直接相关的代表项；这些对象没有持久化不代表可以跨账号复用。
+
+| 状态                             | 内容                                                                                  | 分类                                   | 证据                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| -------------------------------- | ------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| conversation sidebar singleton   | conversations、generating/unread/completed sets、active conversation、初始化/刷新状态 | Agents 账号相关                        | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts:123-143,163-213`                                                                                                                                                                                                                                                                                                                                                                                    |
+| send box drafts/prefill          | conversation id、文本、文件引用                                                       | Agents 账号相关                        | `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/chat/useSendBoxDraft.ts:6-38,47-54,69-86,118-166`                                                                                                                                                                                                                                                                                                                                                                                                                |
+| upload store/aborters            | upload path、conversation id、进度、AbortController                                   | Agents 账号相关/临时                   | `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/file/useUploadState.ts:31-69,71-125,129-145`                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| command queue/background runners | conversation queue、运行中的后台发送                                                  | Agents 账号相关/临时                   | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts:82-100,401,517-575`                                                                                                                                                                                                                                                                                                                                                                                        |
+| ACP/Aion runtime caches          | slash command、config status/inflight、ensure runtime、turn clocks、runtime view maps | Agents 账号相关/临时                   | `/Users/xli/AionUi/packages/desktop/src/renderer/hooks/chat/useSlashCommands.ts:8-37`、`/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts:82-101`、`/Users/xli/AionUi/packages/desktop/src/renderer/hooks/agent/useAcpConfigOptions.ts:102-159`、`/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/utils/ensureConversationRuntime.ts:1-20`、`/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/utils/conversationTurnClock.ts:7-36` |
+| Explorer store cache             | project id、expanded/selected/current path、loaded state                              | Agents 账号相关                        | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/explorer/explorerStore.ts:55-105`                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| preview watch/reloader registry  | 当前 preview 的 watcher/reloader                                                      | Agents 账号相关或混合，取决于 tab 类型 | `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/Preview/context/previewWatchStore.ts:35,64,105`、`/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/Preview/context/tabReloaderRegistry.ts:23`                                                                                                                                                                                                                                                                                     |
+| i18n translation cache           | 已加载语言资源                                                                        | 客户端账号无关                         | `/Users/xli/AionUi/packages/desktop/src/renderer/services/i18n/index.ts:60`                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+
+当前只有 conversation list singleton 注册了账号 resetter：注册中心见 `/Users/xli/AionUi/packages/desktop/src/renderer/services/runtime/accountStateLifecycle.ts:1-20`，conversation reset 会清 conversations、生成中/未读/已完成集合、turn ids 与 active id，见 `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts:199-213`。没有找到其他 `registerAccountStateResetter` 调用。
+
+Ki-Buddy provider 维护前一个已经提交的非空 Core user id；当账号从 A 变为 B 时执行整页 reload，见 `/Users/xli/AionUi/packages/desktop/src/renderer/pages/ki-buddy/Auth/KiBuddyAuthProvider.tsx:11-37,46-73`。这会销毁未注册的模块级状态，是当前实现的重要安全屏障。退出为 `null` 本身不会触发 reload，但之后 B 登录仍会与记住的 A 比较并 reload。
+
+provider 在 render 中只比较当前 user id 与上一次已提交的 user id；发现 B 后立即返回 `null`，不挂载 B 的业务 children，再由 `useLayoutEffect` 请求 reload。该门禁阻止新账号业务树在旧 renderer 中提交，同时登录事务仍先执行 abort/reset，不能用 reload 代替旧账号受管进程和运行状态清理。若未来移除 reload，必须先给上表各账号 store 增加显式 abort/reset/unsubscribe，并证明旧事件不会写入新账号页面。
+
+## 4. 应用内浏览器与 `preview-ui`
+
+### 4.1 浏览器站点数据属于客户端
+
+所有 webview 明确使用一个固定且持久的 named partition：`persist:aionui-browser`。代码注释说明它跨 tab、跨 project 共享并在重启后保留，见 `/Users/xli/AionUi/packages/desktop/src/common/config/constants.ts:13-31`；`BrowserViewer` 把该值传给 webview 的 `partition` 属性，见 `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/Preview/browser/BrowserViewer.tsx:29-40,68-79`。
+
+因此它不是 Electron `defaultSession`。边界如下：
+
+| Electron session                                  | 数据                                                                           | 分类            |
+| ------------------------------------------------- | ------------------------------------------------------------------------------ | --------------- |
+| `session.defaultSession`                          | Ki-Buddy/Core auth Cookie 与 CSRF Cookie                                       | Agents 账号相关 |
+| `session.fromPartition('persist:aionui-browser')` | 第三方网站 Cookie、站点 localStorage/IndexedDB 等、HTTP cache、HTTP auth cache | 客户端账号无关  |
+
+唯一的显式浏览数据清理入口从该 named partition 调用 `clearStorageData()`、`clearCache()`、`clearAuthCache()`，见 `/Users/xli/AionUi/packages/desktop/src/process/bridge/applicationBridge.ts:196-223`。这是 Settings 中用户主动执行的“退出全部网站”，不属于 Agents logout/switch。
+
+产品 PRD 也明确：站点登录态全局共享、不随 project 切换、重启后保留、只由“清除浏览数据”入口删除，见 `/Users/xli/AionUi/docs/prds/agent-browser/prd.md:57-78,94-104`。账号切换时清除该 partition 会破坏客户端功能 contract。
+
+### 4.2 browser tab 与站点 session 是两层数据
+
+browser tab 的 URL、title、favicon 与前进/后退状态属于客户端浏览器 UI；站点 Cookie 等属于 Electron partition。两者都与 Agents identity 无关，但物理位置不同：
+
+- 站点数据在 `persist:aionui-browser`；
+- browser tab metadata 与 file/diff tabs 一起在 project-scoped `preview-ui:<scope>` JSON。
+
+`PreviewContext` 会持久化 tabs、active tab 与 preview 内容，见 `/Users/xli/AionUi/packages/desktop/src/renderer/pages/conversation/Preview/context/PreviewContext.tsx:188-217,222-286,408-417,477-495`。PRD 同时要求 browser tab 和文件 tab 并列共存、browser tab 跟随 project，见 `/Users/xli/AionUi/docs/prds/agent-browser/prd.md:57-70`。这里的“跟随 project”是 UI 展示作用域，不等于 Agents 账号所有权。
+
+`preview-ui:*` 整体属于客户端工作状态。browser 与 file/office/diff/text edit tab 都不随 Agents 账号切换清理或改写。tab 中的 project、conversation、file ref 只负责恢复 UI 上下文；真正读取或写入资源时，Core 仍按当前 `CurrentUser.id` 鉴权。
+
+## 5. Core 持久数据、workspace 与文件边界
+
+### 5.1 已按 Core user 隔离的数据
+
+固定 Ki-Core 对 external user 的唯一约束是 `(user_type, external_user_id)`，见 `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-db/migrations/030_user_scope.sql:165-173`。当前 Ki-Buddy external identity 已把规范化 deployment URL 与 Agents user id 组合后哈希，避免不同 Agents 部署的相同 id 合并。
+
+| Core 数据                               | 分类            | 源码证据                                                                                                                                                                                                                                      |
+| --------------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| conversation、message、artifact         | Agents 账号相关 | routes 全部传入 `CurrentUser.id`：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-conversation/src/routes.rs:137-295`；跨用户 message 测试：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-app/tests/message_e2e.rs:290-318` |
+| Team、task、mailbox、session            | Agents 账号相关 | `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-team/src/routes.rs:127-220`                                                                                                                                                           |
+| cron、provider、remote agent、MCP/OAuth | Agents 账号相关 | user-scope migration：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-db/migrations/030_user_scope.sql:209-277`                                                                                                                       |
+| project、project explorer metadata      | Agents 账号相关 | migration 与 routes：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-db/migrations/030_user_scope.sql:881-948`、`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-project/src/routes.rs:52-107`                                 |
+| 自动 conversation workspace             | Agents 账号相关 | 两个用户获得不同的 `conversations/users/{userDir}`：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-app/tests/conversation_e2e.rs:1225-1284`                                                                                          |
+
+这些数据在账号切换时不需要搬迁或删除，访问隔离由新的 Core session/`CurrentUser.id` 完成。renderer 只需丢弃旧账号的响应与 cache。
+
+### 5.2 显式 project workspace：权限与活动历史必须分开
+
+用户通过本机文件选择器显式选择的目录，是当前 OS 用户已经能够访问的真实路径。固定 Ki-Core 的 `Local` file ref 允许访问主机选择器提供的 canonical path；项目 metadata 和 ref resolve 仍按调用者 user id 检查。证据：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-project/src/chat_files.rs:62-128`。
+
+应按下表描述，而不是笼统称为“workspace 按账号隔离”：
+
+| 对象                                                | 分类                                   | 切换行为                                                         |
+| --------------------------------------------------- | -------------------------------------- | ---------------------------------------------------------------- |
+| 本地目录及 OS 文件权限                              | 客户端/OS 用户资源，与 Agents 账号无关 | 不删除目录，不撤销权限，不阻止另一个 Agents 账号再次选择同一路径 |
+| Core project 记录、project explorer metadata        | Agents 账号相关                        | 由 `CurrentUser.id` 隔离                                         |
+| recent workspace、last-dir、活动时间、展开/选中状态 | 客户端工作状态                         | 保留，不随 Agents 账号切换清理                                   |
+| 对话中的本地文件引用、file/diff preview             | 客户端工作状态                         | 保留；实际读写时按当前 Core user 与 OS 权限重新鉴权              |
+
+### 5.3 managed upload 仍有物理目录缺口
+
+固定 Ki-Core 的 upload handler 没有提取 `CurrentUser`，服务把文件写到系统临时目录 `aionui/{conversationId|general}`，目录结构不含 user id。证据：`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-file/src/routes.rs:523-537`、`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-file/src/service.rs:719-783`。
+
+对话记录按用户隐藏 upload 引用，不等于上传物理文件已经按用户隔离。这个缺口不应通过 renderer 账号切换时删除整个 temp root 解决；应由 Core 的 upload path、metadata 和读取 endpoint 补充 user scope，并单独测试已知路径/ID 的跨用户访问。
+
+## 6. Core client preferences 是混合容器
+
+renderer `configService` 从 `/api/settings/client` 读取统一设置对象，内存中只把 `language` 明确放入 client-scoped cache；账号 reset 会清空其余 cache 后保留 language。证据：`/Users/xli/AionUi/packages/desktop/src/common/config/configKeys.ts:4-47`、`/Users/xli/AionUi/packages/desktop/src/common/config/configService.ts:6-14,16-58,68-118`。
+
+固定 Ki-Core 的 client preference repository 以 `CurrentUser.id` 读写，见 `209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-system/src/routes.rs:155-184`、`209e6844d39bac0762c61e198c1ba3a007f9dd2e:crates/aionui-db/src/repository/sqlite_client_preference.rs:20-90`。
+
+这里存在产品语义与物理存储不一致：
+
+- `guid.lastAssistantId`、`assistants.enabledOrder`、provider/skill/agent 相关选择属于 Agents 账号相关；
+- language、theme/color scheme、zoom/font size、window bounds、system tray、notifications、keep-awake、custom CSS/theme、pet 等更接近客户端账号无关偏好；
+- 当前它们在 Core 中都按 user 保存，renderer cache 又只对 language 做特殊处理。
+
+因此 `/api/settings/client` 整体应标为“混合需拆分”。Issue 17 不应通过切换时清掉全部偏好来掩盖这个差异；需要按 config key 确定最终 owner，再选择 client store 或 Core user store。
+
+## 7. Team、task、conversation 与 idempotency
+
+### 7.1 已存在的业务数据
+
+conversation、Team、task、mailbox 已由 Core user scope 隔离，但 renderer 仍会保存相关 id、列表和运行中状态。账号切换顺序应保持：
+
+1. 主进程停止/abort 旧 Agents 请求并 revoke 旧 Core session；
+2. renderer 清空 A 的 SWR、运行中 store 与订阅；Web Storage 保持不变；
+3. 建立 B 的 Core session；
+4. 重新请求 B 的 Core 数据；
+5. 整页 reload 或等价的完整 reset 屏障保证旧订阅不能继续写入。
+
+当前 `kiBuddyAuthAdapter` 在 refresh/login/logout 需要清理时调用 `clearAccountState({ preserveRendererStorage: true })`，只重置 SWR、运行时 store 与 config cache，保留全部 renderer Web Storage。WebUI 默认路径仍执行原有 auth/preview storage 清理。
+
+### 7.2 Agents Adapter idempotency 目前是设计，不是已存在 cache
+
+ADR 0006 计划使用产品 SQLite ledger，以 `(normalized base_url, Agents user id, taskId)` 唯一，跨 logout/switch 保留，但不保存 secret 或任务结果；删除策略与工作历史一致。证据：`/Users/xli/AionUi/docs/adr/0006-guard-remote-invocations-with-local-ledger.md:5-22`。
+
+ADR 0007 的 `uploadRef` 设计为 task/session/account/deployment 绑定且仅在内存中有效；ADR 0008 的 `deliveryRef` 只在当前 Adapter session 有效，不跨账号、session 或重启。证据：`/Users/xli/AionUi/docs/adr/0007-upload-authorized-local-files-inside-adapter.md:7-19`、`/Users/xli/AionUi/docs/adr/0008-deliver-remote-result-files-inside-adapter.md:7-22`。
+
+当前 `packages/desktop/src/process/ki-buddy/` 中没有这些 ledger、`uploadRef` 或 `deliveryRef` 的业务实现。因此它们应标为“计划中”：
+
+- ledger 将是 Agents 账号相关的持久数据，不能在普通 logout 时删除；
+- `uploadRef`、`deliveryRef` 和 active invocation 属于账号绑定的临时状态，切换时必须失效；
+- 现有 Core `ChatFileRef::Upload` 与计划中的 Agents Adapter `uploadRef` 不是同一个对象，不能混为一类。
+
+## 8. AionUi v2.1.54 生产 OAuth 账号切换对照
+
+### 8.1 生产包与公开 tag 不是同一套 desktop auth
+
+公开 tag `982a6013c...` 的 renderer `AuthContext` 在 Electron 下跳过真实 login/logout，但本机 2.1.54 生产包包含额外的 AionPro 模块：desktop SSO login page、Account settings page、主进程 `AuthManager`、Core user bridge 与 `aionpro` identity mode。生产 renderer 可见 `/settings/account`、`desktop-sso-login-page`、`auth.get-session/login/logout` 等路径；主进程可见 `/account/login_by_token`、`/account/account/refresh_access_token`、`/account/account/user_info` 与 `/account/account/logout`。
+
+因此本节只把公开 tag 用作 UI/storage 基线，OAuth 账号行为以解包发布物为准。证据：
+
+- `/private/tmp/aionui-v2.1.54.GdSdoN/app/out/main/index.js:7459-7597,8318-8916`
+- `/private/tmp/aionui-v2.1.54.GdSdoN/app/out/renderer/assets/index-C3aSQzPy.js:5`
+- `/private/tmp/aionui-v2.1.54.GdSdoN/app/out/renderer/assets/index-DqCShKb_.js:13`
+
+### 8.2 OAuth credential 只保存当前活动账号
+
+生产客户端通过系统浏览器打开 AionUi Cloud authorize URL，使用 loopback callback、PKCE `code_verifier`/`code_challenge` 和随机 `state`，再调用 `/account/login_by_token` 换取 access/refresh token。它没有使用应用内浏览器 partition 完成登录。
+
+credential 的持久化结构如下：
+
+| 数据             | 位置                                                                                | 账号语义                                                                                             |
+| ---------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| access token     | 主进程 `AuthManager` 内存                                                           | 当前活动 OAuth session；过期前刷新，不持久化                                                         |
+| refresh token    | OS keychain，service `AionUi Desktop`，account `refresh_token:<env>:aionui_desktop` | 当前环境只有一个活动 credential slot；新登录覆盖，logout 删除                                        |
+| session metadata | `userData/auth.enc`                                                                 | 实际是明文 JSON metadata，包含 schema/env/clientId/expiry/user，不含 refresh token；当前活动账号单槽 |
+| device identity  | `userData/device-id.json`                                                           | 安装级 `deviceId`/`fpDid`，OAuth 换号保留                                                            |
+
+`auth.enc` 这个文件名不能被理解为整个文件已加密；生产实现只把 refresh token 放入 keychain。证据：`/private/tmp/aionui-v2.1.54.GdSdoN/app/out/main/index.js:7476-7597,7990-8035,8400-8458,8646-8916`。
+
+### 8.3 云端账号如何映射到本地 Core user
+
+生产客户端固定以 `--identity-mode aionpro` 启动 Core。OAuth 返回的稳定 `user.id` 直接作为 `external_user_id`：
+
+1. `PUT /api/auth/internal/external-users/{external_user_id}` 幂等创建/读取 Core user；
+2. `POST /api/auth/internal/external-sessions` 获取 Core session；
+3. Core JWT 只留在主进程内存，renderer 只得到写入 Electron `defaultSession` 的 HttpOnly `aionui-session` Cookie；
+4. Core 返回的内部 `core_user_id` 用作 renderer 判断是否发生了账号变化。
+
+Core 的 conversation、Team、task、project、provider、preference 等记录继续按内部 `CurrentUser.id` 读取。A→B 不删除 A 的本地业务数据；再次登录 A 时会重新映射到同一个 Core user。证据：`/private/tmp/aionui-v2.1.54.GdSdoN/app/out/main/index.js:39655-39676,45046-45363`，以及 AionCore `v0.1.65:crates/aionui-auth/src/service.rs:54-153`。
+
+首次从旧 AionUi 升级时存在一次性认领：数据库只有一个 external user 时，首个 AionUi Cloud 用户接管 `system_default_user` 的既有 user-scoped rows，并迁移对应 per-user 文件；第二个 external user 出现后认领窗口永久关闭。换号本身不会再次迁移或复制这些数据。证据：AionCore `v0.1.65:crates/aionui-auth/src/service.rs:54-104`、`v0.1.65:crates/aionui-db/src/repository/user.rs:53-74`。
+
+### 8.4 A→logout→B 的实际顺序
+
+生产客户端没有“直接替换账号”按钮，切换是 logout 后重新 OAuth 登录：
+
+1. Account settings 调用 renderer `logout()`；desktop 分支只调用主进程 `auth.logout`，不会执行 renderer 的 `clearAuthCache()`。
+2. 主进程最多等待 5 秒调用云端 `/account/account/logout`；无论成功、失败或超时，都取消登录流程、清内存 token、删除 `auth.enc` 与 keychain refresh token，并发布 unauthenticated 事件。
+3. Core user bridge 收到退出事件后，提升 A 的 Core session generation、清主进程 Core token、删除 `defaultSession` 中的 Core auth/CSRF Cookie，并清 paired WebUI sessions。A 的持久业务数据不删除。
+4. renderer 路由进入 `/login`。SWR、React store 等旧账号内存此时没有逐项 reset，但业务页面被 auth gate 隐藏。
+5. B 登录后被投影为另一个 Core user。常驻的 account-switch hook 比较上一次非空 `coreUserId` 与 B 的 id；不同则执行 `window.location.reload()`，销毁 renderer 内存、SWR cache、订阅和模块级 store。
+
+证据：`/private/tmp/aionui-v2.1.54.GdSdoN/app/out/main/index.js:8709-8916,45046-45363`、`/private/tmp/aionui-v2.1.54.GdSdoN/app/out/renderer/assets/index-CbVqlqKU.js:67,8598`、`/private/tmp/aionui-v2.1.54.GdSdoN/app/out/renderer/assets/index-DqCShKb_.js:13`。
+
+这个设计依靠两层隔离：Core user scope 负责持久业务数据，renderer reload 负责内存。它没有给 renderer Web Storage 建立 OAuth user namespace。
+
+### 8.5 renderer 持久缓存属于客户端安装
+
+desktop logout 不调用 `clearAuthCache()`，所以它不删除 `preview-ui:*`，也不扫描 auth/csrf/token 名称。生产包中的 `aionui:recent-workspaces`、workspace expansion/activity、search keywords、Team pin、Explorer state、`preview-ui:*` 等使用固定 key；这些 key 的 owner 是当前客户端安装，而不是 OAuth 用户。
+
+实际效果是：
+
+- Core conversation/Team/project 列表由 B 的 Core session 重新请求，服务端不会返回 A 的记录；
+- A 的模块级内存由 reload 清掉；
+- renderer 持久 UI 记录继续由同一客户端使用；其中的资源引用不会替代 B 的 Core 鉴权；
+- A→退出→关闭应用→B 时，首次非空 `coreUserId` 不触发 reload，但进程重启本身已清内存；Web Storage 仍然是共享的；
+- 换回 A 不会恢复“A 专属 renderer 快照”，因为生产包没有这类快照，只会继续使用同一组设备级 key。
+
+因此生产 2.1.54 的边界可以用于 Issue 17：Core user scope 隔离并恢复持久业务数据，reload 隔离 renderer 内存，Web Storage 作为客户端状态持续存在。
+
+### 8.6 browser 在生产 OAuth 切换中保持不变
+
+OAuth 登录使用 `shell.openExternal()` 打开系统浏览器；应用内 browser 使用独立固定 partition `persist:aionui-browser`。OAuth logout、Core session revoke、renderer reload 都不会调用 `clearBrowserData`。只有用户在 Settings 主动执行“清除浏览数据”时才会清该 partition 的 Cookie、storage、HTTP cache 与 HTTP auth cache。
+
+desktop logout 也不删除 `preview-ui:*`，因此生产包中的 browser tab metadata 与 browser partition 都会跨 OAuth 账号保留。该行为支持本次产品判定：Ki-Buddy 切换 Agents 账号也必须保留 browser。
+
+证据：`/private/tmp/aionui-v2.1.54.GdSdoN/app/out/main/index.js:8400-8440`、生产 renderer auth desktop logout 分支 `/private/tmp/aionui-v2.1.54.GdSdoN/app/out/renderer/assets/index-CbVqlqKU.js:67`，以及公开基线 `982a6013c...:packages/desktop/src/common/config/constants.ts:13-31`、`packages/desktop/src/process/bridge/applicationBridge.ts:196-223`。
+
+### 8.7 生产实现中仍值得注意的时序问题
+
+Core user bridge 的 auth listener 在退出时以 `void handleSignedOut(...)` 启动异步撤销，renderer 的 `auth.logout` IPC 不等待这项 Core 清理完成。若用户非常快地完成下一账号登录，旧账号 revoke/clear-cookie 与新账号 provision/install-cookie 存在并发窗口。Issue 17 不应复制这种时序；Ki-Buddy 需要让旧账号 runtime 停止、旧 Core session 撤销完成后，才允许新账号业务视图读取数据。
+
+证据：`/private/tmp/aionui-v2.1.54.GdSdoN/app/out/main/index.js:45320-45363`。
+
+## 9. Issue 17 的实现判定
+
+最终选择：只由 Core user scope 持久化和恢复账号业务数据。renderer Web Storage 属于客户端安装，不建立账号快照，也不在 logout/switch 时清理；因此 conversation、Team、project 等业务授权随 Core user 变化，route、搜索记录、展开状态、待发送队列和 Preview 则保持客户端原值。
+
+### 必须属于账号切换事务
+
+- Agents credential、Core session/defaultSession auth Cookie、旧请求 AbortController 与验证循环；
+- conversation/Team/task/cron/assistant/project 的运行中请求、响应和订阅；
+- SWR 账号数据及所有模块级账号内存 store；
+- 未来 idempotency ledger 的可见性与 active invocation/ref 失效。
+
+### 必须保持不变
+
+- `persist:aionui-browser` 中的 Cookie、站点 storage、cache 与 HTTP auth cache；
+- browser tabs、URL/title/favicon 等浏览器 UI 状态；
+- renderer `localStorage` 与 `sessionStorage` 中的 route、搜索、Explorer、Team UI、草稿和 Preview；
+- 语言、主题、布局、窗口、更新、onboarding、浏览器首次提示等客户端偏好；
+- 用户显式选择的本地目录及 OS 权限。
+
+### 必须保持授权边界
+
+- 全局 SWR Map：账号资源与客户端 query；
+- `/api/settings/client`：assistant/provider 等账号设置与 language/theme/window 等客户端设置；
+- Web Storage 中保存的 Core resource id/file ref：保留 UI 状态，但访问时重新按当前 Core user 鉴权。
+
+### 当前工作树状态
+
+1. Ki-Buddy 不再维护 renderer storage key 清单、active-account marker 或账号快照。
+2. packaged Electron E2E 已使用真实 browser tab 验证 A→B→A 后原 tab 可通过客户端 UI 恢复；切换前写入 `persist:aionui-browser` 的 Cookie 与 site localStorage 仍可读取，recent workspace、搜索、Explorer 和布局 key 同样保持。
+3. `clearAuthCache` 的 broad name scan 保持旧 WebUI 默认 contract；Ki-Buddy 通过 `preserveRendererStorage` 跳过 renderer storage 清理。
+4. 保留 A→B 整页 reload，直到所有模块级账号状态都有 abort/reset/unsubscribe 证明。
+5. 两账号 packaged Electron E2E 只在最终验证时重新生成一次 unpacked app；测试确认客户端 storage 保留、Core conversation 隔离且 A→B→A 可恢复，并确认 named partition 的 `clearStorageData`、`clearCache`、`clearAuthCache` 均未被调用。
+6. Core managed upload 的 user scope 是独立后端缺口，不能用 renderer 清 cache 代替。
+
+## 验证说明
+
+本次使用当前工作树、固定 Ki-Core commit、AionUi v2.1.54 tag 和本机已解包 v2.1.54 生产发布物交叉核查。当前实现已通过 TypeScript、lint、i18n、Ki-Buddy 聚焦单元测试和 packaged Electron 账号切换 E2E。全量 Vitest 中 452 个文件直接通过；唯一需要监听本地端口的 `static-server.unit.test.ts` 因沙箱 `listen EPERM` 单独失败，移到允许监听的环境后 12 项全部通过。packaged E2E 使用最终源码重新生成了一次 macOS arm64 unpacked app。

--- a/packages/desktop/src/renderer/hooks/context/AuthContext.tsx
+++ b/packages/desktop/src/renderer/hooks/context/AuthContext.tsx
@@ -43,7 +43,7 @@ export type AuthHandlers<TCode extends string = string> = {
 };
 
 export type AuthHandlerFactoryOptions = {
-  clearAccountState: () => void;
+  clearAccountState: (options?: { preserveRendererStorage?: boolean }) => void;
   setReady: (ready: boolean) => void;
   setStatus: (status: AuthStatus) => void;
   setUser: (user: AuthUser | null) => void;
@@ -84,9 +84,7 @@ function clearAuthCache(): void {
     clearCookie(CSRF_COOKIE_NAME, '/');
 
     // Clear localStorage auth-related items, plus per-user UI state that must not
-    // leak across accounts. Preview scopes are keyed by project id and hold file
-    // content, so leaving them behind would show the next user the previous one's
-    // open tabs — and nothing else ever cleaned them up.
+    // leak across accounts in the WebUI authentication contract.
     const keysToRemove: string[] = [];
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
@@ -308,9 +306,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children, handlerFac
   const handlers = useMemo(
     () =>
       handlerFactory?.({
-        clearAccountState: () => {
+        clearAccountState: (options) => {
           clearSWRCache(swrCache);
-          clearAuthCache();
+          if (!options?.preserveRendererStorage) clearAuthCache();
           resetAccountScopedRendererState();
         },
         setReady,

--- a/packages/desktop/src/renderer/pages/ki-buddy/Account/index.tsx
+++ b/packages/desktop/src/renderer/pages/ki-buddy/Account/index.tsx
@@ -3,7 +3,6 @@ import { ReplayFive } from '@icon-park/react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/renderer/hooks/context/AuthContext';
-import { usePreviewContext } from '@/renderer/pages/conversation/Preview/context/PreviewContext';
 import SettingsPageWrapper from '@/renderer/pages/settings/components/SettingsPageWrapper';
 import { replayKiBuddyOpeningGuide } from '../Onboarding';
 import AccountCard from './AccountCard';
@@ -14,7 +13,6 @@ const KiBuddyAccountSettings: React.FC = () => {
   const { t } = useTranslation();
   const { logout, user } = useAuth();
   const { profile } = useKiBuddyAuth();
-  const { clearPreviewForScope, closePreview } = usePreviewContext();
   const [logoutVisible, setLogoutVisible] = useState(false);
   const [logoutLoading, setLogoutLoading] = useState(false);
 
@@ -22,9 +20,7 @@ const KiBuddyAccountSettings: React.FC = () => {
 
   const handleLogout = async () => {
     setLogoutLoading(true);
-    closePreview();
     await logout();
-    clearPreviewForScope();
   };
 
   return (

--- a/packages/desktop/src/renderer/pages/ki-buddy/Auth/KiBuddyAuthProvider.tsx
+++ b/packages/desktop/src/renderer/pages/ki-buddy/Auth/KiBuddyAuthProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { AuthProvider, useAuth } from '@/renderer/hooks/context/AuthContext';
 import type { KiBuddyAgentsProfile } from '@/common/types/platform/kiBuddyAuth';
 import {
@@ -9,23 +9,29 @@ import {
 } from './kiBuddyAuthAdapter';
 
 type KiBuddyAccountSwitchBarrier = {
-  observe: (userId: string | null) => void;
+  recordCommittedUser: (userId: string | null) => void;
+  requestReload: () => void;
+  shouldBlock: (userId: string | null) => boolean;
 };
 
-/** Remembers the last active Core user and reloads when a different account becomes active. */
+/** Remembers the last active Core user and blocks a different account until the renderer reloads. */
 export function createKiBuddyAccountSwitchBarrier(reload: () => void): KiBuddyAccountSwitchBarrier {
   let previousUserId: string | null = null;
   let reloadRequested = false;
 
   return {
-    observe: (userId) => {
-      if (!userId || reloadRequested) return;
-      if (previousUserId && previousUserId !== userId) {
+    recordCommittedUser: (userId) => {
+      if (userId) previousUserId = userId;
+    },
+    requestReload: () => {
+      if (!reloadRequested) {
         reloadRequested = true;
         reload();
-        return;
       }
-      previousUserId = userId;
+    },
+    shouldBlock: (userId) => {
+      if (!userId) return false;
+      return Boolean(previousUserId && previousUserId !== userId);
     },
   };
 }
@@ -37,31 +43,50 @@ type KiBuddyAuthContextValue = {
 
 const KiBuddyAuthContext = createContext<KiBuddyAuthContextValue | undefined>(undefined);
 
+function reloadRenderer(): void {
+  window.location.reload();
+}
+
 const KiBuddyAuthContextBridge: React.FC<
-  React.PropsWithChildren<{ adapter: KiBuddyAuthAdapter; profile: KiBuddyAgentsProfile | null }>
-> = ({ adapter, children, profile }) => {
+  React.PropsWithChildren<{
+    adapter: KiBuddyAuthAdapter;
+    profile: KiBuddyAgentsProfile | null;
+    reload: () => void;
+  }>
+> = ({ adapter, children, profile, reload }) => {
   const { login: authenticate, refresh, user } = useAuth();
-  const accountSwitchBarrier = useMemo(() => createKiBuddyAccountSwitchBarrier(() => window.location.reload()), []);
+  const accountSwitchBarrier = useMemo(() => createKiBuddyAccountSwitchBarrier(reload), [reload]);
   const login = useCallback(
     (params: KiBuddyLoginParams) => adapter.login(params, authenticate),
     [adapter, authenticate]
   );
   const value = useMemo(() => ({ login, profile }), [login, profile]);
+  const accountSwitchBlocked = accountSwitchBarrier.shouldBlock(user?.id ?? null);
 
-  useEffect(() => accountSwitchBarrier.observe(user?.id ?? null), [accountSwitchBarrier, user?.id]);
+  useLayoutEffect(() => {
+    if (accountSwitchBlocked) {
+      accountSwitchBarrier.requestReload();
+      return;
+    }
+    accountSwitchBarrier.recordCommittedUser(user?.id ?? null);
+  }, [accountSwitchBarrier, accountSwitchBlocked, user?.id]);
   useEffect(() => adapter.subscribeToSessionInvalidation(() => void refresh()), [adapter, refresh]);
 
+  if (accountSwitchBlocked) return null;
   return <KiBuddyAuthContext.Provider value={value}>{children}</KiBuddyAuthContext.Provider>;
 };
 
 /** Owns Ki-Buddy-only authentication state while delegating common session state to AuthContext. */
-export const KiBuddyAuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+export const KiBuddyAuthProvider: React.FC<React.PropsWithChildren<{ reload?: () => void }>> = ({
+  children,
+  reload = reloadRenderer,
+}) => {
   const [profile, setProfile] = useState<KiBuddyAgentsProfile | null>(null);
   const adapter = useMemo(() => createKiBuddyAuthAdapter({ setProfile }), []);
 
   return (
     <AuthProvider handlerFactory={adapter.handlerFactory}>
-      <KiBuddyAuthContextBridge adapter={adapter} profile={profile}>
+      <KiBuddyAuthContextBridge adapter={adapter} profile={profile} reload={reload}>
         {children}
       </KiBuddyAuthContextBridge>
     </AuthProvider>

--- a/packages/desktop/src/renderer/pages/ki-buddy/Auth/kiBuddyAuthAdapter.ts
+++ b/packages/desktop/src/renderer/pages/ki-buddy/Auth/kiBuddyAuthAdapter.ts
@@ -51,7 +51,7 @@ export function createKiBuddyAuthAdapter(options: {
       const api = getKiBuddyRendererRuntime()?.authApi;
       if (!api) return null;
       const clearAccountState = () => {
-        state.clearAccountState();
+        state.clearAccountState({ preserveRendererStorage: true });
         configService.resetForAccountChange();
       };
 

--- a/tests/e2e/features/remote/ki-buddy-auth.e2e.ts
+++ b/tests/e2e/features/remote/ki-buddy-auth.e2e.ts
@@ -1,6 +1,8 @@
 import http from 'node:http';
+import { mkdtemp, rm } from 'node:fs/promises';
 import type { AddressInfo } from 'node:net';
 import os from 'node:os';
+import path from 'node:path';
 import { test, expect } from '../../fixtures';
 
 type CoreCurrentUserResponse = {
@@ -14,7 +16,7 @@ type CoreCurrentUserResponse = {
 const AGENTS_USERS = [
   {
     email: 'ki-buddy-e2e-a@example.com',
-    name: 'Ki-Buddy E2E User A',
+    name: 'Ki-Buddy Shared Visible Name',
     orgName: 'Ki-Buddy E2E',
     phone: '10086',
     roles: [{ name: 'member' }],
@@ -24,7 +26,7 @@ const AGENTS_USERS = [
   },
   {
     email: 'ki-buddy-e2e-b@example.com',
-    name: 'Ki-Buddy E2E User B',
+    name: 'Ki-Buddy Shared Visible Name',
     orgName: 'Ki-Buddy E2E',
     phone: '10010',
     roles: [{ name: 'member' }],
@@ -36,6 +38,9 @@ const AGENTS_USERS = [
 
 const AGENTS_USER_A = AGENTS_USERS[0];
 const AGENTS_USER_B = AGENTS_USERS[1];
+const BROWSER_SITE_COOKIE = 'ki-buddy-browser-session=preserved';
+const BROWSER_SITE_STORAGE_KEY = 'ki-buddy-browser-storage';
+const BROWSER_SITE_STORAGE_VALUE = 'preserved';
 
 function findUserByToken(authorization: string | undefined) {
   return AGENTS_USERS.find((user) => authorization === `Bearer ${user.token}`);
@@ -56,7 +61,11 @@ const COMMON_USER_FIELDS = {
 };
 
 async function startFakeAgentsServer(
-  options: { invalidLoginAttempts?: number; repeatFirstUser?: boolean } = {}
+  options: {
+    invalidLoginAttempts?: number;
+    loginUserSequence?: readonly (typeof AGENTS_USERS)[number][];
+    repeatFirstUser?: boolean;
+  } = {}
 ): Promise<{
   baseUrl: string;
   close: () => Promise<void>;
@@ -69,6 +78,12 @@ async function startFakeAgentsServer(
   let validationRequestCount = 0;
   const invalidLoginAttempts = options.invalidLoginAttempts ?? 0;
   const server = http.createServer((request, response) => {
+    if (request.method === 'GET' && request.url === '/browser-state') {
+      response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      response.end('<title>Ki-Buddy Browser State</title><main>Read-only browser partition probe</main>');
+      return;
+    }
+
     const isLogin = request.method === 'POST' && request.url === '/kagent/login';
     const isValidation = request.method === 'POST' && request.url === '/kagent/system/user/validateToken';
 
@@ -84,8 +99,12 @@ async function startFakeAgentsServer(
     }
 
     if (isValidation) validationRequestCount += 1;
+    const loginIndex = Math.max(loginAttempts - invalidLoginAttempts - 1, 0);
+    const sequenceUser = options.loginUserSequence?.length
+      ? options.loginUserSequence[Math.min(loginIndex, options.loginUserSequence.length - 1)]
+      : undefined;
     const user = isLogin
-      ? AGENTS_USERS[options.repeatFirstUser ? 0 : Math.min(loginAttempts - invalidLoginAttempts - 1, 1)]
+      ? (sequenceUser ?? AGENTS_USERS[options.repeatFirstUser ? 0 : Math.min(loginIndex, 1)])
       : findUserByToken(request.headers.authorization);
     if (!user) {
       response.writeHead(401).end();
@@ -140,7 +159,11 @@ async function readCoreCurrentUser(page: import('@playwright/test').Page): Promi
   });
 }
 
-async function createCoreConversation(page: import('@playwright/test').Page, name: string): Promise<string> {
+async function createCoreConversation(
+  page: import('@playwright/test').Page,
+  name: string,
+  workspace = os.tmpdir()
+): Promise<string> {
   return page.evaluate(
     async ({ conversationName, workspace }) => {
       const port = (window as Window & { __backendPort?: number }).__backendPort;
@@ -173,8 +196,35 @@ async function createCoreConversation(page: import('@playwright/test').Page, nam
       if (!body.data?.id) throw new Error('POST /api/conversations returned no conversation id');
       return body.data.id;
     },
-    { conversationName: name, workspace: os.tmpdir() }
+    { conversationName: name, workspace }
   );
+}
+
+type CoreConversationResponse = {
+  success: boolean;
+  data?: {
+    id?: string;
+    extra?: {
+      workspace?: string;
+    };
+  };
+};
+
+async function readCoreConversation(
+  page: import('@playwright/test').Page,
+  conversationId: string
+): Promise<{ body: CoreConversationResponse; status: number }> {
+  return page.evaluate(async (id) => {
+    const port = (window as Window & { __backendPort?: number }).__backendPort;
+    if (!port) throw new Error('Ki-Core backend port is unavailable in the renderer');
+    const response = await fetch(`http://127.0.0.1:${port}/api/conversations/${encodeURIComponent(id)}`, {
+      credentials: 'include',
+    });
+    return {
+      body: (await response.json()) as CoreConversationResponse,
+      status: response.status,
+    };
+  }, conversationId);
 }
 
 async function readCoreConversationStatus(
@@ -216,6 +266,245 @@ async function waitForLoginSuccess(page: import('@playwright/test').Page): Promi
       { cause: error }
     );
   }
+}
+
+async function loginThroughUi(
+  page: import('@playwright/test').Page,
+  params: { baseUrl: string; username: string }
+): Promise<void> {
+  await fillLoginForm(page, params);
+  await page.getByRole('button', { name: /^(登录|Sign In)$/i }).click();
+  await waitForLoginSuccess(page);
+}
+
+async function logoutThroughUi(page: import('@playwright/test').Page): Promise<void> {
+  if (!/#\/settings\//.test(page.url())) {
+    await page
+      .locator('.sider-footer')
+      .getByText(/^(设置|Settings)$/i)
+      .click();
+  }
+  await page.locator('[data-settings-id="account"]').click();
+  await expect(page).toHaveURL(/#\/settings\/account$/);
+  try {
+    await expect(page.getByTestId('ki-buddy-account-card')).toBeVisible({ timeout: 30_000 });
+  } catch (error) {
+    const session = await page.evaluate(() => window.electronAPI?.kiBuddyAuth?.getSession()).catch(() => null);
+    const visibleText = (await page.locator('body').innerText()).slice(0, 2_000);
+    throw new Error(
+      `Ki-Buddy account page did not render. Session: ${JSON.stringify(session)}. Visible text: ${visibleText}`,
+      { cause: error }
+    );
+  }
+  await page.getByTestId('ki-buddy-account-menu-button').click();
+  await page.getByTestId('ki-buddy-account-logout-menu-item').click();
+  const logoutModal = page.getByTestId('ki-buddy-account-logout-modal');
+  await expect(logoutModal).toBeVisible();
+  await logoutModal.getByRole('button', { name: /^(退出登录|Sign out)$/i }).click();
+  await page.locator('input[autocomplete="username"]').waitFor({ state: 'visible' });
+}
+
+type PersistedBrowserTab = {
+  content: string;
+  content_type: string;
+  id: string;
+  title: string;
+};
+
+async function readPersistedBrowserTabs(page: import('@playwright/test').Page): Promise<PersistedBrowserTab[]> {
+  return page.evaluate(() => {
+    const tabs: PersistedBrowserTab[] = [];
+    for (let index = 0; index < localStorage.length; index += 1) {
+      const key = localStorage.key(index);
+      if (!key?.startsWith('preview-ui:')) continue;
+      try {
+        const parsed = JSON.parse(localStorage.getItem(key) ?? '{}') as { tabs?: unknown };
+        if (!Array.isArray(parsed.tabs)) continue;
+        for (const value of parsed.tabs) {
+          if (!value || typeof value !== 'object') continue;
+          const tab = value as Partial<PersistedBrowserTab>;
+          if (
+            tab.content_type === 'browser' &&
+            typeof tab.id === 'string' &&
+            typeof tab.title === 'string' &&
+            typeof tab.content === 'string'
+          ) {
+            tabs.push(tab as PersistedBrowserTab);
+          }
+        }
+      } catch {
+        // Corrupt preview state is not a valid browser tab.
+      }
+    }
+    return tabs;
+  });
+}
+
+async function openClientBrowserForConversation(
+  page: import('@playwright/test').Page,
+  conversationId: string,
+  expectedUrl = 'about:blank'
+): Promise<PersistedBrowserTab> {
+  const conversation = page.locator(`#c-${conversationId}`);
+  await expect(conversation).toBeVisible({ timeout: 30_000 });
+  await conversation.click();
+  await expect(page.locator('.workspace-open-button__dropdown-btn')).toBeVisible({ timeout: 30_000 });
+  await page.locator('.workspace-open-button__dropdown-btn').click();
+  await page
+    .locator('.workspace-open-dropdown-item')
+    .filter({ hasText: /^(浏览器|Browser)$/i })
+    .click();
+  await expect(page.locator('.aion-url-viewer-toolbar .toolbar-input')).toBeVisible({ timeout: 30_000 });
+  await expect
+    .poll(async () => (await readPersistedBrowserTabs(page)).find((tab) => tab.content === expectedUrl), {
+      timeout: 30_000,
+    })
+    .toMatchObject({
+      content: expectedUrl,
+      content_type: 'browser',
+      id: expect.any(String),
+      title: expect.any(String),
+    });
+  const browserTab = (await readPersistedBrowserTabs(page)).find((tab) => tab.content === expectedUrl);
+  if (!browserTab) throw new Error('The client browser tab was not persisted');
+  return browserTab;
+}
+
+async function restoreClientBrowserForConversation(
+  page: import('@playwright/test').Page,
+  conversationId: string,
+  expectedTab: PersistedBrowserTab
+): Promise<void> {
+  const conversation = page.locator(`#c-${conversationId}`);
+  await expect(conversation).toBeVisible({ timeout: 30_000 });
+  await conversation.click();
+  expect(await page.evaluate(() => localStorage.getItem('workspace-open-preference'))).toBe('browser');
+  await page.locator('.workspace-open-button__btn').click();
+  await page.locator(`span[title=${JSON.stringify(expectedTab.title)}]`).click();
+  await expect(
+    page.locator(`.aion-url-viewer-toolbar .toolbar-input[value=${JSON.stringify(expectedTab.content)}]`)
+  ).toHaveCount(1, { timeout: 30_000 });
+  expect(await readPersistedBrowserTabs(page)).toContainEqual(expectedTab);
+}
+
+async function navigateClientBrowser(
+  page: import('@playwright/test').Page,
+  tabId: string,
+  targetUrl: string,
+  expectedTitle: string
+): Promise<PersistedBrowserTab> {
+  const addressBar = page.locator('.aion-url-viewer-toolbar .toolbar-input');
+  await addressBar.fill(targetUrl);
+  await addressBar.press('Enter');
+  await expect
+    .poll(async () => (await readPersistedBrowserTabs(page)).find((tab) => tab.id === tabId), { timeout: 30_000 })
+    .toMatchObject({ content: targetUrl, id: tabId, title: expectedTitle });
+  const browserTab = (await readPersistedBrowserTabs(page)).find((tab) => tab.id === tabId);
+  if (!browserTab) throw new Error('The navigated client browser tab was not persisted');
+  await expect(page.locator('webview[partition="persist:aionui-browser"]')).toHaveCount(1);
+  return browserTab;
+}
+
+type BrowserSiteState = {
+  cookie: string;
+  storageValue: string | null;
+};
+
+async function writeBrowserSiteState(page: import('@playwright/test').Page): Promise<BrowserSiteState> {
+  return page.locator('webview[partition="persist:aionui-browser"]').evaluate(
+    async (element, state) => {
+      const webview = element as HTMLElement & {
+        executeJavaScript: (script: string) => Promise<BrowserSiteState>;
+      };
+      return webview.executeJavaScript(`(() => {
+        document.cookie = ${JSON.stringify(`${state.cookie}; Path=/; SameSite=Lax`)};
+        localStorage.setItem(${JSON.stringify(state.storageKey)}, ${JSON.stringify(state.storageValue)});
+        return {
+          cookie: document.cookie,
+          storageValue: localStorage.getItem(${JSON.stringify(state.storageKey)})
+        };
+      })()`);
+    },
+    {
+      cookie: BROWSER_SITE_COOKIE,
+      storageKey: BROWSER_SITE_STORAGE_KEY,
+      storageValue: BROWSER_SITE_STORAGE_VALUE,
+    }
+  );
+}
+
+async function readBrowserSiteState(
+  page: import('@playwright/test').Page,
+  targetUrl: string
+): Promise<BrowserSiteState> {
+  return page
+    .locator(`webview[partition="persist:aionui-browser"][src=${JSON.stringify(targetUrl)}]`)
+    .evaluate(async (element, storageKey) => {
+      const webview = element as HTMLElement & {
+        executeJavaScript: (script: string) => Promise<BrowserSiteState>;
+      };
+      return webview.executeJavaScript(`({
+        cookie: document.cookie,
+        storageValue: localStorage.getItem(${JSON.stringify(storageKey)})
+      })`);
+    }, BROWSER_SITE_STORAGE_KEY);
+}
+
+async function readClientStorage(
+  page: import('@playwright/test').Page,
+  localKeys: string[],
+  sessionKeys: string[]
+): Promise<{ local: Record<string, string | null>; session: Record<string, string | null> }> {
+  return page.evaluate(
+    ({ localKeys: expectedLocalKeys, sessionKeys: expectedSessionKeys }) => ({
+      local: Object.fromEntries(expectedLocalKeys.map((key) => [key, localStorage.getItem(key)])),
+      session: Object.fromEntries(expectedSessionKeys.map((key) => [key, sessionStorage.getItem(key)])),
+    }),
+    { localKeys, sessionKeys }
+  );
+}
+
+type BrowserDataClearCalls = {
+  authCache: number;
+  httpCache: number;
+  storage: number;
+};
+
+async function trackBrowserDataClearCalls(electronApp: import('@playwright/test').ElectronApplication): Promise<void> {
+  await electronApp.evaluate(async ({ session }, partition) => {
+    const state = globalThis as typeof globalThis & {
+      __kiBuddyBrowserDataClearCalls?: BrowserDataClearCalls;
+    };
+    const calls: BrowserDataClearCalls = { authCache: 0, httpCache: 0, storage: 0 };
+    state.__kiBuddyBrowserDataClearCalls = calls;
+    const browserSession = session.fromPartition(partition);
+    const clearStorageData = browserSession.clearStorageData.bind(browserSession);
+    const clearCache = browserSession.clearCache.bind(browserSession);
+    const clearAuthCache = browserSession.clearAuthCache.bind(browserSession);
+    browserSession.clearStorageData = async (options) => {
+      calls.storage += 1;
+      await clearStorageData(options);
+    };
+    browserSession.clearCache = async () => {
+      calls.httpCache += 1;
+      await clearCache();
+    };
+    browserSession.clearAuthCache = async () => {
+      calls.authCache += 1;
+      await clearAuthCache();
+    };
+  }, 'persist:aionui-browser');
+}
+
+async function readBrowserDataClearCalls(
+  electronApp: import('@playwright/test').ElectronApplication
+): Promise<BrowserDataClearCalls> {
+  return electronApp.evaluate(async () => {
+    const state = globalThis as typeof globalThis & {
+      __kiBuddyBrowserDataClearCalls?: BrowserDataClearCalls;
+    };
+    return state.__kiBuddyBrowserDataClearCalls ?? { authCache: 0, httpCache: 0, storage: 0 };
+  });
 }
 
 test.describe('Ki-Buddy packaged Agents authentication', () => {
@@ -303,16 +592,7 @@ test.describe('Ki-Buddy packaged Agents authentication', () => {
       });
       await staleRequestStarted;
 
-      await page.evaluate(() => {
-        window.location.hash = '#/settings/account';
-      });
-      await expect(page.getByTestId('ki-buddy-account-card')).toBeVisible();
-      await page.getByTestId('ki-buddy-account-menu-button').click();
-      await page.getByTestId('ki-buddy-account-logout-menu-item').click();
-      const logoutModal = page.getByTestId('ki-buddy-account-logout-modal');
-      await expect(logoutModal).toBeVisible();
-      await logoutModal.getByRole('button', { name: /^(退出登录|Sign out)$/i }).click();
-      await page.locator('input[autocomplete="username"]').waitFor({ state: 'visible' });
+      await logoutThroughUi(page);
 
       await fillLoginForm(page, { baseUrl: agents.baseUrl, username: AGENTS_USER_B.userName });
       await page.getByRole('button', { name: /^(登录|Sign In)$/i }).click();
@@ -371,6 +651,153 @@ test.describe('Ki-Buddy packaged Agents authentication', () => {
     } finally {
       await page.evaluate(() => window.electronAPI?.kiBuddyAuth?.logout()).catch(() => undefined);
       await agents.close();
+    }
+  });
+
+  test('uses Core user scope while preserving client storage, browser, and workspace semantics', async ({
+    isolatedPackagedApp: electronApp,
+    isolatedPackagedPage: page,
+  }) => {
+    const agents = await startFakeAgentsServer({
+      loginUserSequence: [AGENTS_USER_A, AGENTS_USER_B, AGENTS_USER_A],
+    });
+    const projectWorkspace = await mkdtemp(path.join(os.tmpdir(), 'ki-buddy-account-workspace-'));
+    let accountAConversationId: string | null = null;
+
+    try {
+      await trackBrowserDataClearCalls(electronApp);
+      await page
+        .locator('#ki-buddy-opening-guide-title, input[autocomplete="username"]')
+        .first()
+        .waitFor({ state: 'visible', timeout: 30_000 });
+      const skipGuide = page.getByRole('button', { name: /^(跳过|Skip)$/i });
+      if (await skipGuide.isVisible().catch(() => false)) await skipGuide.click();
+      await page.locator('input[autocomplete="username"]').waitFor({ state: 'visible', timeout: 30_000 });
+
+      await loginThroughUi(page, { baseUrl: agents.baseUrl, username: AGENTS_USER_A.userName });
+      const accountACoreUser = await readCoreCurrentUser(page);
+      expect(accountACoreUser).toMatchObject({
+        status: 200,
+        body: { user: { id: expect.any(String), username: AGENTS_USER_A.userName } },
+      });
+      accountAConversationId = await createCoreConversation(
+        page,
+        `E2E account A project ${Date.now()}`,
+        projectWorkspace
+      );
+      expect(await readCoreConversation(page, accountAConversationId)).toMatchObject({
+        status: 200,
+        body: {
+          data: {
+            extra: { workspace: projectWorkspace },
+          },
+        },
+      });
+      const blankBrowserTab = await openClientBrowserForConversation(page, accountAConversationId);
+      const browserPageUrl = `${agents.baseUrl}/browser-state`;
+      const clientBrowserTab = await navigateClientBrowser(
+        page,
+        blankBrowserTab.id,
+        browserPageUrl,
+        'Ki-Buddy Browser State'
+      );
+      await expect
+        .poll(() => writeBrowserSiteState(page), { timeout: 30_000 })
+        .toEqual({ cookie: BROWSER_SITE_COOKIE, storageValue: BROWSER_SITE_STORAGE_VALUE });
+      const clientStorage = {
+        'aionui:recent-workspaces': JSON.stringify([{ path: projectWorkspace, name: 'Local client workspace' }]),
+        'conversation.historySearch.recentKeywords': JSON.stringify(['client search history']),
+        'explorer-ui:e2e-client-project': JSON.stringify({ expanded: ['src'], selected: 'src/index.ts' }),
+        'team-section-expanded': 'false',
+      };
+      const clientSessionStorage = {
+        'aion:last-non-settings-path': '/guid',
+        'conversation-command-queue/e2e-client-conversation': JSON.stringify({ items: [{ input: 'client draft' }] }),
+      };
+      await page.evaluate(
+        ({ localEntries, sessionEntries }) => {
+          for (const [key, value] of Object.entries(localEntries)) localStorage.setItem(key, value);
+          for (const [key, value] of Object.entries(sessionEntries)) sessionStorage.setItem(key, value);
+        },
+        { localEntries: clientStorage, sessionEntries: clientSessionStorage }
+      );
+      const expectedClientStorage = { local: clientStorage, session: clientSessionStorage };
+
+      const accountADocumentTimeOrigin = await page.evaluate(() => performance.timeOrigin);
+      await logoutThroughUi(page);
+      await loginThroughUi(page, { baseUrl: agents.baseUrl, username: AGENTS_USER_B.userName });
+      await expect
+        .poll(async () => page.evaluate(() => performance.timeOrigin), { timeout: 30_000 })
+        .not.toBe(accountADocumentTimeOrigin);
+      await expect(page).toHaveURL(/#\/guid$/);
+      const accountBCoreUser = await readCoreCurrentUser(page);
+      expect(accountBCoreUser).toMatchObject({
+        status: 200,
+        body: { user: { id: expect.any(String), username: AGENTS_USER_B.userName } },
+      });
+      expect(accountBCoreUser.body.user?.id).not.toBe(accountACoreUser.body.user?.id);
+      expect(await readPersistedBrowserTabs(page)).toEqual([clientBrowserTab]);
+      expect(await readClientStorage(page, Object.keys(clientStorage), Object.keys(clientSessionStorage))).toEqual(
+        expectedClientStorage
+      );
+      expect((await readCoreConversation(page, accountAConversationId)).status).toBe(404);
+      await expect(page.locator(`#c-${accountAConversationId}`)).toHaveCount(0);
+
+      const accountBConversationId = await createCoreConversation(
+        page,
+        `E2E account B same project ${Date.now()}`,
+        projectWorkspace
+      );
+      expect(await readCoreConversation(page, accountBConversationId)).toMatchObject({
+        status: 200,
+        body: {
+          data: {
+            extra: { workspace: projectWorkspace },
+          },
+        },
+      });
+
+      const accountBDocumentTimeOrigin = await page.evaluate(() => performance.timeOrigin);
+      await logoutThroughUi(page);
+      await loginThroughUi(page, { baseUrl: agents.baseUrl, username: AGENTS_USER_A.userName });
+      await expect
+        .poll(async () => page.evaluate(() => performance.timeOrigin), { timeout: 30_000 })
+        .not.toBe(accountBDocumentTimeOrigin);
+      await expect(page).toHaveURL(/#\/guid$/);
+      expect(await readCoreCurrentUser(page)).toMatchObject({
+        status: 200,
+        body: {
+          user: {
+            id: accountACoreUser.body.user?.id,
+            username: AGENTS_USER_A.userName,
+          },
+        },
+      });
+      expect(await readPersistedBrowserTabs(page)).toEqual([clientBrowserTab]);
+      expect(await readClientStorage(page, Object.keys(clientStorage), Object.keys(clientSessionStorage))).toEqual(
+        expectedClientStorage
+      );
+      expect(await readCoreConversation(page, accountAConversationId)).toMatchObject({
+        status: 200,
+        body: {
+          data: {
+            extra: { workspace: projectWorkspace },
+          },
+        },
+      });
+      expect((await readCoreConversation(page, accountBConversationId)).status).toBe(404);
+      await expect(page.locator(`#c-${accountAConversationId}`)).toBeVisible({ timeout: 30_000 });
+      await expect(page.locator(`#c-${accountBConversationId}`)).toHaveCount(0);
+      await restoreClientBrowserForConversation(page, accountAConversationId, clientBrowserTab);
+      await expect
+        .poll(() => readBrowserSiteState(page, browserPageUrl), { timeout: 30_000 })
+        .toEqual({ cookie: BROWSER_SITE_COOKIE, storageValue: BROWSER_SITE_STORAGE_VALUE });
+      expect(await readBrowserDataClearCalls(electronApp)).toEqual({ authCache: 0, httpCache: 0, storage: 0 });
+    } finally {
+      if (accountAConversationId) await deleteCoreConversation(page, accountAConversationId).catch(() => undefined);
+      await page.evaluate(() => window.electronAPI?.kiBuddyAuth?.logout()).catch(() => undefined);
+      await agents.close();
+      await rm(projectWorkspace, { force: true, recursive: true });
     }
   });
 

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -20,6 +20,11 @@ import os from 'os';
 
 type Fixtures = {
   electronApp: ElectronApplication;
+  isolatedPackagedApp: ElectronApplication;
+  isolatedPackagedContext: {
+    electronApp: ElectronApplication;
+    page: Page;
+  };
   isolatedPackagedPage: Page;
   page: Page;
 };
@@ -318,7 +323,7 @@ export const test = base.extend<Fixtures>({
   // suites. This keeps timers, Core memory, credentials, and database state
   // independent from the shared singleton used by ordinary E2E tests.
   // eslint-disable-next-line no-empty-pattern
-  isolatedPackagedPage: async ({}, use) => {
+  isolatedPackagedContext: async ({}, use) => {
     const packaged = resolvePackagedApp();
     if (!packaged) {
       throw new Error(
@@ -342,11 +347,19 @@ export const test = base.extend<Fixtures>({
     });
 
     try {
-      await use(await resolveMainWindow(isolatedApp));
+      await use({ electronApp: isolatedApp, page: await resolveMainWindow(isolatedApp) });
     } finally {
       await isolatedApp.close().catch(() => undefined);
       fs.rmSync(sandboxDir, { recursive: true, force: true });
     }
+  },
+
+  isolatedPackagedApp: async ({ isolatedPackagedContext }, use) => {
+    await use(isolatedPackagedContext.electronApp);
+  },
+
+  isolatedPackagedPage: async ({ isolatedPackagedContext }, use) => {
+    await use(isolatedPackagedContext.page);
   },
 
   page: async ({ electronApp }, use, testInfo: TestInfo) => {

--- a/tests/unit/renderer/ki-buddy/Account.dom.test.tsx
+++ b/tests/unit/renderer/ki-buddy/Account.dom.test.tsx
@@ -2,16 +2,12 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { authState, productAuthState, clearPreviewForScopeMock, closePreviewMock, logoutMock, replayMock } = vi.hoisted(
-  () => ({
-    authState: { user: null as { id: string; username: string } | null },
-    productAuthState: { profile: null as typeof agentsProfile | null },
-    clearPreviewForScopeMock: vi.fn(),
-    closePreviewMock: vi.fn(),
-    logoutMock: vi.fn(),
-    replayMock: vi.fn(),
-  })
-);
+const { authState, productAuthState, logoutMock, replayMock } = vi.hoisted(() => ({
+  authState: { user: null as { id: string; username: string } | null },
+  productAuthState: { profile: null as typeof agentsProfile | null },
+  logoutMock: vi.fn(),
+  replayMock: vi.fn(),
+}));
 
 const agentsProfile = {
   userId: 'agents-user-42',
@@ -41,13 +37,6 @@ vi.mock('@/renderer/pages/ki-buddy/Auth', () => ({
   useKiBuddyAuth: () => ({ profile: productAuthState.profile }),
 }));
 
-vi.mock('@/renderer/pages/conversation/Preview/context/PreviewContext', () => ({
-  usePreviewContext: () => ({
-    closePreview: closePreviewMock,
-    clearPreviewForScope: clearPreviewForScopeMock,
-  }),
-}));
-
 vi.mock('@/renderer/pages/settings/components/SettingsPageWrapper', () => ({
   default: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
 }));
@@ -64,8 +53,6 @@ describe('KiBuddyAccountSettings', () => {
     productAuthState.profile = agentsProfile;
     logoutMock.mockReset();
     logoutMock.mockResolvedValue(undefined);
-    closePreviewMock.mockReset();
-    clearPreviewForScopeMock.mockReset();
     replayMock.mockReset();
   });
 
@@ -98,7 +85,7 @@ describe('KiBuddyAccountSettings', () => {
     );
   });
 
-  it('confirms logout and clears the in-memory workspace preview', async () => {
+  it('confirms logout without treating the client preview as Agents account state', async () => {
     render(<KiBuddyAccountSettings />);
 
     fireEvent.click(screen.getByRole('button', { name: 'login.kiBuddy.account.openMenu' }));
@@ -113,8 +100,6 @@ describe('KiBuddyAccountSettings', () => {
     fireEvent.click(confirmButton);
 
     await waitFor(() => expect(logoutMock).toHaveBeenCalledOnce());
-    expect(closePreviewMock).toHaveBeenCalledOnce();
-    expect(clearPreviewForScopeMock).toHaveBeenCalledOnce();
   });
 
   it('does not expose account controls without an Agents profile', () => {

--- a/tests/unit/renderer/ki-buddy/AuthContext.dom.test.tsx
+++ b/tests/unit/renderer/ki-buddy/AuthContext.dom.test.tsx
@@ -15,6 +15,32 @@ const getSessionMock = vi.fn();
 const loginMock = vi.fn();
 const logoutMock = vi.fn();
 
+const browserTab = {
+  id: 'client-browser-tab',
+  title: 'Client documentation',
+  content: 'https://docs.example.com',
+  content_type: 'browser',
+};
+
+function setMixedPreviewState(key: string): void {
+  localStorage.setItem(
+    key,
+    JSON.stringify({
+      isOpen: true,
+      tabs: [
+        {
+          id: 'account-file-tab',
+          title: 'secret.txt',
+          content: 'previous account data',
+          content_type: 'code',
+        },
+        browserTab,
+      ],
+      activeTabId: 'account-file-tab',
+    })
+  );
+}
+
 const AuthStatusProbe: React.FC = () => {
   const { status } = useAuth();
   const { login } = useKiBuddyAuth();
@@ -39,6 +65,7 @@ const AuthStatusProbe: React.FC = () => {
 describe('Ki-Buddy AuthProvider session restoration', () => {
   beforeEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
     getSessionMock.mockReset();
     loginMock.mockReset();
     logoutMock.mockReset();
@@ -49,13 +76,14 @@ describe('Ki-Buddy AuthProvider session restoration', () => {
     };
   });
 
-  it('clears account-scoped renderer state when the saved Agents credential is invalidated', async () => {
+  it('clears runtime state without deleting client storage when the credential is invalidated', async () => {
     getSessionMock.mockResolvedValue({
       status: 'unauthenticated',
       user: null,
       cleanupRequired: true,
     });
-    localStorage.setItem('preview-ui:previous-account-project', '{"activeFile":"secret.txt"}');
+    setMixedPreviewState('preview-ui:previous-account-project');
+    localStorage.setItem('client-auth-layout', 'preserved');
     const swrCache = new Map<string, { data?: unknown }>();
     swrCache.set('/api/assistants', { data: [{ id: 'previous-account-assistant' }] });
 
@@ -68,7 +96,8 @@ describe('Ki-Buddy AuthProvider session restoration', () => {
     );
 
     expect(await screen.findByLabelText('authentication-status')).toHaveTextContent('unauthenticated');
-    await waitFor(() => expect(localStorage.getItem('preview-ui:previous-account-project')).toBeNull());
+    expect(JSON.parse(localStorage.getItem('preview-ui:previous-account-project') ?? '{}').tabs).toHaveLength(2);
+    expect(localStorage.getItem('client-auth-layout')).toBe('preserved');
     expect(swrCache.get('/api/assistants')?.data).toBeUndefined();
   });
 
@@ -91,7 +120,7 @@ describe('Ki-Buddy AuthProvider session restoration', () => {
     expect(swrCache.get('/api/assistants')?.data).toEqual([{ id: 'current-account-assistant' }]);
   });
 
-  it('clears preserved account state before activating a newly signed-in Agents account', async () => {
+  it('clears runtime state without deleting client storage before activating a new account', async () => {
     getSessionMock.mockResolvedValue({ status: 'unauthenticated', user: null });
     loginMock.mockResolvedValue({
       success: true,
@@ -110,7 +139,8 @@ describe('Ki-Buddy AuthProvider session restoration', () => {
         },
       },
     });
-    localStorage.setItem('preview-ui:previous-account-project', '{"activeFile":"secret.txt"}');
+    setMixedPreviewState('preview-ui:previous-account-project');
+    sessionStorage.setItem('conversation-command-queue/previous-account', '{"items":[{"input":"draft"}]}');
     const swrCache = new Map<string, { data?: unknown }>();
     swrCache.set('/api/assistants', { data: [{ id: 'previous-account-assistant' }] });
     render(
@@ -125,7 +155,13 @@ describe('Ki-Buddy AuthProvider session restoration', () => {
     fireEvent.click(screen.getByRole('button', { name: 'sign-in-new-account' }));
 
     await waitFor(() => expect(screen.getByLabelText('authentication-status')).toHaveTextContent('authenticated'));
-    expect(localStorage.getItem('preview-ui:previous-account-project')).toBeNull();
+    expect({
+      previewTabs: JSON.parse(localStorage.getItem('preview-ui:previous-account-project') ?? '{}').tabs.length,
+      queuedCommand: sessionStorage.getItem('conversation-command-queue/previous-account'),
+    }).toEqual({
+      previewTabs: 2,
+      queuedCommand: '{"items":[{"input":"draft"}]}',
+    });
     expect(swrCache.get('/api/assistants')?.data).toBeUndefined();
   });
 });

--- a/tests/unit/renderer/ki-buddy/KiBuddyAuthProvider.dom.test.tsx
+++ b/tests/unit/renderer/ki-buddy/KiBuddyAuthProvider.dom.test.tsx
@@ -40,14 +40,20 @@ const ProductProbe: React.FC = () => {
       >
         product-login
       </button>
+      <button onClick={() => void auth.logout()}>product-logout</button>
       <button onClick={() => void httpRequest('GET', '/api/settings/client').catch(() => {})}>core-request</button>
     </div>
   );
 };
 
 const CommonProbe: React.FC = () => {
-  const { status, user } = useAuth();
-  return <output aria-label='common-session'>{JSON.stringify({ status, user })}</output>;
+  const { logout, status, user } = useAuth();
+  return (
+    <div>
+      <output aria-label='common-session'>{JSON.stringify({ status, user })}</output>
+      <button onClick={() => void logout()}>common-logout</button>
+    </div>
+  );
 };
 
 describe('Ki-Buddy product authentication context', () => {
@@ -151,22 +157,79 @@ describe('Ki-Buddy product authentication context', () => {
     expect(configService.get('language')).toBe('en-US');
   });
 
-  it('reloads once when a different Core account becomes active after logout', () => {
+  it('blocks a different Core account before requesting one renderer reload', () => {
     const reload = vi.fn();
     const barrier = createKiBuddyAccountSwitchBarrier(reload);
 
-    barrier.observe(null);
-    barrier.observe('core-user-a');
+    expect(barrier.shouldBlock(null)).toBe(false);
+    expect(barrier.shouldBlock('core-user-a')).toBe(false);
+    barrier.recordCommittedUser('core-user-a');
     expect(reload).not.toHaveBeenCalled();
 
-    barrier.observe(null);
+    expect(barrier.shouldBlock(null)).toBe(false);
     expect(reload).not.toHaveBeenCalled();
 
-    barrier.observe('core-user-b');
+    expect(barrier.shouldBlock('core-user-b')).toBe(true);
+    expect(reload).not.toHaveBeenCalled();
+
+    barrier.requestReload();
     expect(reload).toHaveBeenCalledOnce();
 
-    barrier.observe('core-user-b');
+    expect(barrier.shouldBlock('core-user-b')).toBe(true);
+    barrier.requestReload();
     expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('removes product children before reloading for another Core account', async () => {
+    const reload = vi.fn();
+    getSessionMock.mockResolvedValue({
+      status: 'authenticated',
+      user: {
+        id: 'core-user-a',
+        username: 'shared-visible-name',
+        agents: {
+          userId: 'agents-user-a',
+          username: 'account-a@example.com',
+          displayName: 'Shared visible name',
+          roles: [],
+          deploymentUrl: 'https://agents.example.com',
+        },
+      },
+    });
+    logoutMock.mockResolvedValue(undefined);
+    loginMock.mockResolvedValue({
+      success: true,
+      session: {
+        status: 'authenticated',
+        user: {
+          id: 'core-user-b',
+          username: 'shared-visible-name',
+          agents: {
+            userId: 'agents-user-b',
+            username: 'account-b@example.com',
+            displayName: 'Shared visible name',
+            roles: [],
+            deploymentUrl: 'https://agents.example.com',
+          },
+        },
+      },
+    });
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <KiBuddyAuthProvider reload={reload}>
+          <ProductProbe />
+        </KiBuddyAuthProvider>
+      </SWRConfig>
+    );
+    await waitFor(() => expect(screen.getByLabelText('core-user')).toHaveTextContent('core-user-a'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'product-logout' }));
+    await waitFor(() => expect(screen.getByLabelText('auth-status')).toHaveTextContent('unauthenticated'));
+    fireEvent.click(screen.getByRole('button', { name: 'product-login' }));
+
+    await waitFor(() => expect(reload).toHaveBeenCalledOnce());
+    expect(screen.queryByRole('button', { name: 'product-login' })).not.toBeInTheDocument();
   });
 
   it('keeps the active account when a Core business request returns 401', async () => {
@@ -284,5 +347,45 @@ describe('Ki-Buddy product authentication context', () => {
     await waitFor(() => expect(screen.getByLabelText('common-session')).toHaveTextContent('web-user'));
     expect(fetchMock).toHaveBeenCalledWith('/api/auth/user', expect.objectContaining({ method: 'GET' }));
     expect(configService.get('language')).toBe('en-US');
+  });
+
+  it('keeps the WebUI logout cleanup contract when no product adapter is active', async () => {
+    window.electronAPI = undefined;
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      if (input === '/api/auth/user') {
+        return new Response(JSON.stringify({ success: true, user: { id: 'web-user', username: 'web-admin' } }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    localStorage.setItem('auth-session', 'remove');
+    localStorage.setItem('csrf-state', 'remove');
+    localStorage.setItem('access-token', 'remove');
+    localStorage.setItem('preview-ui:web-project', '{"tabs":[]}');
+    localStorage.setItem('client-layout', 'preserve');
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <AuthProvider>
+          <CommonProbe />
+        </AuthProvider>
+      </SWRConfig>
+    );
+    await waitFor(() => expect(screen.getByLabelText('common-session')).toHaveTextContent('web-user'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'common-logout' }));
+
+    await waitFor(() => expect(screen.getByLabelText('common-session')).toHaveTextContent('unauthenticated'));
+    expect(localStorage.getItem('auth-session')).toBeNull();
+    expect(localStorage.getItem('csrf-state')).toBeNull();
+    expect(localStorage.getItem('access-token')).toBeNull();
+    expect(localStorage.getItem('preview-ui:web-project')).toBeNull();
+    expect(localStorage.getItem('client-layout')).toBe('preserve');
   });
 });

--- a/tests/unit/renderer/ki-buddy/kiBuddyAuthAdapter.dom.test.ts
+++ b/tests/unit/renderer/ki-buddy/kiBuddyAuthAdapter.dom.test.ts
@@ -25,6 +25,8 @@ function createHandlers() {
 
 describe('Ki-Buddy renderer authentication handlers', () => {
   beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
     getSessionMock.mockReset();
     loginMock.mockReset();
     logoutMock.mockReset();
@@ -66,7 +68,7 @@ describe('Ki-Buddy renderer authentication handlers', () => {
 
     await createHandlers().handlers.logout();
 
-    expect(clearAccountStateMock).toHaveBeenCalledOnce();
+    expect(clearAccountStateMock).toHaveBeenCalledWith({ preserveRendererStorage: true });
     expect(setUserMock).toHaveBeenCalledWith(null);
     expect(setStatusMock).toHaveBeenCalledWith('unauthenticated');
   });
@@ -95,7 +97,7 @@ describe('Ki-Buddy renderer authentication handlers', () => {
 
     await createHandlers().handlers.refresh();
 
-    expect(clearAccountStateMock).toHaveBeenCalledOnce();
+    expect(clearAccountStateMock).toHaveBeenCalledWith({ preserveRendererStorage: true });
     expect(configService.get('language')).toBe('en-US');
     expect(setStatusMock).toHaveBeenLastCalledWith('unauthenticated');
   });
@@ -116,7 +118,7 @@ describe('Ki-Buddy renderer authentication handlers', () => {
       )
     ).resolves.toEqual({ success: false, code: 'serverError', shouldClearCache: true });
 
-    expect(clearAccountStateMock).toHaveBeenCalledOnce();
+    expect(clearAccountStateMock).toHaveBeenCalledWith({ preserveRendererStorage: true });
     expect(configService.get('language')).toBe('en-US');
     expect(setProfileMock).toHaveBeenCalledWith(null);
     expect(setUserMock).toHaveBeenCalledWith(null);
@@ -156,7 +158,59 @@ describe('Ki-Buddy renderer authentication handlers', () => {
     ).resolves.toEqual({ success: true });
 
     expect(localStorage.getItem('i18nextLng')).toBe('en-US');
-    expect(clearAccountStateMock).toHaveBeenCalledOnce();
+    expect(clearAccountStateMock).toHaveBeenCalledWith({ preserveRendererStorage: true });
+  });
+
+  it('requests storage-preserving cleanup for every Core account activation', async () => {
+    const agentsProfile = {
+      userId: 'agents-user',
+      username: 'shared-visible-name',
+      displayName: 'Shared visible name',
+      roles: [],
+      deploymentUrl: 'https://agents.example.com',
+    };
+    loginMock
+      .mockResolvedValueOnce({
+        success: true,
+        session: {
+          status: 'authenticated',
+          user: { id: 'core-user-a', username: 'shared-visible-name', agents: agentsProfile },
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        session: {
+          status: 'authenticated',
+          user: { id: 'core-user-b', username: 'shared-visible-name', agents: agentsProfile },
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        session: {
+          status: 'authenticated',
+          user: { id: 'core-user-a', username: 'shared-visible-name', agents: agentsProfile },
+        },
+      });
+    const { adapter, handlers } = createHandlers();
+    const login = () =>
+      adapter.login(
+        {
+          baseUrl: 'https://agents.example.com',
+          username: 'shared-visible-name',
+          password: 'password',
+        },
+        handlers.login
+      );
+
+    await login();
+    await login();
+    await login();
+
+    expect(clearAccountStateMock.mock.calls).toEqual([
+      [{ preserveRendererStorage: true }],
+      [{ preserveRendererStorage: true }],
+      [{ preserveRendererStorage: true }],
+    ]);
   });
 
   it('does not create product handlers when the Ki-Buddy capability is absent', () => {


### PR DESCRIPTION
# Pull Request

## Description

本 PR 完成 Issue 17 中尚未由 Issue 15 覆盖的账号状态隔离行为，并按最新产品语义调整 Ki-Buddy 的 Agents 账号切换流程。

Ki-Buddy 只把认证会话和 Core user scope 中的持久业务数据视为 Agents 账号数据。renderer `localStorage`、`sessionStorage`、Preview tab、最近 workspace、客户端布局和应用内浏览器都属于当前客户端安装，退出或切换 Agents 账号时不再清理，也不建立账号级 Web Storage namespace。

主要变化：

- Ki-Buddy logout 仅清理认证相关 runtime、SWR cache 和已注册的账号状态，不清 renderer Web Storage。
- AionUi WebUI 的默认 logout 清理行为保持不变。
- 删除 Account 页面 logout 对 Preview 的关闭和清除操作。
- A→B 切换时，在 B 的业务 children 渲染前建立账号切换屏障，再通过整页 reload 销毁旧 renderer runtime。
- packaged Electron E2E 覆盖 A→B→A：验证 Core conversation 隔离与恢复、客户端 storage 保留、真实 browser tab 恢复、`persist:aionui-browser` 的 Cookie/site localStorage 保留，以及浏览器数据清理 API 未被调用。
- 更新 ADR 和 AionUi v2.1.54 生产客户端解包研究，明确客户端状态与 Agents 账号数据的所有权边界。

## Related Issues

- Closes #17

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [x] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format:check` — formatting passes
- [x] `bun run lint` — no lint errors（877 个仓库既有 warning）
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bun run test` — 453 个文件通过、1 个文件跳过；3853 项通过、5 项跳过
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — 本 PR 未新增用户可见文本

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

macOS arm64 unpacked app 已重新生成，并通过目标 packaged Electron E2E。未生成 DMG/ZIP。

## Screenshots

不适用。本 PR 不修改界面视觉样式。

## Additional Context

- Standards 与 Spec 双轴代码审查均无剩余 finding。
- Core managed upload 的 file/result ref user scope 缺口不属于本 PR 范围。
- 首次打包尝试因沙箱无法解析 GitHub 域名而在下载 Ki-Core 前中止；允许联网后成功生成 unpacked app。

---

**Thank you for contributing to AionUi! 🎉**
