### PR TITLE
feat(ki-buddy): add product experience policy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,6 +58,60 @@ _Avoid_：AionPro 账户复用、用户名映射、裸用户 ID 映射
 归属于一个 Agents 部署中某个 Agents 平台账户的持久化 conversation、Team 记录和结果引用。
 _Avoid_：登录会话、临时状态、全局历史
 
+## 产品能力控制
+
+**产品体验策略**：
+一个产品版本对 AionUi 功能、资源和默认行为作出的统一可用性声明；同一声明同时约束用户入口、直接访问和相关运行行为。
+_Avoid_：页面显隐清单、菜单白名单、Ki-Buddy 条件判断
+
+**随包产品策略**：
+随 Ki-Buddy 安装包发布并由该版本唯一采用的产品体验策略；产品功能变化通过发布新版本生效。
+_Avoid_：远程功能开关、用户功能开关、环境变量覆盖
+
+**产品能力 ID**：
+在产品体验策略中稳定标识一项完整产品能力的领域名称；入口、直接访问和运行行为可以共同引用同一个 ID。
+_Avoid_：路由路径、组件名、菜单 ID
+
+**产品功能状态**：
+产品体验策略对一项完整产品能力作出的启用或停用决定；停用表示该能力不可展示、不可直接访问，也不启动其专属运行行为，但不构成底层接口的安全授权。
+_Avoid_：仅隐藏、CSS 隐藏、菜单开关
+
+**首发数据基线**：
+Ki-Buddy 第一个正式版本使用独立且没有历史产品数据的运行空间；开发数据、AionUi 数据和未正式发布版本的数据不构成产品兼容输入。
+_Avoid_：旧版 Ki-Buddy 数据、AionUi 数据迁移、预发布数据兼容
+
+**产品资源访问**：
+产品体验策略对一类 Agent、Assistant、Model、Skill 或 MCP 资源规定的隐藏、使用或管理范围；使用允许调用及必要的运行检测，但不允许改变资源定义，管理保留该类资源的完整管理能力。
+_Avoid_：列表过滤、按钮显隐、资源权限
+
+**产品内置资源**：
+由 Ki-Buddy 随产品发布并负责定义和生命周期的 Agent、Assistant、Skill 或 MCP 资源；用户可以使用和检测，但不能修改其定义。
+_Avoid_：上游内置资源、Custom 资源、Extension 贡献资源
+
+**上游内置资源**：
+由 AionUi 或 AionCore 提供、但没有被 Ki-Buddy 声明为产品内置资源的 Agent、Assistant、Skill 或 MCP 资源。
+_Avoid_：产品内置资源、Custom 资源
+
+**未分类资源**：
+Ki-Buddy 无法依据稳定身份和来源归入已声明资源类别的上游或 Extension 资源；它不自动取得可见或可用状态。
+_Avoid_：Custom 资源、默认允许资源
+
+**Custom 资源**：
+用户通过 Ki-Buddy 保留的内置扩展入口创建并管理的 Agent、Assistant、Model、Skill 或 MCP 资源。
+_Avoid_：Extension 贡献资源、产品内置资源、上游内置资源
+
+**Extension 贡献资源**：
+AionUi Extension 运行时提供的设置页、Agent、Skill 或 MCP 资源；它不因表现得像 Custom 资源而取得 Custom 资源访问范围。
+_Avoid_：Custom 资源、产品内置资源
+
+**自动注入 Skill**：
+AionCore 在 conversation 运行时自动提供、无需用户从 Skills 目录选择的 Skill；它是否注入与是否在 Skills 设置页展示是两个独立决定。
+_Avoid_：产品官方 Skill、Custom Skill、目录可见 Skill
+
+**定时任务**：
+由一个 Assistant 按计划在新 conversation 或指定的现有 conversation 中执行的任务；Team 不是定时任务执行者。
+_Avoid_：Team 定时任务、Team 执行计划
+
 ## Agents 混合执行
 
 **混合执行**：

--- a/docs/adr/0011-control-aionui-with-product-experience-policy.md
+++ b/docs/adr/0011-control-aionui-with-product-experience-policy.md
@@ -1,0 +1,58 @@
+---
+status: accepted
+---
+
+# 通过产品体验策略控制 Ki-Buddy 的 AionUi 能力
+
+Ki-Buddy 长期跟随 AionUi 演进，但首个正式版本只开放经过产品确认的功能和资源。Ki-Buddy 使用随安装包发布、严格版本化的产品体验策略统一决定产品功能状态、产品资源访问和运行默认值；AionUi 保持完整能力，并通过少量稳定 seam 消费策略结果。
+
+产品功能使用稳定的产品能力 ID 标识，不使用路由、组件名或菜单 ID。一个功能状态同时约束入口、直接访问和专属运行行为；Agent、Assistant、Model、Skill 和 MCP 通过 `hidden`、`use`、`manage` 三档产品资源访问控制全部 catalog 消费者。主进程与 renderer 使用同一份不可变策略快照，renderer 在首个业务画面前通过 preload 取得快照。
+
+AionUi 与 Ki-Buddy 分别提供 adapter。产品 capability 完全缺失时使用完整 AionUi 行为；运行环境已经识别为 Ki-Buddy，但策略缺失、字段未知、依赖矛盾或版本不支持时显示安装完整性错误，不能退回 AionUi。AionUi 新增产品能力后，Ki-Buddy 必须明确声明启用或停用，构建校验才能通过。
+
+路由、导航、资源 catalog 和生命周期分别根据同一策略生成投影。导航 registry 保持稳定顺序，产品策略不复制菜单和路由结构。停用功能的代码继续随上游基线打包，使后续 Ki-Buddy 版本可以通过更新策略重新开放能力；产品功能状态只约束客户端产品行为，不替代 Agents 平台或 AionCore 的安全授权。
+
+## 上游接缝与同步维护
+
+现有 AionUi 扩展点只能分别控制页面或运行模块，不能在首个业务画面前向 main、preload 和 renderer 提供同一份产品能力快照，也不能保证导航、直接路由和生命周期同时停用。因此当前版本保留以下显式接缝：
+
+| 上游文件                                                                                                                                     | 产品职责                                                                        | AionUi 原行为保护                                                        |
+| -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `packages/desktop/src/index.ts`                                                                                                              | 选择产品启动状态；配置损坏时只转发到 Ki-Buddy 完整性窗口，不进入业务生命周期    | capability 缺失时继续执行完整 AionUi 启动、更新、Tray 和 backend 流程    |
+| `packages/desktop/src/preload/main.ts`、`packages/desktop/src/common/types/platform/electron.ts`                                             | 通过单一 getter 转发不可变 bootstrap snapshot；完整性启动不读取业务 IPC         | AionUi preload 继续暴露原有 backend 与 renderer bridge                   |
+| `packages/desktop/src/renderer/index.html`、`packages/desktop/src/renderer/main.tsx`、`packages/desktop/src/renderer/services/i18n/index.ts` | 在首个业务画面前应用产品 capability；配置损坏时只显示完整性错误并停止业务初始化 | capability 缺失时继续使用 AionUi 标题、主题、i18n 与应用 host            |
+| `packages/desktop/src/renderer/components/layout/Layout.tsx`、`Router.tsx`、`Sider/index.tsx`、`Titlebar/index.tsx`                          | 从同一 feature ID 投影 Team 入口、直接路由、订阅和 workspace 控件               | `ProductExperience` 的 AionUi adapter 保持 Team 入口、路由与生命周期可用 |
+| `packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx`                                                           | 从 behavior defaults 决定 Scheduled Tasks 是否允许 Team 执行者                  | AionUi adapter 继续使用 `assistant-or-team`                              |
+| `packages/desktop/src/process/bridge/updateBridge.ts`、`notificationBridge.ts`                                                               | 注入产品更新源和通知资源；完整性失败时禁用对应业务服务                          | capability 缺失时继续使用 AionUi 更新源、User-Agent 和通知图标           |
+
+AionUi 原行为由以下测试保护：
+
+- `tests/unit/process/ki-buddy/runtimeFacade.test.ts`：capability 缺失时保留 AionUi lifecycle，并验证有效、无效 Ki-Buddy 分支。
+- `tests/integration/ProductExperienceSiderHost.dom.test.tsx`：AionUi adapter 保留 Team 导航，Ki-Buddy adapter 隐藏入口。
+- `tests/unit/renderer/layout/TitlebarWorkspaceToggle.dom.test.tsx`：AionUi 保留 workspace 切换能力。
+- `tests/unit/renderer/cron/CreateTaskDialog.dom.test.tsx`：AionUi 保留 Assistant/Team 执行者，Ki-Buddy 只允许 Assistant。
+- `tests/unit/renderer/services/runtime/productBootstrap.dom.test.ts` 与 `kiBuddyRuntime.dom.test.ts`：capability 存在、缺失和损坏时使用对应启动路径。
+
+每次同步 AionUi 基线时必须复查：
+
+1. main、preload、renderer 启动顺序是否改变，bootstrap 是否仍在首个业务画面前只读取一次。
+2. Router、Sider、Layout、Titlebar 或 Scheduled Tasks 是否新增了绕过 `ProductExperience` 的入口、直接访问或生命周期。
+3. AionUi 新增的完整产品能力是否已经加入稳定 feature ID，并在 Ki-Buddy 策略中明确声明启用或停用。
+4. 更新、通知、Tray、菜单、backend 和后台订阅是否仍在 invalid 路径之外启动。
+5. capability 存在与缺失两组回归、AionUi 原行为保护测试以及完整测试是否通过。
+
+当 AionUi 提供正式的产品策略注册、单一 preload bootstrap、首帧 capability 注入和按 capability 管理生命周期的公开扩展点后，应将对应职责迁移到上游接口，并删除本 ADR 列出的本地上游接缝。迁移只有在 Ki-Buddy invalid/ready 与 AionUi absent 三种状态的等价测试全部通过后才能完成。
+
+## Considered Options
+
+- 分别配置可见路由、导航和设置项：同一能力可能出现入口隐藏、路由可达或副作用仍启动的不一致状态。
+- 在各个 AionUi 页面直接判断 Ki-Buddy：产品规则会分散到上游文件，增加每次基线同步的冲突和遗漏风险。
+- 由服务端或用户设置动态覆盖策略：会增加远程状态、缓存和启动时序问题，首个正式版本没有该需求。
+
+## Consequences
+
+- `ki-buddy-product.json` 升级为 schema v3，并完整声明当前产品能力；schema v2 不进行运行时迁移。
+- 产品内置资源缺失时，受影响能力显示安装完整性错误，不按名称选择相似上游资源替代；账户和诊断功能仍然可用。
+- Ki-Buddy 首个正式版本使用独立且没有历史产品数据的运行空间；#40 不处理 AionUi、开发版或预发布 Ki-Buddy 数据兼容。
+- Scheduled Tasks 只选择 Assistant，并使用产品策略投影后的 Assistant catalog；Team 不是定时任务执行者。
+- #41 第一阶段只验收 standalone Agents 执行。ADR 0005 继续描述未来开放 Team 后的目标设计，当前不建设不可见的 Team 集成链路。

--- a/ki-buddy-product.json
+++ b/ki-buddy-product.json
@@ -1,9 +1,80 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "runtimeIdentity": "ki-buddy",
   "defaults": {
     "agentsBaseUrl": "https://ksapi.kingsware.cn",
     "language": "zh-CN"
+  },
+  "experience": {
+    "schemaVersion": 1,
+    "features": {
+      "account": "enabled",
+      "agents": "enabled",
+      "appearance": "enabled",
+      "assistants": "enabled",
+      "channels": "disabled",
+      "componentShowcase": "disabled",
+      "conversation": "enabled",
+      "desktopPet": "disabled",
+      "extensionMarketplace": "disabled",
+      "extensionRuntime": "disabled",
+      "extensionSettings": "disabled",
+      "guid": "enabled",
+      "guidFeedback": "disabled",
+      "guidGithubStar": "disabled",
+      "guidWebUi": "disabled",
+      "models": "enabled",
+      "scheduledTasks": "enabled",
+      "skills": "enabled",
+      "system": "enabled",
+      "team": "disabled",
+      "themeCustomEditor": "disabled",
+      "themeMarketplace": "disabled",
+      "themePresets": "disabled",
+      "tools": "enabled",
+      "webUi": "disabled"
+    },
+    "resources": {
+      "agent": {
+        "productBuiltin": "use",
+        "upstreamBuiltin": "hidden",
+        "custom": "manage",
+        "extension": "hidden",
+        "unclassified": "hidden"
+      },
+      "assistant": {
+        "productBuiltin": "use",
+        "upstreamBuiltin": "hidden",
+        "custom": "manage",
+        "extension": "hidden",
+        "unclassified": "hidden"
+      },
+      "model": {
+        "productBuiltin": "manage",
+        "upstreamBuiltin": "manage",
+        "custom": "manage",
+        "extension": "hidden",
+        "unclassified": "hidden"
+      },
+      "skill": {
+        "productBuiltin": "use",
+        "upstreamBuiltin": "hidden",
+        "custom": "manage",
+        "extension": "hidden",
+        "unclassified": "hidden"
+      },
+      "mcp": {
+        "productBuiltin": "use",
+        "upstreamBuiltin": "hidden",
+        "custom": "manage",
+        "extension": "hidden",
+        "unclassified": "hidden"
+      }
+    },
+    "behaviorDefaults": {
+      "scheduledTaskExecutor": "assistant",
+      "autoInjectedSkillExclusions": ["aionui-config"]
+    }
   },
   "locale": {
     "namespace": "kiBuddy"

--- a/packages/desktop/src/common/platform/ki-buddy/channels.ts
+++ b/packages/desktop/src/common/platform/ki-buddy/channels.ts
@@ -1,4 +1,5 @@
 export const KI_BUDDY_CORE_TRANSPORT_CHANNEL = 'ki-buddy:core-transport:get-csrf-token';
+export const KI_BUDDY_PRODUCT_BOOTSTRAP_CHANNEL = 'ki-buddy:product-bootstrap:get';
 
 const KI_BUDDY_CORE_SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 

--- a/packages/desktop/src/common/platform/ki-buddy/index.ts
+++ b/packages/desktop/src/common/platform/ki-buddy/index.ts
@@ -4,9 +4,38 @@ export {
   resolveLanguagePreference,
 } from './productDefaults';
 export { normalizeAgentsBaseUrl } from './deploymentUrl';
-export { KI_BUDDY_PRODUCT_RUNTIME, resolveKiBuddyRuntimeIdentity } from './runtimeIdentity';
+export { resolveKiBuddyRuntimeIdentity } from './runtimeIdentity';
 export { applyKiBuddyLocaleOverlay } from './localeOverlay';
-export { KI_BUDDY_PRODUCT_CAPABILITY } from './productCapability';
-export { KI_BUDDY_PRODUCT_CONFIG, parseKiBuddyProductConfig } from './productConfig';
-export { KI_BUDDY_CORE_TRANSPORT_CHANNEL, isKiBuddyCoreSafeMethod } from './channels';
-export type { KiBuddyProductConfig } from './productConfig';
+export { KI_BUDDY_PRODUCT_CAPABILITY, createKiBuddyProductCapability } from './productCapability';
+export {
+  KI_BUDDY_PRODUCT_CONFIG_RESULT,
+  KI_BUDDY_PRODUCT_RUNTIME,
+  loadKiBuddyProductConfig,
+  parseKiBuddyProductConfig,
+} from './productConfig';
+export {
+  PRODUCT_FEATURE_IDS,
+  PRODUCT_RESOURCE_KINDS,
+  PRODUCT_RESOURCE_ORIGINS,
+  createAionUiProductExperience,
+  createKiBuddyProductExperience,
+  deepFreeze,
+  parseProductExperiencePolicy,
+} from './productExperience';
+export type {
+  DeepReadonly,
+  ProductBehaviorDefaults,
+  ProductExperience,
+  ProductExperienceSnapshot,
+  ProductFeatureId,
+  ProductFeatureState,
+  ProductResourceAccess,
+  ProductResourceKind,
+  ProductResourceOrigin,
+} from './productExperience';
+export {
+  KI_BUDDY_CORE_TRANSPORT_CHANNEL,
+  KI_BUDDY_PRODUCT_BOOTSTRAP_CHANNEL,
+  isKiBuddyCoreSafeMethod,
+} from './channels';
+export type { KiBuddyProductConfig, KiBuddyProductConfigLoadResult } from './productConfig';

--- a/packages/desktop/src/common/platform/ki-buddy/productCapability.ts
+++ b/packages/desktop/src/common/platform/ki-buddy/productCapability.ts
@@ -1,12 +1,20 @@
 import type { KiBuddyProductCapability } from '@/common/types/platform/kiBuddyProduct';
-import { KI_BUDDY_PRODUCT_CONFIG } from './productConfig';
+import { KI_BUDDY_PRODUCT_CONFIG_RESULT, type KiBuddyProductConfig } from './productConfig';
+import { deepFreeze } from './productExperience';
 
 /** Serializable renderer capability for the configured Ki-Buddy product runtime. */
-export const KI_BUDDY_PRODUCT_CAPABILITY = {
-  id: 'ki-buddy',
-  schemaVersion: 2,
-  brand: KI_BUDDY_PRODUCT_CONFIG.brand,
-  assets: KI_BUDDY_PRODUCT_CONFIG.assets.renderer,
-  locale: KI_BUDDY_PRODUCT_CONFIG.locale,
-  themes: KI_BUDDY_PRODUCT_CONFIG.themes,
-} satisfies KiBuddyProductCapability;
+export function createKiBuddyProductCapability(config: KiBuddyProductConfig): KiBuddyProductCapability {
+  return deepFreeze({
+    id: 'ki-buddy',
+    schemaVersion: 3,
+    brand: config.brand,
+    assets: config.assets.renderer,
+    locale: config.locale,
+    themes: config.themes,
+    experience: config.experience,
+  });
+}
+
+export const KI_BUDDY_PRODUCT_CAPABILITY = KI_BUDDY_PRODUCT_CONFIG_RESULT.config
+  ? createKiBuddyProductCapability(KI_BUDDY_PRODUCT_CONFIG_RESULT.config)
+  : null;

--- a/packages/desktop/src/common/platform/ki-buddy/productConfig.ts
+++ b/packages/desktop/src/common/platform/ki-buddy/productConfig.ts
@@ -1,8 +1,16 @@
 import rawProductConfig from '../../../../../../ki-buddy-product.json';
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '@/common/config/i18n';
 import { normalizeAgentsBaseUrl } from './deploymentUrl';
+import {
+  deepFreeze,
+  parseProductExperiencePolicy,
+  type DeepReadonly,
+  type ProductExperienceSnapshot,
+} from './productExperience';
 
-export type KiBuddyProductConfig = {
+export const KI_BUDDY_PRODUCT_RUNTIME = 'ki-buddy' as const;
+
+export type KiBuddyProductConfig = DeepReadonly<{
   assets: {
     packaged: {
       icon: string;
@@ -38,11 +46,12 @@ export type KiBuddyProductConfig = {
     appId: string;
     protocolScheme: string;
   };
+  experience: ProductExperienceSnapshot;
   locale: {
     namespace: string;
   };
-  runtimeIdentity: string;
-  schemaVersion: 2;
+  runtimeIdentity: typeof KI_BUDDY_PRODUCT_RUNTIME;
+  schemaVersion: 3;
   themes: {
     dark: string;
     light: string;
@@ -53,7 +62,11 @@ export type KiBuddyProductConfig = {
     repository: string;
     tagPrefix: string;
   };
-};
+}>;
+
+export type KiBuddyProductConfigLoadResult =
+  | Readonly<{ config: KiBuddyProductConfig; error: null }>
+  | Readonly<{ config: null; error: string }>;
 
 const PRODUCT_CONFIG_TOP_LEVEL_KEYS = [
   'schemaVersion',
@@ -69,6 +82,7 @@ const PRODUCT_CONFIG_TOP_LEVEL_KEYS = [
   'webCli',
   'updates',
   'kiCore',
+  'experience',
 ] as const;
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
@@ -106,10 +120,14 @@ function requireString(value: unknown, label: string): string {
   return value;
 }
 
-function requireSupportedString(value: unknown, expected: string, label: string): string {
+function requireSupportedString<const Expected extends string>(
+  value: unknown,
+  expected: Expected,
+  label: string
+): Expected {
   const result = requireString(value, label);
   if (result !== expected) throw new Error(`${label} must be ${expected}`);
-  return result;
+  return expected;
 }
 
 function requireProtocolScheme(value: unknown): string {
@@ -155,14 +173,17 @@ export function parseKiBuddyProductConfig(value: unknown): KiBuddyProductConfig 
       'assets',
       'electronBuilder',
       'updates',
+      'experience',
     ],
     PRODUCT_CONFIG_TOP_LEVEL_KEYS,
     'Ki-Buddy product configuration'
   );
-  if (config.schemaVersion !== 2) throw new Error('Unsupported Ki-Buddy product configuration schema');
-  if (typeof config.runtimeIdentity !== 'string' || config.runtimeIdentity.trim() === '') {
-    throw new Error('Ki-Buddy runtime identity must be a non-empty string');
-  }
+  if (config.schemaVersion !== 3) throw new Error('Unsupported Ki-Buddy product configuration schema');
+  const runtimeIdentity = requireSupportedString(
+    config.runtimeIdentity,
+    KI_BUDDY_PRODUCT_RUNTIME,
+    'Ki-Buddy runtime identity'
+  );
   const defaults = requireRecord(config.defaults, 'Ki-Buddy product defaults');
   requireExactKeys(defaults, ['agentsBaseUrl', 'language'], 'Ki-Buddy product defaults');
   if (typeof defaults.agentsBaseUrl !== 'string' || defaults.agentsBaseUrl.trim() === '') {
@@ -209,9 +230,9 @@ export function parseKiBuddyProductConfig(value: unknown): KiBuddyProductConfig 
   if (updateProvider !== 'github' || updateRepository !== brandRepositoryPath) {
     throw new Error('Ki-Buddy update source must match the configured GitHub repository');
   }
-  return {
-    schemaVersion: 2,
-    runtimeIdentity: config.runtimeIdentity,
+  return deepFreeze({
+    schemaVersion: 3,
+    runtimeIdentity,
     brand: {
       cliName: requireString(brand.cliName, 'Ki-Buddy CLI name'),
       productName: requireString(brand.productName, 'Ki-Buddy product name'),
@@ -254,13 +275,26 @@ export function parseKiBuddyProductConfig(value: unknown): KiBuddyProductConfig 
       light: requireSupportedString(themes.light, 'ki-buddy-light', 'Ki-Buddy light theme'),
       dark: requireSupportedString(themes.dark, 'ki-buddy-dark', 'Ki-Buddy dark theme'),
     },
+    experience: parseProductExperiencePolicy(config.experience),
     updates: {
       provider: updateProvider,
       repository: updateRepository,
       tagPrefix: updateTagPrefix,
       releasePageUrl: updateReleasePageUrl,
     },
-  };
+  });
 }
 
-export const KI_BUDDY_PRODUCT_CONFIG = parseKiBuddyProductConfig(rawProductConfig);
+/** Captures packaged configuration failures without aborting main or preload module evaluation. */
+export function loadKiBuddyProductConfig(value: unknown): KiBuddyProductConfigLoadResult {
+  try {
+    return deepFreeze({ config: parseKiBuddyProductConfig(value), error: null });
+  } catch (error) {
+    return deepFreeze({
+      config: null,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export const KI_BUDDY_PRODUCT_CONFIG_RESULT = loadKiBuddyProductConfig(rawProductConfig);

--- a/packages/desktop/src/common/platform/ki-buddy/productDefaults.ts
+++ b/packages/desktop/src/common/platform/ki-buddy/productDefaults.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_LANGUAGE, normalizeLanguageCode, type SupportedLanguage } from '@/common/config/i18n';
-import { KI_BUDDY_PRODUCT_CONFIG } from './productConfig';
+import { KI_BUDDY_PRODUCT_CONFIG_RESULT } from './productConfig';
 
 type LanguagePreferenceInput = {
   fallbackLanguage?: string | null;
@@ -14,8 +14,8 @@ function nonEmpty(value: string | null | undefined): string | null {
   return trimmed === '' ? null : trimmed;
 }
 
-export const KI_BUDDY_DEFAULT_AGENTS_BASE_URL = KI_BUDDY_PRODUCT_CONFIG.defaults.agentsBaseUrl;
-export const KI_BUDDY_DEFAULT_LANGUAGE = KI_BUDDY_PRODUCT_CONFIG.defaults.language;
+export const KI_BUDDY_DEFAULT_AGENTS_BASE_URL = KI_BUDDY_PRODUCT_CONFIG_RESULT.config?.defaults.agentsBaseUrl ?? null;
+export const KI_BUDDY_DEFAULT_LANGUAGE = KI_BUDDY_PRODUCT_CONFIG_RESULT.config?.defaults.language ?? null;
 
 /** Resolves saved → product → system → global fallback using one rule for every startup phase. */
 export function resolveLanguagePreference(input: LanguagePreferenceInput): SupportedLanguage {

--- a/packages/desktop/src/common/platform/ki-buddy/productExperience.ts
+++ b/packages/desktop/src/common/platform/ki-buddy/productExperience.ts
@@ -1,0 +1,208 @@
+export const PRODUCT_FEATURE_IDS = [
+  'account',
+  'agents',
+  'appearance',
+  'assistants',
+  'channels',
+  'componentShowcase',
+  'conversation',
+  'desktopPet',
+  'extensionMarketplace',
+  'extensionRuntime',
+  'extensionSettings',
+  'guid',
+  'guidFeedback',
+  'guidGithubStar',
+  'guidWebUi',
+  'models',
+  'scheduledTasks',
+  'skills',
+  'system',
+  'team',
+  'themeCustomEditor',
+  'themeMarketplace',
+  'themePresets',
+  'tools',
+  'webUi',
+] as const;
+
+export const PRODUCT_RESOURCE_KINDS = ['agent', 'assistant', 'model', 'skill', 'mcp'] as const;
+export const PRODUCT_RESOURCE_ORIGINS = [
+  'productBuiltin',
+  'upstreamBuiltin',
+  'custom',
+  'extension',
+  'unclassified',
+] as const;
+
+export type ProductFeatureId = (typeof PRODUCT_FEATURE_IDS)[number];
+export type ProductFeatureState = 'enabled' | 'disabled';
+export type ProductResourceKind = (typeof PRODUCT_RESOURCE_KINDS)[number];
+export type ProductResourceOrigin = (typeof PRODUCT_RESOURCE_ORIGINS)[number];
+export type ProductResourceAccess = 'hidden' | 'use' | 'manage';
+export type ScheduledTaskExecutorDefault = 'assistant' | 'assistant-or-team';
+
+export type DeepReadonly<T> = T extends readonly (infer Item)[]
+  ? readonly DeepReadonly<Item>[]
+  : T extends object
+    ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
+    : T;
+
+export type ProductBehaviorDefaults = Readonly<{
+  autoInjectedSkillExclusions: readonly string[];
+  scheduledTaskExecutor: ScheduledTaskExecutorDefault;
+}>;
+
+export type ProductExperienceSnapshot = Readonly<{
+  behaviorDefaults: ProductBehaviorDefaults;
+  features: Readonly<Record<ProductFeatureId, ProductFeatureState>>;
+  resources: Readonly<Record<ProductResourceKind, Readonly<Record<ProductResourceOrigin, ProductResourceAccess>>>>;
+  schemaVersion: 1;
+}>;
+
+export type ProductExperience = Readonly<{
+  behaviorDefaults: () => ProductBehaviorDefaults;
+  featureState: (featureId: ProductFeatureId) => ProductFeatureState;
+  resourceAccess: (kind: ProductResourceKind, origin: ProductResourceOrigin) => ProductResourceAccess;
+}>;
+
+const FEATURE_DEPENDENCIES: ReadonlyArray<readonly [ProductFeatureId, ProductFeatureId]> = [
+  ['extensionMarketplace', 'extensionRuntime'],
+  ['extensionSettings', 'extensionRuntime'],
+  ['guidFeedback', 'guid'],
+  ['guidGithubStar', 'guid'],
+  ['guidWebUi', 'guid'],
+  ['guidWebUi', 'webUi'],
+  ['themeCustomEditor', 'appearance'],
+  ['themeMarketplace', 'appearance'],
+  ['themePresets', 'appearance'],
+];
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireExactKeys(value: Record<string, unknown>, keys: readonly string[], label: string): void {
+  const missing = keys.filter((key) => !(key in value));
+  const unexpected = Object.keys(value).filter((key) => !keys.includes(key));
+  if (missing.length === 0 && unexpected.length === 0) return;
+  const details = [
+    missing.length > 0 ? `missing ${missing.join(', ')}` : '',
+    unexpected.length > 0 ? `unexpected ${unexpected.join(', ')}` : '',
+  ]
+    .filter(Boolean)
+    .join('; ');
+  throw new Error(`${label} has invalid fields: ${details}`);
+}
+
+function requireEnum<T extends string>(value: unknown, allowed: readonly T[], label: string): T {
+  if (typeof value !== 'string' || !allowed.includes(value as T)) {
+    throw new Error(`${label} must be one of ${allowed.join(', ')}`);
+  }
+  return value as T;
+}
+
+export function deepFreeze<T>(value: T): DeepReadonly<T> {
+  if (typeof value !== 'object' || value === null || Object.isFrozen(value)) return value as DeepReadonly<T>;
+  for (const child of Object.values(value)) deepFreeze(child);
+  return Object.freeze(value) as DeepReadonly<T>;
+}
+
+/** Strictly validates the serialized product experience snapshot shipped with Ki-Buddy. */
+export function parseProductExperiencePolicy(value: unknown): ProductExperienceSnapshot {
+  const policy = requireRecord(value, 'Product experience policy');
+  requireExactKeys(policy, ['schemaVersion', 'features', 'resources', 'behaviorDefaults'], 'Product experience policy');
+  if (policy.schemaVersion !== 1) throw new Error('Unsupported product experience policy schema');
+
+  const rawFeatures = requireRecord(policy.features, 'Product experience features');
+  requireExactKeys(rawFeatures, PRODUCT_FEATURE_IDS, 'Product experience features');
+  const features = Object.fromEntries(
+    PRODUCT_FEATURE_IDS.map((featureId) => [
+      featureId,
+      requireEnum(rawFeatures[featureId], ['enabled', 'disabled'] as const, `Product feature ${featureId}`),
+    ])
+  ) as Record<ProductFeatureId, ProductFeatureState>;
+
+  for (const [child, parent] of FEATURE_DEPENDENCIES) {
+    if (features[child] === 'enabled' && features[parent] !== 'enabled') {
+      throw new Error(`Product feature ${child} requires enabled parent ${parent}`);
+    }
+  }
+
+  const rawResources = requireRecord(policy.resources, 'Product experience resources');
+  requireExactKeys(rawResources, PRODUCT_RESOURCE_KINDS, 'Product experience resources');
+  const resources = Object.fromEntries(
+    PRODUCT_RESOURCE_KINDS.map((kind) => {
+      const rawAccess = requireRecord(rawResources[kind], `Product resource ${kind}`);
+      requireExactKeys(rawAccess, PRODUCT_RESOURCE_ORIGINS, `Product resource ${kind}`);
+      return [
+        kind,
+        Object.fromEntries(
+          PRODUCT_RESOURCE_ORIGINS.map((origin) => [
+            origin,
+            requireEnum(rawAccess[origin], ['hidden', 'use', 'manage'] as const, `Product resource ${kind}.${origin}`),
+          ])
+        ) as Record<ProductResourceOrigin, ProductResourceAccess>,
+      ];
+    })
+  ) as Record<ProductResourceKind, Record<ProductResourceOrigin, ProductResourceAccess>>;
+
+  const rawDefaults = requireRecord(policy.behaviorDefaults, 'Product experience behavior defaults');
+  requireExactKeys(
+    rawDefaults,
+    ['scheduledTaskExecutor', 'autoInjectedSkillExclusions'],
+    'Product experience behavior defaults'
+  );
+  const rawExclusions = rawDefaults.autoInjectedSkillExclusions;
+  if (
+    !Array.isArray(rawExclusions) ||
+    rawExclusions.some((item) => typeof item !== 'string' || item.trim() === '') ||
+    new Set(rawExclusions).size !== rawExclusions.length
+  ) {
+    throw new Error('Product auto-injected skill exclusions must contain unique non-empty strings');
+  }
+
+  return deepFreeze({
+    schemaVersion: 1,
+    features,
+    resources,
+    behaviorDefaults: {
+      scheduledTaskExecutor: requireEnum(
+        rawDefaults.scheduledTaskExecutor,
+        ['assistant', 'assistant-or-team'] as const,
+        'Product scheduled task executor'
+      ),
+      autoInjectedSkillExclusions: [...rawExclusions] as string[],
+    },
+  });
+}
+
+function createProductExperience(snapshot: ProductExperienceSnapshot): ProductExperience {
+  return Object.freeze({
+    featureState: (featureId: ProductFeatureId) => snapshot.features[featureId],
+    resourceAccess: (kind: ProductResourceKind, origin: ProductResourceOrigin) => snapshot.resources[kind][origin],
+    behaviorDefaults: () => snapshot.behaviorDefaults,
+  });
+}
+
+/** Creates the adapter for the strict, packaged Ki-Buddy policy. */
+export function createKiBuddyProductExperience(value: unknown): ProductExperience {
+  return createProductExperience(parseProductExperiencePolicy(value));
+}
+
+const AION_UI_BEHAVIOR_DEFAULTS = deepFreeze({
+  scheduledTaskExecutor: 'assistant-or-team' as const,
+  autoInjectedSkillExclusions: [] as string[],
+});
+
+/** Creates the compatibility adapter used when the Ki-Buddy product capability is absent. */
+export function createAionUiProductExperience(): ProductExperience {
+  return Object.freeze({
+    featureState: () => 'enabled',
+    resourceAccess: () => 'manage',
+    behaviorDefaults: () => AION_UI_BEHAVIOR_DEFAULTS,
+  });
+}

--- a/packages/desktop/src/common/platform/ki-buddy/runtimeIdentity.ts
+++ b/packages/desktop/src/common/platform/ki-buddy/runtimeIdentity.ts
@@ -1,6 +1,6 @@
-import { KI_BUDDY_PRODUCT_CONFIG } from './productConfig';
+import { KI_BUDDY_PRODUCT_RUNTIME } from './productConfig';
 
-export const KI_BUDDY_PRODUCT_RUNTIME = KI_BUDDY_PRODUCT_CONFIG.runtimeIdentity;
+export { KI_BUDDY_PRODUCT_RUNTIME } from './productConfig';
 
 /** Returns whether packaged product metadata explicitly selects the Ki-Buddy runtime. */
 export function resolveKiBuddyRuntimeIdentity(metadata: unknown): boolean {

--- a/packages/desktop/src/common/types/platform/electron.ts
+++ b/packages/desktop/src/common/types/platform/electron.ts
@@ -84,7 +84,7 @@ export interface BackendStartupFailureInfo {
 declare global {
   interface Window {
     electronAPI?: ElectronBridgeAPI;
-    __getKiBuddyProductPresentation?: () => KiBuddyProductCapability | null;
+    __getKiBuddyProductBootstrap?: () => import('./kiBuddyProduct').KiBuddyProductBootstrap;
     __kiBuddyProductBootstrapError?: string | null;
     __kiBuddyProductPresentation?: KiBuddyProductCapability | null;
     __initialLanguage?: string | null;

--- a/packages/desktop/src/common/types/platform/kiBuddyProduct.ts
+++ b/packages/desktop/src/common/types/platform/kiBuddyProduct.ts
@@ -1,10 +1,22 @@
 import type { KiBuddyProductConfig } from '@/common/platform/ki-buddy/productConfig';
+import type { DeepReadonly } from '@/common/platform/ki-buddy/productExperience';
 
-export type KiBuddyProductCapability = {
+export type KiBuddyProductCapability = DeepReadonly<{
   assets: KiBuddyProductConfig['assets']['renderer'];
   brand: KiBuddyProductConfig['brand'];
   id: 'ki-buddy';
+  experience: KiBuddyProductConfig['experience'];
   locale: KiBuddyProductConfig['locale'];
-  schemaVersion: 2;
+  schemaVersion: 3;
   themes: KiBuddyProductConfig['themes'];
-};
+}>;
+
+export type KiBuddyProductBootstrap =
+  | Readonly<{ capability: null; error: null; productIdentity: null; status: 'absent' }>
+  | Readonly<{ capability: null; error: string; productIdentity: 'ki-buddy'; status: 'invalid' }>
+  | Readonly<{
+      capability: KiBuddyProductCapability;
+      error: null;
+      productIdentity: 'ki-buddy';
+      status: 'ready';
+    }>;

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -19,7 +19,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { initMainAdapterWithWindow } from './common/adapter/main';
 import { ipcBridge } from './common';
-import { initializeProcess } from './process';
 import { startBackendOrExit } from './process/startup/backendStartup';
 import { assertStartupArchitectureCompatible } from './process/startup/architectureCompatibility';
 import { classifyBackendStartupFailure } from './process/startup/backendStartupFailure';
@@ -30,7 +29,6 @@ import type { BackendStartupFailureInfo } from './common/types/platform/electron
 import { registerWindowMaximizeListeners } from '@process/bridge';
 import { BackendLifecycleManager } from '@aionui/web-host';
 import { resolveBinaryPath } from '@process/backend';
-import './process/bridge/feedbackBridge';
 import { configureNotificationBrandIcon } from '@process/bridge/notificationBridge';
 import { configureUpdateBridge } from '@process/bridge/updateBridge';
 import { wasLaunchedAtLogin } from '@process/bridge/applicationBridge';
@@ -77,7 +75,17 @@ import {
   setIsQuitting,
 } from './process/utils/tray';
 import { readCloseToTraySetting } from './process/utils/closeToTraySetting';
-import { createKiBuddyRuntime, resolveKiBuddyProtocolScheme, shouldEnsureDefaultCoreUser } from '@process/ki-buddy';
+import { KI_BUDDY_PRODUCT_BOOTSTRAP_CHANNEL } from '@/common/platform/ki-buddy';
+import {
+  createKiBuddyProductBootstrap,
+  createKiBuddyProductIntegrityWindow,
+  createKiBuddyRuntime,
+  readKiBuddyRuntimeIdentity,
+  resolveKiBuddyCoreDataPath,
+  resolveKiBuddyProtocolScheme,
+  shouldEnsureDefaultCoreUser,
+  shouldStartProductBusinessLifecycle,
+} from '@process/ki-buddy';
 // @ts-expect-error - electron-squirrel-startup doesn't have types
 import electronSquirrelStartup from 'electron-squirrel-startup';
 
@@ -87,9 +95,11 @@ import electronSquirrelStartup from 'electron-squirrel-startup';
 // to the first instance via second-instance event, then quits.
 const isE2ETestMode = process.env.AIONUI_E2E_TEST === '1';
 const skipSingleInstanceLock = isE2ETestMode || process.env.AIONUI_MULTI_INSTANCE === '1';
-const protocolScheme = configureDeepLinkProtocol(
-  resolveKiBuddyProtocolScheme(app.getAppPath()) ?? AION_UI_PROTOCOL_SCHEME
-);
+const packagedKiBuddyRuntime = readKiBuddyRuntimeIdentity(app.getAppPath());
+const selectedProtocolScheme = packagedKiBuddyRuntime
+  ? resolveKiBuddyProtocolScheme(app.getAppPath())
+  : AION_UI_PROTOCOL_SCHEME;
+const protocolScheme = selectedProtocolScheme ? configureDeepLinkProtocol(selectedProtocolScheme) : null;
 const deepLinkFromArgv = findDeepLinkUrl(process.argv);
 const gotTheLock = skipSingleInstanceLock ? true : app.requestSingleInstanceLock({ deepLinkUrl: deepLinkFromArgv });
 if (!gotTheLock) {
@@ -115,7 +125,7 @@ if (!gotTheLock) {
         mainWindow,
         createWindow: () => {
           console.log('[AionUi] second-instance received with no active main window, recreating main window');
-          createWindow();
+          createWindowForSelectedProduct();
         },
       });
     }
@@ -188,19 +198,24 @@ const isWebUIMode = hasSwitch('webui');
 const isRemoteMode = hasSwitch('remote');
 const isResetPasswordMode = hasCommand('--resetpass');
 const isVersionMode = hasCommand('--version') || hasCommand('-v');
-const kiBuddyRuntime = createKiBuddyRuntime({
+const kiBuddyRuntimeSelection = createKiBuddyRuntime({
   appPath: app.getAppPath(),
   resetPassword: isResetPasswordMode,
   webUi: isWebUIMode,
 });
-configureUpdateBridge(kiBuddyRuntime?.updateBridge);
+const kiBuddyRuntime = kiBuddyRuntimeSelection.runtime;
+const kiBuddyProductBootstrap = createKiBuddyProductBootstrap(kiBuddyRuntimeSelection);
+const kiBuddyProductInvalid = kiBuddyRuntimeSelection.status === 'invalid';
+const productBusinessLifecycleEnabled = shouldStartProductBusinessLifecycle(kiBuddyRuntimeSelection);
+configureUpdateBridge(kiBuddyProductInvalid ? null : kiBuddyRuntime?.updateBridge);
+configureNotificationBrandIcon(kiBuddyProductInvalid ? null : (kiBuddyRuntime?.brand.iconPath ?? 'app.png'));
 if (kiBuddyRuntime) {
   configureTrayBrand(kiBuddyRuntime.brand);
-  configureNotificationBrandIcon(kiBuddyRuntime.brand.iconPath);
 }
 const kiBuddyCoreAuthOptions = kiBuddyRuntime?.coreAuthOptions ?? null;
-const ensureDefaultCoreUser = shouldEnsureDefaultCoreUser(Boolean(kiBuddyRuntime));
-const resolveBackendDataPath = (dataPath: string): string => kiBuddyRuntime?.resolveDataPath(dataPath) ?? dataPath;
+const ensureDefaultCoreUser = shouldEnsureDefaultCoreUser(kiBuddyRuntimeSelection.status !== 'absent');
+const resolveBackendDataPath = (dataPath: string): string =>
+  kiBuddyRuntimeSelection.status !== 'absent' ? resolveKiBuddyCoreDataPath(dataPath) : dataPath;
 
 // Flag to distinguish intentional quit from unexpected exit in WebUI mode
 let isExplicitQuit = false;
@@ -233,85 +248,88 @@ let rendererInitialLanguage: string | null = null;
 let backendMigrationsScheduled = false;
 let ensureAdminUserPromise: Promise<void> | null = null;
 
-ipcMain.on('get-backend-port', (event) => {
-  event.returnValue = backendManager.port;
+ipcMain.on(KI_BUDDY_PRODUCT_BOOTSTRAP_CHANNEL, (event) => {
+  event.returnValue = kiBuddyProductBootstrap;
 });
 
-ipcMain.on('get-product-runtime-identity', (event) => {
-  event.returnValue = kiBuddyRuntime?.productIdentity ?? null;
-});
+if (productBusinessLifecycleEnabled) {
+  ipcMain.on('get-backend-port', (event) => {
+    event.returnValue = backendManager.port;
+  });
 
-ipcMain.on('get-initial-language', (event) => {
-  event.returnValue = rendererInitialLanguage;
-});
+  ipcMain.on('get-initial-language', (event) => {
+    event.returnValue = rendererInitialLanguage;
+  });
 
-if (kiBuddyRuntime) {
-  ipcMain.on(kiBuddyRuntime.coreTransportChannel, (event) => {
-    event.returnValue = kiBuddyRuntime.coreAuthOptions.coreCsrfToken;
+  if (kiBuddyRuntime) {
+    ipcMain.on(kiBuddyRuntime.coreTransportChannel, (event) => {
+      event.returnValue = kiBuddyRuntime.coreAuthOptions.coreCsrfToken;
+    });
+  }
+
+  ipcMain.on('get-backend-startup-failed', (event) => {
+    event.returnValue = backendStartupFailed;
+  });
+
+  ipcMain.on('get-backend-startup-failure', (event) => {
+    event.returnValue = backendStartupFailureInfo;
+  });
+
+  ipcMain.handle('backend:recover-corrupted-database', async () => {
+    const { recoverCorruptedDatabaseAfterUserConfirmation } =
+      await import('./process/startup/recoverCorruptedDatabase');
+
+    await recoverCorruptedDatabaseAfterUserConfirmation({
+      getFailure: () => backendStartupFailureInfo,
+      stopBackend: () => backendManager.stop(),
+      startBackendWithRecovery: async () => {
+        try {
+          const { getDataPath } = await import('./process/utils/utils');
+          const { getSystemDir } = await import('./process/utils/initStorage');
+          const sysDir = getSystemDir();
+          return await backendManager.start(
+            resolveBackendDataPath(getDataPath()),
+            sysDir.logDir,
+            {
+              cacheDir: sysDir.cacheDir,
+              workDir: sysDir.workDir,
+              logDir: sysDir.logDir,
+            },
+            {
+              allowPendingOnHealthTimeout: false,
+              ...kiBuddyCoreAuthOptions,
+              onHealthTimeout: async (error) => {
+                markBackendStartupFailed(error);
+                await captureBackendStartupFailure(error);
+              },
+              onPendingExit: async (error) => {
+                markBackendStartupFailed(error);
+                await captureBackendStartupFailure(error);
+              },
+              onReady: (backendPort) => {
+                markBackendReady(backendPort, 'backendManager.recoverCorruptedDatabase.lateReady');
+              },
+            },
+            undefined,
+            { recoverCorruptedDatabase: true }
+          );
+        } catch (error) {
+          markBackendStartupFailed(error);
+          await captureBackendStartupFailure(error);
+          throw error;
+        }
+      },
+      markReady: markBackendReady,
+      reloadMainWindow: () => {
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.reload();
+        }
+      },
+      logInfo: console.info,
+      logWarn: console.warn,
+    });
   });
 }
-
-ipcMain.on('get-backend-startup-failed', (event) => {
-  event.returnValue = backendStartupFailed;
-});
-
-ipcMain.on('get-backend-startup-failure', (event) => {
-  event.returnValue = backendStartupFailureInfo;
-});
-
-ipcMain.handle('backend:recover-corrupted-database', async () => {
-  const { recoverCorruptedDatabaseAfterUserConfirmation } = await import('./process/startup/recoverCorruptedDatabase');
-
-  await recoverCorruptedDatabaseAfterUserConfirmation({
-    getFailure: () => backendStartupFailureInfo,
-    stopBackend: () => backendManager.stop(),
-    startBackendWithRecovery: async () => {
-      try {
-        const { getDataPath } = await import('./process/utils/utils');
-        const { getSystemDir } = await import('./process/utils/initStorage');
-        const sysDir = getSystemDir();
-        return await backendManager.start(
-          resolveBackendDataPath(getDataPath()),
-          sysDir.logDir,
-          {
-            cacheDir: sysDir.cacheDir,
-            workDir: sysDir.workDir,
-            logDir: sysDir.logDir,
-          },
-          {
-            allowPendingOnHealthTimeout: false,
-            ...kiBuddyCoreAuthOptions,
-            onHealthTimeout: async (error) => {
-              markBackendStartupFailed(error);
-              await captureBackendStartupFailure(error);
-            },
-            onPendingExit: async (error) => {
-              markBackendStartupFailed(error);
-              await captureBackendStartupFailure(error);
-            },
-            onReady: (backendPort) => {
-              markBackendReady(backendPort, 'backendManager.recoverCorruptedDatabase.lateReady');
-            },
-          },
-          undefined,
-          { recoverCorruptedDatabase: true }
-        );
-      } catch (error) {
-        markBackendStartupFailed(error);
-        await captureBackendStartupFailure(error);
-        throw error;
-      }
-    },
-    markReady: markBackendReady,
-    reloadMainWindow: () => {
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.reload();
-      }
-    },
-    logInfo: console.info,
-    logWarn: console.warn,
-  });
-});
 
 // Push the latest backend startup state to the renderer so it can either show
 // the "starting" view, switch to the honest-failure view, or return to the App.
@@ -551,7 +569,7 @@ const createWindow = ({ showOnReady = true }: { showOnReady?: boolean } = {}): v
   initMainAdapterWithWindow(mainWindow);
   bindMainWindowReferences(mainWindow);
 
-  setupApplicationMenu();
+  if (!kiBuddyProductInvalid) setupApplicationMenu();
 
   setupZoomForWindow(mainWindow);
   registerWindowMaximizeListeners(mainWindow);
@@ -561,7 +579,10 @@ const createWindow = ({ showOnReady = true }: { showOnReady?: boolean } = {}): v
   // 初始化自动更新服务（通过环境变量禁用时跳过，例如 E2E / CI 场景）
   const isCiRuntime = process.env.CI === 'true' || process.env.CI === '1' || process.env.GITHUB_ACTIONS === 'true';
   const disableAutoUpdater =
-    process.env.AIONUI_DISABLE_AUTO_UPDATE === '1' || process.env.AIONUI_E2E_TEST === '1' || isCiRuntime;
+    kiBuddyProductInvalid ||
+    process.env.AIONUI_DISABLE_AUTO_UPDATE === '1' ||
+    process.env.AIONUI_E2E_TEST === '1' ||
+    isCiRuntime;
   if (!disableAutoUpdater) {
     Promise.all([import('@process/services/autoUpdaterService'), import('@process/bridge/updateBridge')])
       .then(([{ autoUpdaterService }, { createAutoUpdateStatusBroadcast }]) => {
@@ -664,10 +685,33 @@ const createWindow = ({ showOnReady = true }: { showOnReady?: boolean } = {}): v
   });
 };
 
+const createProductIntegrityWindow = (): void => {
+  mainWindow = createKiBuddyProductIntegrityWindow({
+    isPackaged: app.isPackaged,
+    preloadPath: path.join(__dirname, '../preload/index.js'),
+    rendererFile: path.join(__dirname, '../renderer/index.html'),
+    rendererUrl: process.env['ELECTRON_RENDERER_URL'],
+  });
+};
+
+const createWindowForSelectedProduct = (): void => {
+  if (productBusinessLifecycleEnabled) createWindow();
+  else createProductIntegrityWindow();
+};
+
 const handleAppReady = async (): Promise<void> => {
   const t0 = performance.now();
   const mark = (label: string) => console.log(`[AionUi:ready] ${label} +${Math.round(performance.now() - t0)}ms`);
   mark('start');
+
+  if (!productBusinessLifecycleEnabled) {
+    setCloseToTrayEnabled(false);
+    destroyTray();
+    createProductIntegrityWindow();
+    appReadyDone = true;
+    mark('createProductIntegrityWindow');
+    return;
+  }
 
   if (!app.isPackaged) {
     try {
@@ -705,6 +749,8 @@ const handleAppReady = async (): Promise<void> => {
   setSentryDeviceId();
 
   try {
+    await import('./process/bridge/feedbackBridge');
+    const { initializeProcess } = await import('./process');
     await initializeProcess();
     const savedLanguage = ProcessConfig.getSync('language');
     rendererInitialLanguage = kiBuddyRuntime?.resolveLanguage(savedLanguage, app.getLocale()) ?? savedLanguage ?? null;
@@ -970,7 +1016,7 @@ const handleAppReady = async (): Promise<void> => {
     });
   } else {
     // 初始化关闭到托盘设置 / Initialize close-to-tray setting
-    if (isE2ETestMode) {
+    if (isE2ETestMode || kiBuddyProductInvalid) {
       setCloseToTrayEnabled(false);
       destroyTray();
     } else {
@@ -992,23 +1038,25 @@ const handleAppReady = async (): Promise<void> => {
     mark('createWindow');
 
     // Initialize desktop pet (delayed to not block main window)
-    setTimeout(() => {
-      void (async () => {
-        try {
-          const petEnabled = await ProcessConfig.get('pet.enabled');
-          if (petEnabled === true) {
-            // Read pet sub-settings before creating the pet so flags are honored
-            // on the first createPetWindow() call (which is sync).
-            const confirmEnabled = (await ProcessConfig.get('pet.confirmEnabled')) ?? true;
-            const { createPetWindow, setPetConfirmEnabled } = await import('./process/pet/petManager');
-            setPetConfirmEnabled(confirmEnabled);
-            createPetWindow();
+    if (!kiBuddyProductInvalid) {
+      setTimeout(() => {
+        void (async () => {
+          try {
+            const petEnabled = await ProcessConfig.get('pet.enabled');
+            if (petEnabled === true) {
+              // Read pet sub-settings before creating the pet so flags are honored
+              // on the first createPetWindow() call (which is sync).
+              const confirmEnabled = (await ProcessConfig.get('pet.confirmEnabled')) ?? true;
+              const { createPetWindow, setPetConfirmEnabled } = await import('./process/pet/petManager');
+              setPetConfirmEnabled(confirmEnabled);
+              createPetWindow();
+            }
+          } catch (error) {
+            console.error('[Pet] Failed to initialize:', error);
           }
-        } catch (error) {
-          console.error('[Pet] Failed to initialize:', error);
-        }
-      })();
-    }, 3000);
+        })();
+      }, 3000);
+    }
 
     // 读取语言设置并初始化主进程 i18n，然后刷新托盘菜单
     // Read language setting and initialize main process i18n, then refresh tray menu
@@ -1017,17 +1065,19 @@ const handleAppReady = async (): Promise<void> => {
       const language = kiBuddyRuntime?.resolveLanguage(savedLanguage, app.getLocale()) ?? savedLanguage;
       await setInitialLanguage(language);
       // After language is set, refresh tray menu if it exists
-      await refreshTrayMenu();
+      if (!kiBuddyProductInvalid) await refreshTrayMenu();
     } catch (error) {
       console.error('[index] Failed to initialize i18n language:', error);
     }
 
     // 监听语言变更，刷新托盘菜单文案 / Listen for language changes to refresh tray menu labels
-    onLanguageChanged(() => {
-      void refreshTrayMenu();
-    });
+    if (!kiBuddyProductInvalid) {
+      onLanguageChanged(() => {
+        void refreshTrayMenu();
+      });
+    }
 
-    if (!isE2ETestMode) {
+    if (!isE2ETestMode && !kiBuddyProductInvalid) {
       // 窗口创建后异步恢复 WebUI，不阻塞 UI / Restore WebUI async after window creation, non-blocking
       restoreDesktopWebUIFromPreferences().catch((error) => {
         console.error('[WebUI] Failed to auto-restore:', error);
@@ -1047,10 +1097,10 @@ const handleAppReady = async (): Promise<void> => {
 
 // ============ Protocol Registration ============
 // Register the selected desktop product protocol.
-if (process.defaultApp) {
+if (protocolScheme && process.defaultApp) {
   // Dev mode: need to pass execPath explicitly
   app.setAsDefaultProtocolClient(protocolScheme, process.execPath, [path.resolve(process.argv[1])]);
-} else {
+} else if (protocolScheme) {
   app.setAsDefaultProtocolClient(protocolScheme);
 }
 
@@ -1062,11 +1112,11 @@ app.on('open-url', (event, url) => {
     return;
   }
   // Focus existing window so user sees the result
-  showOrCreateMainWindow({ mainWindow, createWindow });
+  showOrCreateMainWindow({ mainWindow, createWindow: createWindowForSelectedProduct });
 });
 
 // 监听 GPU 子进程崩溃，连续多次后下次启动自动关闭硬件加速（参见 ELECTRON-9A / ELECTRON-9D）。
-installGpuCrashHandler();
+if (productBusinessLifecycleEnabled) installGpuCrashHandler();
 
 // Register the backend startup flow only when this process owns the single
 // instance lock. A lock-losing instance must NOT spawn a competing aioncore
@@ -1112,7 +1162,7 @@ app.on('activate', () => {
         void app.dock.show();
       }
     } else {
-      createWindow();
+      createWindowForSelectedProduct();
     }
   }
 });
@@ -1131,11 +1181,13 @@ installQuitCleanup({
   },
   // Stop aioncore subprocess — backend shutdown kills all agent children
   // transitively (no separate frontend workerTaskManager remains).
-  stopBackend: () => backendManager.stop(),
-  destroyPetWindow: async () => {
-    const { destroyPetWindow } = await import('./process/pet/petManager');
-    destroyPetWindow();
-  },
+  stopBackend: () => (productBusinessLifecycleEnabled ? backendManager.stop() : Promise.resolve()),
+  destroyPetWindow: productBusinessLifecycleEnabled
+    ? async () => {
+        const { destroyPetWindow } = await import('./process/pet/petManager');
+        destroyPetWindow();
+      }
+    : () => Promise.resolve(),
   logInfo: console.log,
   logWarn: console.warn,
   logError: console.error,

--- a/packages/desktop/src/preload/main.ts
+++ b/packages/desktop/src/preload/main.ts
@@ -11,40 +11,34 @@
 import '@sentry/electron/preload';
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import { ADAPTER_BRIDGE_EVENT_KEY } from '../common/adapter/constant';
-import {
-  KI_BUDDY_CORE_TRANSPORT_CHANNEL,
-  KI_BUDDY_PRODUCT_CAPABILITY,
-  KI_BUDDY_PRODUCT_RUNTIME,
-} from '@/common/platform/ki-buddy';
+import { KI_BUDDY_CORE_TRANSPORT_CHANNEL, KI_BUDDY_PRODUCT_BOOTSTRAP_CHANNEL } from '@/common/platform/ki-buddy';
+import type { KiBuddyProductBootstrap } from '@/common/types/platform/kiBuddyProduct';
 import { KI_BUDDY_AUTH_CHANNELS } from '@/common/platform/kiBuddyAuth';
 import type { KiBuddyAuthApi } from '@/common/types/platform/kiBuddyAuth';
 
-const productRuntimeIdentity = ipcRenderer.sendSync('get-product-runtime-identity') as string | null;
-const coreCsrfToken =
-  productRuntimeIdentity === KI_BUDDY_PRODUCT_RUNTIME
-    ? (ipcRenderer.sendSync(KI_BUDDY_CORE_TRANSPORT_CHANNEL) as string | null)
-    : null;
-const kiBuddyAuthCapability =
-  productRuntimeIdentity === KI_BUDDY_PRODUCT_RUNTIME
-    ? {
-        kiBuddyAuth: {
-          getSession: () => ipcRenderer.invoke(KI_BUDDY_AUTH_CHANNELS.getSession),
-          login: (request: Parameters<KiBuddyAuthApi['login']>[0]) =>
-            ipcRenderer.invoke(KI_BUDDY_AUTH_CHANNELS.login, request),
-          logout: () => ipcRenderer.invoke(KI_BUDDY_AUTH_CHANNELS.logout),
-          onSessionInvalidated: (listener: () => void) => {
-            const handler = () => listener();
-            ipcRenderer.on(KI_BUDDY_AUTH_CHANNELS.sessionInvalidated, handler);
-            return () => ipcRenderer.off(KI_BUDDY_AUTH_CHANNELS.sessionInvalidated, handler);
-          },
-        } satisfies KiBuddyAuthApi,
-        ...(coreCsrfToken ? { kiBuddyCoreTransport: { csrfToken: coreCsrfToken } } : {}),
-      }
-    : {};
-const productPresentationCapability =
-  productRuntimeIdentity === KI_BUDDY_PRODUCT_RUNTIME ? KI_BUDDY_PRODUCT_CAPABILITY : null;
-
-contextBridge.exposeInMainWorld('__getKiBuddyProductPresentation', () => productPresentationCapability);
+const productBootstrap = ipcRenderer.sendSync(KI_BUDDY_PRODUCT_BOOTSTRAP_CHANNEL) as KiBuddyProductBootstrap;
+const productIntegrityOnly = productBootstrap.status === 'invalid';
+const kiBuddyRuntimeReady = productBootstrap.status === 'ready';
+const coreCsrfToken = kiBuddyRuntimeReady
+  ? (ipcRenderer.sendSync(KI_BUDDY_CORE_TRANSPORT_CHANNEL) as string | null)
+  : null;
+const kiBuddyAuthCapability = kiBuddyRuntimeReady
+  ? {
+      kiBuddyAuth: {
+        getSession: () => ipcRenderer.invoke(KI_BUDDY_AUTH_CHANNELS.getSession),
+        login: (request: Parameters<KiBuddyAuthApi['login']>[0]) =>
+          ipcRenderer.invoke(KI_BUDDY_AUTH_CHANNELS.login, request),
+        logout: () => ipcRenderer.invoke(KI_BUDDY_AUTH_CHANNELS.logout),
+        onSessionInvalidated: (listener: () => void) => {
+          const handler = () => listener();
+          ipcRenderer.on(KI_BUDDY_AUTH_CHANNELS.sessionInvalidated, handler);
+          return () => ipcRenderer.off(KI_BUDDY_AUTH_CHANNELS.sessionInvalidated, handler);
+        },
+      } satisfies KiBuddyAuthApi,
+      ...(coreCsrfToken ? { kiBuddyCoreTransport: { csrfToken: coreCsrfToken } } : {}),
+    }
+  : {};
+contextBridge.exposeInMainWorld('__getKiBuddyProductBootstrap', () => productBootstrap);
 
 /**
  * @description 注入到renderer进程中, 用于与main进程通信
@@ -88,10 +82,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
 // Synchronously fetch the aioncore port and expose it to the renderer
 // via contextBridge (direct window assignment is invisible under contextIsolation).
-const backendPort = ipcRenderer.sendSync('get-backend-port') as number;
-const initialLanguage = ipcRenderer.sendSync('get-initial-language') as string | null;
-const backendStartupFailed = ipcRenderer.sendSync('get-backend-startup-failed') as boolean;
-const backendStartupFailure = ipcRenderer.sendSync('get-backend-startup-failure') as unknown;
+const backendPort = productIntegrityOnly ? 0 : (ipcRenderer.sendSync('get-backend-port') as number);
+const initialLanguage = productIntegrityOnly ? null : (ipcRenderer.sendSync('get-initial-language') as string | null);
+const backendStartupFailed = productIntegrityOnly
+  ? false
+  : (ipcRenderer.sendSync('get-backend-startup-failed') as boolean);
+const backendStartupFailure = productIntegrityOnly
+  ? null
+  : (ipcRenderer.sendSync('get-backend-startup-failure') as unknown);
 contextBridge.exposeInMainWorld('__backendPort', backendPort > 0 ? backendPort : 0);
 contextBridge.exposeInMainWorld('__initialLanguage', initialLanguage ?? null);
 contextBridge.exposeInMainWorld('__aionuiE2ETest', process.env.AIONUI_E2E_TEST === '1');
@@ -103,8 +101,9 @@ contextBridge.exposeInMainWorld('__backendStartupFailure', backendStartupFailure
 // `subscribe` receives subsequent ready/exit pushes on the backend-startup-state
 // channel. All communication stays behind the preload contextBridge.
 contextBridge.exposeInMainWorld('__backendStartupBridge', {
-  getState: () => ipcRenderer.sendSync('get-backend-startup-failure'),
+  getState: () => (productIntegrityOnly ? null : ipcRenderer.sendSync('get-backend-startup-failure')),
   subscribe: (callback: (state: unknown) => void) => {
+    if (productIntegrityOnly) return () => {};
     const handler = (_event: unknown, value: unknown) => callback(value);
     ipcRenderer.on('backend-startup-state', handler);
     return () => {
@@ -123,8 +122,10 @@ const trayEvents = [
   'tray:check-update',
 ];
 
-for (const channel of trayEvents) {
-  ipcRenderer.on(channel, (_event, ...args) => {
-    window.dispatchEvent(new CustomEvent(channel, { detail: args[0] }));
-  });
+if (!productIntegrityOnly) {
+  for (const channel of trayEvents) {
+    ipcRenderer.on(channel, (_event, ...args) => {
+      window.dispatchEvent(new CustomEvent(channel, { detail: args[0] }));
+    });
+  }
 }

--- a/packages/desktop/src/process/bridge/notificationBridge.ts
+++ b/packages/desktop/src/process/bridge/notificationBridge.ts
@@ -21,10 +21,10 @@ import fs from 'fs';
 
 // Main window reference, used to gate on focus and to focus + navigate on click.
 let mainWindowRef: BrowserWindow | null = null;
-let notificationBrandIconPath = 'app.png';
+let notificationBrandIconPath: string | null = 'app.png';
 
-/** Selects the packaged icon used by system notifications for the active product. */
-export function configureNotificationBrandIcon(iconPath: string): void {
+/** Selects the packaged icon used by system notifications, or disables notifications on integrity failure. */
+export function configureNotificationBrandIcon(iconPath: string | null): void {
   notificationBrandIconPath = iconPath;
 }
 
@@ -36,6 +36,7 @@ export const setNotificationMainWindow = (win: BrowserWindow): void => {
  * Get app icon path for notifications
  */
 const getNotificationIcon = (): string | undefined => {
+  if (!notificationBrandIconPath) return undefined;
   try {
     const resourcesPath = getPlatformServices().paths.isPackaged()
       ? process.resourcesPath
@@ -70,6 +71,8 @@ export async function showNotification({
   body: string;
   conversation_id?: string;
 }): Promise<void> {
+  if (!notificationBrandIconPath) return;
+
   // Check if notification is enabled
   const notificationEnabled = await ProcessConfig.get('system.notificationEnabled');
   if (notificationEnabled === false) {

--- a/packages/desktop/src/process/bridge/updateBridge.ts
+++ b/packages/desktop/src/process/bridge/updateBridge.ts
@@ -76,12 +76,19 @@ const AION_UI_UPDATE_BRIDGE_CONFIGURATION: UpdateBridgeConfiguration = {
   userAgent: 'AionUi',
 };
 
-let updateBridgeConfiguration = AION_UI_UPDATE_BRIDGE_CONFIGURATION;
+let updateBridgeConfiguration: UpdateBridgeConfiguration | null = AION_UI_UPDATE_BRIDGE_CONFIGURATION;
 
-/** Selects the manual update source while preserving AionUi when no product configuration is provided. */
-export function configureUpdateBridge(configuration?: UpdateBridgeConfiguration): void {
-  updateBridgeConfiguration = configuration ?? AION_UI_UPDATE_BRIDGE_CONFIGURATION;
+/** Selects the manual update source, or disables updates while product configuration is invalid. */
+export function configureUpdateBridge(configuration?: UpdateBridgeConfiguration | null): void {
+  updateBridgeConfiguration = configuration === undefined ? AION_UI_UPDATE_BRIDGE_CONFIGURATION : configuration;
 }
+
+const getUpdateBridgeConfiguration = (): UpdateBridgeConfiguration => {
+  if (!updateBridgeConfiguration) {
+    throw new Error('Update service is unavailable because the product configuration is invalid.');
+  }
+  return updateBridgeConfiguration;
+};
 
 const ALLOWED_ASSET_EXTS = new Set(['.exe', '.msi', '.dmg', '.zip', '.deb', '.rpm']);
 const CDN_HOST = 'static.aionui.com';
@@ -102,7 +109,7 @@ const isAllowedAssetName = (name: string) => {
 
 const normalizeTagToSemver = (tag: string): string | null => {
   const trimmed = tag.trim();
-  const tagPrefix = updateBridgeConfiguration.tagPrefix;
+  const tagPrefix = getUpdateBridgeConfiguration().tagPrefix;
   if (!trimmed.startsWith(tagPrefix)) return null;
   const withoutV = trimmed.slice(tagPrefix.length);
   // Ensure it looks like a semver prefix at least.
@@ -261,7 +268,8 @@ export const parseCdnManifest = (raw: string): CdnLatestManifest | null => {
 export const mapCdnManifestToRelease = (manifest: CdnLatestManifest, repo: string): UpdateReleaseInfo | null => {
   const version = semver.valid(manifest.version);
   if (!version) return null;
-  const tagPrefix = repo === updateBridgeConfiguration.repository ? updateBridgeConfiguration.tagPrefix : 'v';
+  const configuration = getUpdateBridgeConfiguration();
+  const tagPrefix = repo === configuration.repository ? configuration.tagPrefix : 'v';
   const assets: GitHubReleaseAsset[] = [];
   for (const file of manifest.files) {
     const name = path.basename(file.url.trim());
@@ -324,10 +332,11 @@ const selectLatestGitHubRelease = (
 };
 
 const resolveRepo = (requestRepo?: string): string => {
-  if (!updateBridgeConfiguration.allowRepositoryOverride) return updateBridgeConfiguration.repository;
+  const configuration = getUpdateBridgeConfiguration();
+  if (!configuration.allowRepositoryOverride) return configuration.repository;
   const envRepo = process.env.AIONUI_GITHUB_REPO?.trim();
-  const repo = (requestRepo || envRepo || updateBridgeConfiguration.repository).trim();
-  return repo || updateBridgeConfiguration.repository;
+  const repo = (requestRepo || envRepo || configuration.repository).trim();
+  return repo || configuration.repository;
 };
 
 const assertAllowedUrl = async (rawUrl: string) => {
@@ -356,7 +365,7 @@ const fetchWithAllowlistedRedirects = async (rawUrl: string, signal: AbortSignal
       signal,
       redirect: 'manual',
       headers: {
-        'User-Agent': updateBridgeConfiguration.userAgent,
+        'User-Agent': getUpdateBridgeConfiguration().userAgent,
       },
     });
 
@@ -386,7 +395,7 @@ const fetchGitHubReleases = async (repo: string, timeoutMs = 30000): Promise<Git
     const res = await fetch(url, {
       headers: {
         Accept: 'application/vnd.github+json',
-        'User-Agent': updateBridgeConfiguration.userAgent,
+        'User-Agent': getUpdateBridgeConfiguration().userAgent,
       },
       signal: controller.signal,
     });
@@ -419,7 +428,7 @@ const fetchCdnManifest = async (): Promise<CdnLatestManifest> => {
   const timeoutId = setTimeout(() => controller.abort(), CDN_MANIFEST_TIMEOUT_MS);
   try {
     const res = await fetch(url, {
-      headers: { 'User-Agent': updateBridgeConfiguration.userAgent },
+      headers: { 'User-Agent': getUpdateBridgeConfiguration().userAgent },
       signal: controller.signal,
     });
     if (!res.ok) throw new Error((await getI18n()).t('update.errors.cdnManifestFailed', { status: res.status }));
@@ -467,7 +476,7 @@ const sanitizeFileName = (name: string): string => {
   // Keep only base name and trim weird whitespace.
   const base = path.basename(name).trim();
   // Avoid empty names.
-  return base || `${updateBridgeConfiguration.userAgent}-update-${Date.now()}`;
+  return base || `${getUpdateBridgeConfiguration().userAgent}-update-${Date.now()}`;
 };
 
 const ensureUniquePath = (target: string): string => {
@@ -726,7 +735,8 @@ export function initUpdateBridge(): void {
         // 注入为带 prerelease 的 semver（如 `1.7.2-dev.1234+sha.abcdef0`），以保证比较顺序正确。
 
         let latest: UpdateReleaseInfo | null;
-        if (updateBridgeConfiguration.source === 'github' && repo === updateBridgeConfiguration.repository) {
+        const configuration = getUpdateBridgeConfiguration();
+        if (configuration.source === 'github' && repo === configuration.repository) {
           const releases = await fetchGitHubReleases(repo);
           latest = selectLatestGitHubRelease(releases, Boolean(params?.includePrerelease));
         } else {

--- a/packages/desktop/src/process/ki-buddy/index.ts
+++ b/packages/desktop/src/process/ki-buddy/index.ts
@@ -7,10 +7,16 @@
 import type { SupportedLanguage } from '@/common/config/i18n';
 import {
   KI_BUDDY_CORE_TRANSPORT_CHANNEL,
-  KI_BUDDY_DEFAULT_LANGUAGE,
-  KI_BUDDY_PRODUCT_CONFIG,
+  KI_BUDDY_PRODUCT_CONFIG_RESULT,
+  createKiBuddyProductCapability,
+  createKiBuddyProductExperience,
+  deepFreeze,
   resolveLanguagePreference,
+  type KiBuddyProductConfigLoadResult,
+  type ProductExperience,
+  type ProductFeatureId,
 } from '@/common/platform/ki-buddy';
+import type { KiBuddyProductBootstrap, KiBuddyProductCapability } from '@/common/types/platform/kiBuddyProduct';
 import { registerKiBuddyAuthBridge } from './authBridge';
 import type { AgentsAuthService } from './AgentsAuthService';
 import { createKiBuddyCoreAuthOptions, type KiBuddyCoreAuthOptions } from './bootstrap';
@@ -20,6 +26,7 @@ import { KI_BUDDY_PRODUCT_RUNTIME, readKiBuddyRuntimeIdentity, shouldEnableKiBud
 import { createKiBuddyUpdateBridgeConfiguration, createKiBuddyUpdateFeedConfiguration } from './update/updateFeed';
 import type { UpdateBridgeConfiguration } from '@process/bridge/updateBridge';
 import type { UpdateFeedConfiguration } from '@process/services/updateFeed';
+import { BrowserWindow } from 'electron';
 
 export type KiBuddyRuntime = {
   brand: {
@@ -29,38 +36,148 @@ export type KiBuddyRuntime = {
   coreAuthOptions: KiBuddyCoreAuthOptions;
   coreTransportChannel: typeof KI_BUDDY_CORE_TRANSPORT_CHANNEL;
   productIdentity: typeof KI_BUDDY_PRODUCT_RUNTIME;
+  productCapability: KiBuddyProductCapability;
+  productExperience: ProductExperience;
   registerAuthBridge: (getCoreBaseUrl: () => string) => AgentsAuthService;
   resolveDataPath: (dataPath: string) => string;
   resolveLanguage: (savedLanguage: string | null | undefined, systemLanguage: string | null) => SupportedLanguage;
+  startFeatureLifecycles: (lifecycles: readonly ProductFeatureLifecycle[]) => void;
   updateBridge: UpdateBridgeConfiguration;
   updateFeed: UpdateFeedConfiguration;
 };
 
+export type KiBuddyRuntimeSelection =
+  | Readonly<{ error: null; productIdentity: null; runtime: null; status: 'absent' }>
+  | Readonly<{ error: string; productIdentity: typeof KI_BUDDY_PRODUCT_RUNTIME; runtime: null; status: 'invalid' }>
+  | Readonly<{
+      error: null;
+      productIdentity: typeof KI_BUDDY_PRODUCT_RUNTIME;
+      runtime: KiBuddyRuntime;
+      status: 'ready';
+    }>;
+
+export type ProductFeatureLifecycle = {
+  featureId: ProductFeatureId;
+  start: () => void;
+};
+
+export type KiBuddyProductIntegrityWindowOptions = {
+  isPackaged: boolean;
+  preloadPath: string;
+  rendererFile: string;
+  rendererUrl?: string;
+};
+
+/** Builds the single serializable product bootstrap snapshot forwarded through preload. */
+export function createKiBuddyProductBootstrap(selection: KiBuddyRuntimeSelection): KiBuddyProductBootstrap {
+  if (selection.status === 'ready') {
+    return deepFreeze({
+      status: 'ready',
+      productIdentity: selection.productIdentity,
+      capability: selection.runtime.productCapability,
+      error: null,
+    });
+  }
+  if (selection.status === 'invalid') {
+    return deepFreeze({
+      status: 'invalid',
+      productIdentity: selection.productIdentity,
+      capability: null,
+      error: selection.error,
+    });
+  }
+  return deepFreeze({ status: 'absent', productIdentity: null, capability: null, error: null });
+}
+
+/** Keeps product-integrity startup isolated from every business lifecycle. */
+export function shouldStartProductBusinessLifecycle(selection: KiBuddyRuntimeSelection): boolean {
+  return selection.status !== 'invalid';
+}
+
+/** Creates the isolated Ki-Buddy window used only for packaged product integrity failures. */
+export function createKiBuddyProductIntegrityWindow(options: KiBuddyProductIntegrityWindowOptions): BrowserWindow {
+  const window = new BrowserWindow({
+    width: 900,
+    height: 640,
+    minWidth: 720,
+    minHeight: 480,
+    show: false,
+    title: 'Ki-Buddy',
+    webPreferences: {
+      preload: options.preloadPath,
+    },
+  });
+
+  window.once('ready-to-show', () => {
+    if (!window.isDestroyed()) window.show();
+  });
+
+  if (!options.isPackaged && options.rendererUrl) {
+    window.loadURL(options.rendererUrl).catch((error) => {
+      console.error('[Ki-Buddy] Failed to load product integrity UI:', error);
+    });
+  } else {
+    window.loadFile(options.rendererFile).catch((error) => {
+      console.error('[Ki-Buddy] Failed to load product integrity UI:', error);
+    });
+  }
+
+  return window;
+}
+
+/** Starts only lifecycle entries enabled by the selected product adapter. */
+export function startProductFeatureLifecycles(
+  productExperience: ProductExperience,
+  lifecycles: readonly ProductFeatureLifecycle[]
+): void {
+  for (const lifecycle of lifecycles) {
+    if (productExperience.featureState(lifecycle.featureId) === 'enabled') lifecycle.start();
+  }
+}
+
 /** Creates and installs the main-process Ki-Buddy runtime when explicit product metadata selects it. */
-export function createKiBuddyRuntime(options: {
-  appPath: string;
-  resetPassword: boolean;
-  webUi: boolean;
-}): KiBuddyRuntime | null {
+export function createKiBuddyRuntime(
+  options: {
+    appPath: string;
+    resetPassword: boolean;
+    webUi: boolean;
+  },
+  productConfigResult: KiBuddyProductConfigLoadResult = KI_BUDDY_PRODUCT_CONFIG_RESULT
+): KiBuddyRuntimeSelection {
+  const productIdentity = readKiBuddyRuntimeIdentity(options.appPath);
+  if (!productIdentity) return { status: 'absent', productIdentity: null, runtime: null, error: null };
+  if (!productConfigResult.config) {
+    return {
+      status: 'invalid',
+      productIdentity: KI_BUDDY_PRODUCT_RUNTIME,
+      runtime: null,
+      error: `Ki-Buddy product configuration is invalid: ${productConfigResult.error}`,
+    };
+  }
+
   const enabled = shouldEnableKiBuddyRuntime({
-    productIdentity: readKiBuddyRuntimeIdentity(options.appPath),
+    productIdentity,
     resetPassword: options.resetPassword,
     webUi: options.webUi,
   });
-  if (!enabled) return null;
+  if (!enabled) return { status: 'absent', productIdentity: null, runtime: null, error: null };
 
+  const config = productConfigResult.config;
+  const productExperience = createKiBuddyProductExperience(config.experience);
   const coreAuthOptions = createKiBuddyCoreAuthOptions();
   const coreTransport = new KiBuddyMainCoreTransport(coreAuthOptions.coreCsrfToken);
-  coreTransport.install();
+  startProductFeatureLifecycles(productExperience, [{ featureId: 'account', start: () => coreTransport.install() }]);
 
-  return {
+  const runtime: KiBuddyRuntime = {
     brand: {
-      iconPath: KI_BUDDY_PRODUCT_CONFIG.assets.packaged.icon,
-      productName: KI_BUDDY_PRODUCT_CONFIG.brand.productName,
+      iconPath: config.assets.packaged.icon,
+      productName: config.brand.productName,
     },
     coreAuthOptions,
     coreTransportChannel: KI_BUDDY_CORE_TRANSPORT_CHANNEL,
     productIdentity: KI_BUDDY_PRODUCT_RUNTIME,
+    productCapability: createKiBuddyProductCapability(config),
+    productExperience,
     registerAuthBridge: (getCoreBaseUrl) =>
       registerKiBuddyAuthBridge({
         bootstrapSecret: coreAuthOptions.bootstrapSecret,
@@ -71,12 +188,19 @@ export function createKiBuddyRuntime(options: {
     resolveLanguage: (savedLanguage, systemLanguage) =>
       resolveLanguagePreference({
         savedLanguage,
-        productLanguage: KI_BUDDY_DEFAULT_LANGUAGE,
+        productLanguage: config.defaults.language,
         systemLanguage,
       }),
-    updateBridge: createKiBuddyUpdateBridgeConfiguration(),
-    updateFeed: createKiBuddyUpdateFeedConfiguration(),
+    startFeatureLifecycles: (lifecycles) => startProductFeatureLifecycles(productExperience, lifecycles),
+    updateBridge: createKiBuddyUpdateBridgeConfiguration(config),
+    updateFeed: createKiBuddyUpdateFeedConfiguration(config),
   };
+  return { status: 'ready', productIdentity: KI_BUDDY_PRODUCT_RUNTIME, runtime, error: null };
 }
 
-export { resolveKiBuddyProtocolScheme, shouldEnsureDefaultCoreUser } from './runtimeIdentity';
+export {
+  readKiBuddyRuntimeIdentity,
+  resolveKiBuddyProtocolScheme,
+  shouldEnsureDefaultCoreUser,
+} from './runtimeIdentity';
+export { resolveKiBuddyCoreDataPath } from './coreDataPath';

--- a/packages/desktop/src/process/ki-buddy/runtimeIdentity.ts
+++ b/packages/desktop/src/process/ki-buddy/runtimeIdentity.ts
@@ -6,7 +6,11 @@
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { KI_BUDDY_PRODUCT_CONFIG, resolveKiBuddyRuntimeIdentity } from '@/common/platform/ki-buddy';
+import {
+  KI_BUDDY_PRODUCT_CONFIG_RESULT,
+  resolveKiBuddyRuntimeIdentity,
+  type KiBuddyProductConfigLoadResult,
+} from '@/common/platform/ki-buddy';
 
 export { KI_BUDDY_PRODUCT_RUNTIME, resolveKiBuddyRuntimeIdentity } from '@/common/platform/ki-buddy';
 
@@ -20,8 +24,13 @@ export function readKiBuddyRuntimeIdentity(appPath: string): boolean {
 }
 
 /** Resolves the packaged product protocol without enabling any product runtime side effects. */
-export function resolveKiBuddyProtocolScheme(appPath: string): string | null {
-  return readKiBuddyRuntimeIdentity(appPath) ? KI_BUDDY_PRODUCT_CONFIG.electronBuilder.protocolScheme : null;
+export function resolveKiBuddyProtocolScheme(
+  appPath: string,
+  productConfigResult: KiBuddyProductConfigLoadResult = KI_BUDDY_PRODUCT_CONFIG_RESULT
+): string | null {
+  return readKiBuddyRuntimeIdentity(appPath)
+    ? (productConfigResult.config?.electronBuilder.protocolScheme ?? null)
+    : null;
 }
 
 /** Selects the Ki-Buddy desktop runtime without conflating it with other Electron modes. */

--- a/packages/desktop/src/process/ki-buddy/update/updateFeed.ts
+++ b/packages/desktop/src/process/ki-buddy/update/updateFeed.ts
@@ -1,4 +1,4 @@
-import { KI_BUDDY_PRODUCT_CONFIG } from '@/common/platform/ki-buddy';
+import type { KiBuddyProductConfig } from '@/common/platform/ki-buddy';
 import type { UpdateBridgeConfiguration } from '@process/bridge/updateBridge';
 import type { UpdateFeedConfiguration } from '@process/services/updateFeed';
 import {
@@ -10,34 +10,34 @@ type KiBuddyFeedOptions = KiBuddyGitHubProviderConfiguration & {
   updateProvider: typeof KiBuddyGitHubProvider;
 };
 
-function buildKiBuddyFeedOptions(): KiBuddyFeedOptions {
-  const [owner, repo] = KI_BUDDY_PRODUCT_CONFIG.updates.repository.split('/');
+function buildKiBuddyFeedOptions(config: KiBuddyProductConfig): KiBuddyFeedOptions {
+  const [owner, repo] = config.updates.repository.split('/');
   if (!owner || !repo) throw new Error('Ki-Buddy update repository must use owner/repo format');
   return {
     owner,
     provider: 'custom',
     repo,
-    tagPrefix: KI_BUDDY_PRODUCT_CONFIG.updates.tagPrefix,
+    tagPrefix: config.updates.tagPrefix,
     updateProvider: KiBuddyGitHubProvider,
   };
 }
 
 /** Creates the product-owned update contract supplied to the shared updater service. */
-export function createKiBuddyUpdateFeedConfiguration(): UpdateFeedConfiguration {
+export function createKiBuddyUpdateFeedConfiguration(config: KiBuddyProductConfig): UpdateFeedConfiguration {
   return {
-    feedOptions: buildKiBuddyFeedOptions(),
+    feedOptions: buildKiBuddyFeedOptions(config),
     label: 'Ki-Buddy GitHub provider',
-    updaterCacheDirName: KI_BUDDY_PRODUCT_CONFIG.electronBuilder.appId,
+    updaterCacheDirName: config.electronBuilder.appId,
   };
 }
 
 /** Creates the product-owned manual update contract supplied to the shared update bridge. */
-export function createKiBuddyUpdateBridgeConfiguration(): UpdateBridgeConfiguration {
+export function createKiBuddyUpdateBridgeConfiguration(config: KiBuddyProductConfig): UpdateBridgeConfiguration {
   return {
     allowRepositoryOverride: false,
-    repository: KI_BUDDY_PRODUCT_CONFIG.updates.repository,
+    repository: config.updates.repository,
     source: 'github',
-    tagPrefix: KI_BUDDY_PRODUCT_CONFIG.updates.tagPrefix,
-    userAgent: KI_BUDDY_PRODUCT_CONFIG.brand.productName,
+    tagPrefix: config.updates.tagPrefix,
+    userAgent: config.brand.productName,
   };
 }

--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -5,7 +5,6 @@
  */
 
 import { ipcBridge } from '@/common';
-import { TEAM_MODE_ENABLED } from '@/common/config/constants';
 import PwaPullToRefresh from '@/renderer/components/layout/PwaPullToRefresh';
 import Titlebar from '@/renderer/components/layout/Titlebar';
 import { Layout as ArcoLayout, Tooltip } from '@arco-design/web-react';
@@ -41,6 +40,7 @@ import { IS_DISCONTINUED_BUILD } from '@/renderer/utils/discontinuedBuild';
 import UpdateMigrationDialog from '@/renderer/components/settings/UpdateMigrationDialog';
 import { getRendererBrand } from '@/renderer/services/runtime/productBrandRuntime';
 import '@renderer/styles/layout.css';
+import { isProductFeatureEnabled } from '@/renderer/services/runtime/kiBuddyRuntime';
 
 const SidebarIcon: React.FC<{ size?: number; strokeWidth?: number }> = ({ size = 18, strokeWidth = 4 }) => (
   <svg
@@ -134,8 +134,9 @@ const Layout: React.FC<{
   const location = useLocation();
   const brand = getRendererBrand();
   const productName = brand.productName;
+  const teamEnabled = isProductFeatureEnabled('team');
   const workspaceAvailable =
-    location.pathname.startsWith('/conversation/') || (TEAM_MODE_ENABLED && location.pathname.startsWith('/team/'));
+    location.pathname.startsWith('/conversation/') || (teamEnabled && location.pathname.startsWith('/team/'));
   const toggleSider = useCallback(() => {
     setCollapsed((previous) => !previous);
   }, []);

--- a/packages/desktop/src/renderer/components/layout/Router.tsx
+++ b/packages/desktop/src/renderer/components/layout/Router.tsx
@@ -2,8 +2,7 @@ import React, { Suspense } from 'react';
 import { HashRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import AppLoader from '@renderer/components/layout/AppLoader';
 import { useAuth } from '@renderer/hooks/context/AuthContext';
-import { TEAM_MODE_ENABLED } from '@/common/config/constants';
-import { getKiBuddyRouteComponents } from '@/renderer/services/runtime/kiBuddyRuntime';
+import { getKiBuddyRouteComponents, isProductFeatureEnabled } from '@/renderer/services/runtime/kiBuddyRuntime';
 const Conversation = React.lazy(() => import('@renderer/pages/conversation'));
 const Guid = React.lazy(() => import('@renderer/pages/guid'));
 const AgentSettings = React.lazy(() => import('@renderer/pages/settings/AgentSettings'));
@@ -57,6 +56,7 @@ const ProtectedLayout: React.FC<{ layout: React.ReactElement }> = ({ layout }) =
 const PanelRoute: React.FC<{ layout: React.ReactElement }> = ({ layout }) => {
   const { status } = useAuth();
   const kiBuddyRoutes = getKiBuddyRouteComponents();
+  const teamEnabled = isProductFeatureEnabled('team');
   const LoginPage = kiBuddyRoutes?.LoginPage ?? AionUiLoginPage;
 
   const routes = (
@@ -78,10 +78,7 @@ const PanelRoute: React.FC<{ layout: React.ReactElement }> = ({ layout }) => {
           <Route index element={<Navigate to='/guid' replace />} />
           <Route path='/guid' element={withRouteFallback(Guid)} />
           <Route path='/conversation/:id' element={withRouteFallback(Conversation)} />
-          <Route
-            path='/team/:id'
-            element={TEAM_MODE_ENABLED ? withRouteFallback(TeamIndex) : <Navigate to='/guid' replace />}
-          />
+          {teamEnabled && <Route path='/team/:id' element={withRouteFallback(TeamIndex)} />}
           <Route path='/settings/model' element={withRouteFallback(ModeSettings)} />
           <Route path='/assistants' element={withRouteFallback(AssistantSettings)} />
           {/* Assistants moved out of Settings to a top-level entry; keep a redirect

--- a/packages/desktop/src/renderer/components/layout/Sider/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/index.tsx
@@ -11,6 +11,7 @@ import { SiderToolbar, SiderSearchEntry, SiderScheduledEntry, SiderAssistantEntr
 import SiderFooter, { shouldShowAionUiSiderLogout } from './SiderFooter';
 import TeamSiderSection from './TeamSiderSection';
 import siderStyles from './Sider.module.css';
+import { isProductFeatureEnabled } from '@/renderer/services/runtime/kiBuddyRuntime';
 
 const WorkspaceGroupedHistory = React.lazy(() => import('@renderer/pages/conversation/GroupedHistory'));
 const SettingsSider = React.lazy(() => import('@renderer/pages/settings/components/SettingsSider'));
@@ -37,6 +38,7 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
     authenticated: status === 'authenticated',
     electronDesktop: typeof window !== 'undefined' && Boolean(window.electronAPI),
   });
+  const teamEnabled = isProductFeatureEnabled('team');
 
   useEffect(() => {
     if (!pathname.startsWith('/settings')) {
@@ -232,12 +234,14 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
                   {...workspaceHistoryProps}
                   afterPinnedContent={
                     <>
-                      <TeamSiderSection
-                        collapsed={collapsed}
-                        pathname={pathname}
-                        siderTooltipProps={siderTooltipProps}
-                        onSessionClick={onSessionClick}
-                      />
+                      {teamEnabled && (
+                        <TeamSiderSection
+                          collapsed={collapsed}
+                          pathname={pathname}
+                          siderTooltipProps={siderTooltipProps}
+                          onSessionClick={onSessionClick}
+                        />
+                      )}
                     </>
                   }
                 />

--- a/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { ipcBridge } from '@/common';
-import { TEAM_MODE_ENABLED } from '@/common/config/constants';
 import ConversationSearchPopover from '@renderer/pages/conversation/GroupedHistory/ConversationSearchPopover';
 import MobileConversationBrand from './MobileConversationBrand';
 import WindowControls from '../WindowControls';
@@ -19,6 +18,7 @@ import { isElectronDesktop, isMacOS } from '@/renderer/utils/platform';
 import { IS_DISCONTINUED_BUILD } from '@/renderer/utils/discontinuedBuild';
 import MigrationInviteCapsule from './MigrationInviteCapsule';
 import { getRendererBrand } from '@/renderer/services/runtime/productBrandRuntime';
+import { isProductFeatureEnabled } from '@/renderer/services/runtime/kiBuddyRuntime';
 import './titlebar.css';
 
 interface TitlebarProps {
@@ -98,6 +98,7 @@ const SidebarIcon: React.FC<{ size?: number; strokeWidth?: number }> = ({ size =
 );
 
 const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
+  const teamEnabled = isProductFeatureEnabled('team');
   const { t } = useTranslation();
   const appTitle = getRendererBrand().productName;
   const [workspaceCollapsed, setWorkspaceCollapsed] = useState(true);
@@ -213,7 +214,7 @@ const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
     }
 
     // Team mode: show team name
-    if (TEAM_MODE_ENABLED) {
+    if (teamEnabled) {
       const teamMatch = location.pathname.match(/^\/team\/([^/]+)/);
       const team_id = teamMatch?.[1];
       if (team_id) {
@@ -257,7 +258,7 @@ const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
     return () => {
       cancelled = true;
     };
-  }, [appTitle, layout?.isMobile, location.pathname]);
+  }, [appTitle, layout?.isMobile, location.pathname, teamEnabled]);
 
   useEffect(() => {
     if (!layout?.isMobile) {
@@ -395,7 +396,7 @@ const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
             if (conversation_id) {
               return <MobileConversationBrand conversation_id={conversation_id} fallbackTitle={mobileCenterTitle} />;
             }
-            const isTeamRoute = TEAM_MODE_ENABLED && /^\/team\/[^/]+/.test(location.pathname);
+            const isTeamRoute = teamEnabled && /^\/team\/[^/]+/.test(location.pathname);
             return (
               <span className='app-titlebar__brand-mobile'>
                 {isTeamRoute && (

--- a/packages/desktop/src/renderer/index.html
+++ b/packages/desktop/src/renderer/index.html
@@ -23,14 +23,19 @@
         try {
           window.__kiBuddyProductPresentation = null;
           window.__kiBuddyProductBootstrapError = null;
-          var candidate =
-            typeof window.__getKiBuddyProductPresentation === 'function'
-              ? window.__getKiBuddyProductPresentation()
-              : null;
+          var bootstrap =
+            typeof window.__getKiBuddyProductBootstrap === 'function'
+              ? window.__getKiBuddyProductBootstrap()
+              : { status: 'absent', productIdentity: null, capability: null, error: null };
+          if (!bootstrap || !['absent', 'invalid', 'ready'].includes(bootstrap.status)) {
+            throw new Error('Invalid Ki-Buddy product bootstrap snapshot');
+          }
+          if (bootstrap.status === 'invalid') throw new Error(bootstrap.error);
+          var candidate = bootstrap.status === 'ready' ? bootstrap.capability : null;
           var product =
             candidate &&
             candidate.id === 'ki-buddy' &&
-            candidate.schemaVersion === 2 &&
+            candidate.schemaVersion === 3 &&
             candidate.brand &&
             typeof candidate.brand.productName === 'string' &&
             candidate.assets &&
@@ -44,7 +49,12 @@
             typeof candidate.themes.light === 'string' &&
             candidate.themes.light.length > 0 &&
             typeof candidate.themes.dark === 'string' &&
-            candidate.themes.dark.length > 0
+            candidate.themes.dark.length > 0 &&
+            candidate.experience &&
+            candidate.experience.schemaVersion === 1 &&
+            candidate.experience.features &&
+            candidate.experience.resources &&
+            candidate.experience.behaviorDefaults
               ? candidate
               : null;
           if (candidate && !product) throw new Error('Invalid Ki-Buddy product presentation capability');

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -52,7 +52,11 @@ import type { TFunction } from 'i18next';
 // Context providers
 import { AuthProvider } from './hooks/context/AuthContext';
 import { installKiBuddyRendererCoreTransport, KiBuddyAuthProvider } from './pages/ki-buddy/Auth';
-import { getKiBuddyProductRuntime, getKiBuddyRendererRuntime } from './services/runtime/kiBuddyRuntime';
+import {
+  getKiBuddyProductBootstrapError,
+  getKiBuddyProductRuntime,
+  getKiBuddyRendererRuntime,
+} from './services/runtime/kiBuddyRuntime';
 import { initializeRendererBrand, installProductAssistantCatalogAdapter } from './services/runtime/productBrandRuntime';
 import { FeedbackProvider } from './hooks/context/FeedbackContext';
 import { ThemeProvider } from './hooks/context/ThemeContext';
@@ -82,12 +86,15 @@ import './styles/markdown.css';
 import { configService } from '@/common/config/configService';
 const kiBuddyRuntime = getKiBuddyRendererRuntime();
 const kiBuddyProductRuntime = getKiBuddyProductRuntime();
-if (kiBuddyRuntime) installKiBuddyRendererCoreTransport();
-installProductAssistantCatalogAdapter();
-initializeRendererBrand();
-configService.initialize().catch((err) => {
-  console.error('Failed to initialize config:', err);
-});
+const kiBuddyProductBootstrapError = getKiBuddyProductBootstrapError();
+if (!kiBuddyProductBootstrapError) {
+  if (kiBuddyRuntime) installKiBuddyRendererCoreTransport();
+  installProductAssistantCatalogAdapter();
+  initializeRendererBrand();
+  configService.initialize().catch((err) => {
+    console.error('Failed to initialize config:', err);
+  });
+}
 
 // i18n
 import './services/i18n';
@@ -100,6 +107,7 @@ import { bootstrapRendererConfig } from '@renderer/services/bootstrapRenderer';
 // Components and utilities
 import BackendStartingView from './components/layout/BackendStartingView';
 import BackendStartupGate from './components/layout/BackendStartupGate';
+import KiBuddyProductIntegrityGate from './pages/ki-buddy/KiBuddyProductIntegrityGate';
 import GpuAutoDisableNotice from './components/layout/GpuAutoDisableNotice';
 import Layout from './components/layout/Layout';
 import Router from './components/layout/Router';
@@ -457,25 +465,31 @@ const BackendStartupFailureDialog: React.FC<{ failure: BackendStartupFailureInfo
   );
 };
 
-void registerPwa();
+if (!kiBuddyProductBootstrapError) void registerPwa();
 
 const root = createRoot(document.getElementById('root')!);
 root.render(
-  <BackendStartupGate
-    renderStarting={() => (
-      <Config>
-        <BackendStartingView />
-      </Config>
-    )}
-    renderFailure={(failure) => (
-      <Config>
-        <BackendStartupFailureDialog failure={failure} />
-      </Config>
-    )}
-    renderApp={() => (
-      <AppProviders>
-        <App />
-      </AppProviders>
-    )}
-  />
+  kiBuddyProductBootstrapError ? (
+    <Config>
+      <KiBuddyProductIntegrityGate failure={kiBuddyProductBootstrapError} />
+    </Config>
+  ) : (
+    <BackendStartupGate
+      renderStarting={() => (
+        <Config>
+          <BackendStartingView />
+        </Config>
+      )}
+      renderFailure={(failure) => (
+        <Config>
+          <BackendStartupFailureDialog failure={failure} />
+        </Config>
+      )}
+      renderApp={() => (
+        <AppProviders>
+          <App />
+        </AppProviders>
+      )}
+    />
+  )
 );

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
@@ -27,6 +27,7 @@ import { resolveAssistantAvatar } from '@renderer/utils/model/assistantAvatar';
 import { resolveAssistantName } from '@renderer/utils/model/assistantDisplay';
 import { resolveCronAgentConfig } from './resolveCronAgentConfig';
 import { assistantRuntimeKey, isAionrsAssistant } from '@/common/types/agent/assistantTypes';
+import { getProductExperience } from '@/renderer/services/runtime/kiBuddyRuntime';
 
 const FormItem = Form.Item;
 const TextArea = Input.TextArea;
@@ -244,6 +245,8 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
   const { presetAssistants } = useConversationAssistants();
   const managedAgentRuntimeCatalog = useManagedAgentRuntimeCatalog();
   const { providers, getAvailableModels } = useModelProviderList();
+  const teamScheduledTaskExecutorsEnabled =
+    getProductExperience().behaviorDefaults().scheduledTaskExecutor === 'assistant-or-team';
   const [frequency, setFrequency] = useState<FrequencyType>('manual');
   const [time, setTime] = useState('09:00');
   const [weekday, setWeekday] = useState('MON');
@@ -312,7 +315,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
   }, [visible, editJob, form]);
 
   useEffect(() => {
-    if (!visible || !editJob?.metadata.conversation_id) {
+    if (!teamScheduledTaskExecutorsEnabled || !visible || !editJob?.metadata.conversation_id) {
       setTeamOwnershipStatus('standalone');
       return;
     }
@@ -338,7 +341,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [visible, editJob]);
+  }, [teamScheduledTaskExecutorsEnabled, visible, editJob]);
 
   // Edit mode needs the assistant catalog to map a stored job to its
   // current assistant id. We isolate this in a separate effect so that

--- a/packages/desktop/src/renderer/pages/ki-buddy/KiBuddyProductIntegrityGate.tsx
+++ b/packages/desktop/src/renderer/pages/ki-buddy/KiBuddyProductIntegrityGate.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { InstallationIntegrityModalHost } from '@/renderer/components/layout/InstallationIntegrityDialog';
+
+type KiBuddyProductIntegrityGateProps = {
+  failure: string;
+};
+
+/** Blocks the business host when a recognized Ki-Buddy installation has an invalid packaged policy. */
+const KiBuddyProductIntegrityGate: React.FC<KiBuddyProductIntegrityGateProps> = ({ failure }) => {
+  const { t } = useTranslation();
+  const description = t('login.kiBuddy.productExperience.invalidPolicyDescription');
+
+  return (
+    <div className='min-h-screen bg-bg-1'>
+      <InstallationIntegrityModalHost
+        description={description}
+        diagnostics={{
+          source: 'runtime_status',
+          description,
+          runtime: {
+            failureKind: 'bundled_resource_invalid',
+            message: failure,
+            resource: 'product-experience-policy',
+            scopeKind: 'application',
+          },
+        }}
+      />
+    </div>
+  );
+};
+
+export default KiBuddyProductIntegrityGate;

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1030,6 +1030,7 @@ export type I18nKey =
   | 'login.kiBuddy.onboarding.tools.openCode'
   | 'login.kiBuddy.onboarding.tools.qwen'
   | 'login.kiBuddy.pageTitle'
+  | 'login.kiBuddy.productExperience.invalidPolicyDescription'
   | 'login.kiBuddy.subtitle'
   | 'login.kiBuddy.welcome'
   | 'login.languageToggle'

--- a/packages/desktop/src/renderer/services/i18n/index.ts
+++ b/packages/desktop/src/renderer/services/i18n/index.ts
@@ -5,7 +5,7 @@ import { configService } from '@/common/config/configService';
 import { ipcBridge } from '@/common';
 import i18nConfig from '@/common/config/i18n-config.json';
 import { applyKiBuddyLocaleOverlay, resolveLanguagePreference } from '@/common/platform/ki-buddy';
-import { getKiBuddyProductRuntime } from '@/renderer/services/runtime/kiBuddyRuntime';
+import { getKiBuddyProductBootstrapError, getKiBuddyProductRuntime } from '@/renderer/services/runtime/kiBuddyRuntime';
 import {
   DEFAULT_LANGUAGE,
   normalizeLanguageCode,
@@ -201,18 +201,21 @@ i18n.on('languageChanged', async (lang: string) => {
 });
 
 // Initialize on module load
-void syncLanguageFromConfig();
+const productIntegrityOnly = Boolean(getKiBuddyProductBootstrapError());
+if (!productIntegrityOnly) void syncLanguageFromConfig();
 
 // Listen for language changes broadcast by the main process (from other renderers).
 // This enables real-time sync between desktop and WebUI — when one changes language,
 // the other updates immediately without requiring a restart.
-ipcBridge.systemSettings.languageChanged.on(async ({ language }) => {
-  const normalized = normalizeLanguageCode(language);
-  // Skip if already on this language (we're the one who triggered the change)
-  if (i18n.language === normalized) return;
-  await ensureAndSwitch(i18n, normalized, loadLocaleModules);
-  setLanguageHint(normalized);
-});
+if (!productIntegrityOnly) {
+  ipcBridge.systemSettings.languageChanged.on(async ({ language }) => {
+    const normalized = normalizeLanguageCode(language);
+    // Skip if already on this language (we're the one who triggered the change)
+    if (i18n.language === normalized) return;
+    await ensureAndSwitch(i18n, normalized, loadLocaleModules);
+    setLanguageHint(normalized);
+  });
+}
 
 /**
  * Change language with lazy loading.

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/login.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/login.json
@@ -16,6 +16,9 @@
   "footerPrimary": "Verwandle deine Kommandozeilen-KI",
   "footerSecondary": "Modern & Effizient",
   "kiBuddy": {
+    "productExperience": {
+      "invalidPolicyDescription": "Die Produkterlebnisrichtlinie von Ki-Buddy fehlt oder ist ungültig. Installieren Sie diese Version aus einem offiziellen Paket neu."
+    },
     "pageTitle": "{{productName}} - Bei Agents anmelden",
     "brand": "Ki-Buddy",
     "subtitle": "Mit einem vorhandenen Agents-Konto anmelden",

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/login.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/login.json
@@ -16,6 +16,9 @@
   "footerPrimary": "Transform your command-line AI",
   "footerSecondary": "Modern & Efficient",
   "kiBuddy": {
+    "productExperience": {
+      "invalidPolicyDescription": "Ki-Buddy's product experience policy is missing or invalid. Reinstall this version from an official package."
+    },
     "pageTitle": "{{productName}} - Sign in to Agents",
     "brand": "Ki-Buddy",
     "subtitle": "Sign in with your existing Agents account",

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/login.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/login.json
@@ -16,6 +16,9 @@
   "footerPrimary": "Transforma tu IA de línea de comandos",
   "footerSecondary": "Moderno y eficiente",
   "kiBuddy": {
+    "productExperience": {
+      "invalidPolicyDescription": "La política de experiencia de producto de Ki-Buddy falta o no es válida. Reinstale esta versión desde un paquete oficial."
+    },
     "pageTitle": "{{productName}} - Iniciar sesión en Agents",
     "brand": "Ki-Buddy",
     "subtitle": "Inicia sesión con tu cuenta de Agents existente",

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/login.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/login.json
@@ -16,6 +16,9 @@
   "footerPrimary": "هوش مصنوعی خط فرمان خود را متحول کنید",
   "footerSecondary": "مدرن و کارآمد",
   "kiBuddy": {
+    "productExperience": {
+      "invalidPolicyDescription": "سیاست تجربه محصول Ki-Buddy وجود ندارد یا نامعتبر است. این نسخه را از یک بسته رسمی دوباره نصب کنید."
+    },
     "pageTitle": "{{productName}} - ورود به Agents",
     "brand": "Ki-Buddy",
     "subtitle": "با حساب موجود Agents وارد شوید",

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/login.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/login.json
@@ -16,6 +16,9 @@
   "footerPrimary": "Transformez votre IA en ligne de commande",
   "footerSecondary": "Moderne et efficace",
   "kiBuddy": {
+    "productExperience": {
+      "invalidPolicyDescription": "La politique d'expérience produit de Ki-Buddy est absente ou non valide. Réinstallez cette version depuis un paquet officiel."
+    },
     "pageTitle": "{{productName}} - Connexion à Agents",
     "brand": "Ki-Buddy",
     "subtitle": "Connectez-vous avec votre compte Agents existant",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/login.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/login.json
@@ -16,6 +16,9 @@
   "footerPrimary": "コマンドラインAIをモダンに変革",
   "footerSecondary": "効率的でエレガント",
   "kiBuddy": {
+    "productExperience": {
+      "invalidPolicyDescription": "Ki-Buddy の製品エクスペリエンスポリシーが見つからないか無効です。公式パッケージからこのバージョンを再インストールしてください。"
+    },
     "pageTitle": "{{productName}} - Agents にログイン",
     "brand": "Ki-Buddy",
     "subtitle": "既存の Agents アカウントでログインしてください",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/login.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/login.json
@@ -16,6 +16,9 @@
   "footerPrimary": "명령줄 AI의 혁신",
   "footerSecondary": "현대적이고 효율적인",
   "kiBuddy": {
+    "productExperience": {
+      "invalidPolicyDescription": "Ki-Buddy 제품 경험 정책이 없거나 유효하지 않습니다. 공식 패키지에서 이 버전을 다시 설치하세요."
+    },
     "pageTitle": "{{productName}} - Agents 로그인",
     "brand": "Ki-Buddy",
     "subtitle": "기존 Agents 계정으로 로그인하세요",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/login.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/login.json
@@ -16,6 +16,9 @@
   "footerPrimary": "Transforme sua IA de linha de comando",
   "footerSecondary": "Moderno e Eficiente",
   "kiBuddy": {
+    "productExperience": {
+      "invalidPolicyDescription": "A política de experiência do produto Ki-Buddy está ausente ou é inválida. Reinstale esta versão usando um pacote oficial."
+    },
     "pageTitle": "{{productName}} - Entrar no Agents",
     "brand": "Ki-Buddy",
     "subtitle": "Entre com sua conta existente do Agents",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/login.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/login.json
@@ -16,6 +16,9 @@
   "footerPrimary": "Преобразуйте свой ИИ командной строки",
   "footerSecondary": "Современно и эффективно",
   "kiBuddy": {
+    "productExperience": {
+      "invalidPolicyDescription": "Политика продукта Ki-Buddy отсутствует или недействительна. Переустановите эту версию из официального пакета."
+    },
     "pageTitle": "{{productName}} — Вход в Agents",
     "brand": "Ki-Buddy",
     "subtitle": "Войдите с существующей учётной записью Agents",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/login.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/login.json
@@ -16,6 +16,9 @@
   "footerPrimary": "Komut satırı AI'nızı dönüştürün",
   "footerSecondary": "Modern ve Verimli",
   "kiBuddy": {
+    "productExperience": {
+      "invalidPolicyDescription": "Ki-Buddy ürün deneyimi ilkesi eksik veya geçersiz. Bu sürümü resmi bir paketten yeniden yükleyin."
+    },
     "pageTitle": "{{productName}} - Agents oturumu aç",
     "brand": "Ki-Buddy",
     "subtitle": "Mevcut Agents hesabınızla oturum açın",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/login.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/login.json
@@ -16,6 +16,9 @@
   "footerPrimary": "Трансформуйте свій ШІ у командному рядку",
   "footerSecondary": "Сучасно та ефективно",
   "kiBuddy": {
+    "productExperience": {
+      "invalidPolicyDescription": "Політика продукту Ki-Buddy відсутня або недійсна. Перевстановіть цю версію з офіційного пакета."
+    },
     "pageTitle": "{{productName}} — Вхід до Agents",
     "brand": "Ki-Buddy",
     "subtitle": "Увійдіть за допомогою наявного облікового запису Agents",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/login.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/login.json
@@ -16,6 +16,9 @@
   "footerPrimary": "命令行 AI 的现代化体验",
   "footerSecondary": "高效且优雅",
   "kiBuddy": {
+    "productExperience": {
+      "invalidPolicyDescription": "Ki-Buddy 的产品体验策略缺失或无效。请使用官方安装包重新安装当前版本。"
+    },
     "pageTitle": "{{productName}} - 登录 Agents",
     "brand": "Ki-Buddy",
     "subtitle": "使用现有 Agents 平台账户登录",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/login.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/login.json
@@ -16,6 +16,9 @@
   "footerPrimary": "命令列 AI 的現代化體驗",
   "footerSecondary": "高效且優雅",
   "kiBuddy": {
+    "productExperience": {
+      "invalidPolicyDescription": "Ki-Buddy 的產品體驗策略缺失或無效。請使用官方安裝套件重新安裝目前版本。"
+    },
     "pageTitle": "{{productName}} - 登入 Agents",
     "brand": "Ki-Buddy",
     "subtitle": "使用現有 Agents 平台帳戶登入",

--- a/packages/desktop/src/renderer/services/runtime/kiBuddyRuntime.ts
+++ b/packages/desktop/src/renderer/services/runtime/kiBuddyRuntime.ts
@@ -1,4 +1,10 @@
-import { KI_BUDDY_DEFAULT_LANGUAGE } from '@/common/platform/ki-buddy';
+import {
+  KI_BUDDY_DEFAULT_LANGUAGE,
+  createAionUiProductExperience,
+  createKiBuddyProductExperience,
+  type ProductExperience,
+  type ProductFeatureId,
+} from '@/common/platform/ki-buddy';
 import type { KiBuddyAuthApi } from '@/common/types/platform/kiBuddyAuth';
 import React from 'react';
 import { loadKiBuddyAccountSettings, loadKiBuddyLoginPage, loadKiBuddyStartupGate } from '@/renderer/pages/ki-buddy';
@@ -37,8 +43,11 @@ export type KiBuddyProductRuntime = {
   defaultLanguage: string | null;
   id: 'ki-buddy';
   localeNamespace: string;
+  productExperience: ProductExperience;
   themes: KiBuddyProductCapability['themes'];
 };
+
+const AION_UI_PRODUCT_EXPERIENCE = createAionUiProductExperience();
 
 const KI_BUDDY_ASSET_URLS = {
   'ki-buddy-app': kiBuddyLogoUrl,
@@ -48,18 +57,50 @@ const KI_BUDDY_ASSET_URLS = {
 /** Resolves product-owned renderer semantics from the validated first-frame bootstrap state. */
 export function getKiBuddyProductRuntime(): KiBuddyProductRuntime | null {
   const bootstrapError = typeof window === 'undefined' ? null : window.__kiBuddyProductBootstrapError;
-  if (bootstrapError) throw new Error(`Ki-Buddy product bootstrap failed: ${bootstrapError}`);
+  if (bootstrapError) return null;
   const product = typeof window === 'undefined' ? null : (window.__kiBuddyProductPresentation ?? null);
   if (!product) return null;
-  const logoUrl = KI_BUDDY_ASSET_URLS[product.assets.logo as keyof typeof KI_BUDDY_ASSET_URLS];
-  const mascotUrl = KI_BUDDY_ASSET_URLS[product.assets.mascot as keyof typeof KI_BUDDY_ASSET_URLS];
-  return {
-    id: 'ki-buddy',
-    brand: { ...product.brand, logoUrl, mascotUrl },
-    defaultLanguage: KI_BUDDY_DEFAULT_LANGUAGE ?? null,
-    localeNamespace: product.locale.namespace,
-    themes: product.themes,
-  };
+  try {
+    const productExperience = createKiBuddyProductExperience(product.experience);
+    const logoUrl = KI_BUDDY_ASSET_URLS[product.assets.logo as keyof typeof KI_BUDDY_ASSET_URLS];
+    const mascotUrl = KI_BUDDY_ASSET_URLS[product.assets.mascot as keyof typeof KI_BUDDY_ASSET_URLS];
+    return {
+      id: 'ki-buddy',
+      brand: { ...product.brand, logoUrl, mascotUrl },
+      defaultLanguage: KI_BUDDY_DEFAULT_LANGUAGE ?? null,
+      localeNamespace: product.locale.namespace,
+      productExperience,
+      themes: product.themes,
+    };
+  } catch (error) {
+    if (typeof window !== 'undefined') {
+      const detail = error instanceof Error ? error.message : String(error);
+      window.__kiBuddyProductBootstrapError = `Ki-Buddy product experience policy is invalid: ${detail}`;
+    }
+    return null;
+  }
+}
+
+/** Returns the installation-integrity failure captured before business UI mounts. */
+export function getKiBuddyProductBootstrapError(): string | null {
+  if (typeof window === 'undefined') return null;
+  if (!window.__kiBuddyProductBootstrapError && window.__kiBuddyProductPresentation) {
+    getKiBuddyProductRuntime();
+  }
+  return window.__kiBuddyProductBootstrapError ?? null;
+}
+
+/** Resolves the active adapter without exposing its serialized policy. */
+export function getProductExperience(): ProductExperience {
+  const productRuntime = getKiBuddyProductRuntime();
+  const bootstrapError = getKiBuddyProductBootstrapError();
+  if (bootstrapError) throw new Error(`Ki-Buddy product bootstrap failed: ${bootstrapError}`);
+  return productRuntime?.productExperience ?? AION_UI_PRODUCT_EXPERIENCE;
+}
+
+/** Thin renderer seam for product-controlled feature registration and mounting. */
+export function isProductFeatureEnabled(featureId: ProductFeatureId): boolean {
+  return getProductExperience().featureState(featureId) === 'enabled';
 }
 
 /** Resolves the authenticated Ki-Buddy runtime only when both capabilities are present. */

--- a/packages/shared-scripts/src/kiBuddyRelease.js
+++ b/packages/shared-scripts/src/kiBuddyRelease.js
@@ -13,6 +13,46 @@ const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const PACKAGE_VERSION_PATTERN =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const SHA40_PATTERN = /^[0-9a-f]{40}$/;
+const PRODUCT_FEATURE_IDS = [
+  'account',
+  'agents',
+  'appearance',
+  'assistants',
+  'channels',
+  'componentShowcase',
+  'conversation',
+  'desktopPet',
+  'extensionMarketplace',
+  'extensionRuntime',
+  'extensionSettings',
+  'guid',
+  'guidFeedback',
+  'guidGithubStar',
+  'guidWebUi',
+  'models',
+  'scheduledTasks',
+  'skills',
+  'system',
+  'team',
+  'themeCustomEditor',
+  'themeMarketplace',
+  'themePresets',
+  'tools',
+  'webUi',
+];
+const PRODUCT_RESOURCE_KINDS = ['agent', 'assistant', 'model', 'skill', 'mcp'];
+const PRODUCT_RESOURCE_ORIGINS = ['productBuiltin', 'upstreamBuiltin', 'custom', 'extension', 'unclassified'];
+const PRODUCT_FEATURE_DEPENDENCIES = [
+  ['extensionMarketplace', 'extensionRuntime'],
+  ['extensionSettings', 'extensionRuntime'],
+  ['guidFeedback', 'guid'],
+  ['guidGithubStar', 'guid'],
+  ['guidWebUi', 'guid'],
+  ['guidWebUi', 'webUi'],
+  ['themeCustomEditor', 'appearance'],
+  ['themeMarketplace', 'appearance'],
+  ['themePresets', 'appearance'],
+];
 
 function requireExactKeys(value, keys, label) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -22,6 +62,55 @@ function requireExactKeys(value, keys, label) {
   const expected = keys.toSorted();
   if (JSON.stringify(actual) !== JSON.stringify(expected)) {
     throw new Error(`${label} has unexpected or missing fields`);
+  }
+}
+
+function requireEnum(value, allowed, label) {
+  if (typeof value !== 'string' || !allowed.includes(value)) {
+    throw new Error(`${label} must be one of ${allowed.join(', ')}`);
+  }
+}
+
+function validateProductExperiencePolicy(policy) {
+  requireExactKeys(policy, ['schemaVersion', 'features', 'resources', 'behaviorDefaults'], 'Product experience policy');
+  if (policy.schemaVersion !== 1) throw new Error('Unsupported product experience policy schema');
+
+  requireExactKeys(policy.features, PRODUCT_FEATURE_IDS, 'Product experience features');
+  for (const featureId of PRODUCT_FEATURE_IDS) {
+    requireEnum(policy.features[featureId], ['enabled', 'disabled'], `Product feature ${featureId}`);
+  }
+  for (const [child, parent] of PRODUCT_FEATURE_DEPENDENCIES) {
+    if (policy.features[child] === 'enabled' && policy.features[parent] !== 'enabled') {
+      throw new Error(`Product feature ${child} requires enabled parent ${parent}`);
+    }
+  }
+
+  requireExactKeys(policy.resources, PRODUCT_RESOURCE_KINDS, 'Product experience resources');
+  for (const kind of PRODUCT_RESOURCE_KINDS) {
+    const access = policy.resources[kind];
+    requireExactKeys(access, PRODUCT_RESOURCE_ORIGINS, `Product resource ${kind}`);
+    for (const origin of PRODUCT_RESOURCE_ORIGINS) {
+      requireEnum(access[origin], ['hidden', 'use', 'manage'], `Product resource ${kind}.${origin}`);
+    }
+  }
+
+  requireExactKeys(
+    policy.behaviorDefaults,
+    ['scheduledTaskExecutor', 'autoInjectedSkillExclusions'],
+    'Product experience behavior defaults'
+  );
+  requireEnum(
+    policy.behaviorDefaults.scheduledTaskExecutor,
+    ['assistant', 'assistant-or-team'],
+    'Product scheduled task executor'
+  );
+  const exclusions = policy.behaviorDefaults.autoInjectedSkillExclusions;
+  if (
+    !Array.isArray(exclusions) ||
+    exclusions.some((item) => typeof item !== 'string' || item.trim() === '') ||
+    new Set(exclusions).size !== exclusions.length
+  ) {
+    throw new Error('Product auto-injected skill exclusions must contain unique non-empty strings');
   }
 }
 
@@ -64,6 +153,7 @@ function readProductConfig(projectRoot) {
       'schemaVersion',
       'runtimeIdentity',
       'defaults',
+      'experience',
       'locale',
       'themes',
       'runtimeDependencies',
@@ -77,7 +167,7 @@ function readProductConfig(projectRoot) {
     ],
     'Ki-Buddy product configuration'
   );
-  if (config.schemaVersion !== 2) throw new Error('Unsupported Ki-Buddy product configuration schema');
+  if (config.schemaVersion !== 3) throw new Error('Unsupported Ki-Buddy product configuration schema');
   if (typeof config.runtimeIdentity !== 'string' || config.runtimeIdentity.trim() === '') {
     throw new Error('Ki-Buddy runtime identity must be a non-empty string');
   }
@@ -94,6 +184,7 @@ function readProductConfig(projectRoot) {
   if (typeof config.defaults.language !== 'string' || config.defaults.language.trim() === '') {
     throw new Error('Ki-Buddy default language must be a non-empty string');
   }
+  validateProductExperiencePolicy(config.experience);
   requireExactKeys(config.locale, ['namespace'], 'Ki-Buddy locale');
   if (typeof config.locale.namespace !== 'string' || config.locale.namespace.trim() === '') {
     throw new Error('Ki-Buddy locale namespace must be a non-empty string');

--- a/tests/integration/KiBuddyAuthFlow.dom.test.tsx
+++ b/tests/integration/KiBuddyAuthFlow.dom.test.tsx
@@ -56,6 +56,7 @@ vi.mock('@/renderer/hooks/system/useExtI18n', () => ({
 
 vi.mock('@renderer/pages/guid', () => ({ default: () => <div>guid-page</div> }));
 vi.mock('@renderer/pages/conversation', () => ({ default: () => <div>conversation-page</div> }));
+vi.mock('@renderer/pages/team', () => ({ default: () => <div>team-page</div> }));
 vi.mock('@/renderer/components/settings/SettingsModal/contents/AboutModalContent', () => ({
   default: () => <div>about-content</div>,
 }));
@@ -448,5 +449,34 @@ describe('Ki-Buddy Agents authentication gate', () => {
     expect(await screen.findByText('Agents User')).toBeInTheDocument();
     expect(screen.getByText('agents-user-42')).toBeInTheDocument();
     expect(screen.getByText('login.kiBuddy.onboarding.replayTitle')).toBeInTheDocument();
+  });
+
+  it('replaces an authenticated legacy Team address with Guid without mounting Team', async () => {
+    getSessionMock.mockResolvedValue({ status: 'authenticated', user: authenticatedUser });
+    window.location.hash = '#/team/legacy-team';
+
+    render(
+      <AuthProvider>
+        <PanelRoute layout={<TestLayout />} />
+      </AuthProvider>
+    );
+
+    expect(await screen.findByText('guid-page')).toBeInTheDocument();
+    expect(screen.queryByText('team-page')).not.toBeInTheDocument();
+    await waitFor(() => expect(window.location.hash).toBe('#/guid'));
+  });
+
+  it('replaces an unauthenticated legacy Team address with login', async () => {
+    window.location.hash = '#/team/legacy-team';
+
+    render(
+      <AuthProvider>
+        <PanelRoute layout={<TestLayout />} />
+      </AuthProvider>
+    );
+
+    expect(await screen.findByText('login.kiBuddy.agentsDeployment')).toBeInTheDocument();
+    expect(screen.queryByText('team-page')).not.toBeInTheDocument();
+    await waitFor(() => expect(window.location.hash).toBe('#/login'));
   });
 });

--- a/tests/integration/ProductExperienceSiderHost.dom.test.tsx
+++ b/tests/integration/ProductExperienceSiderHost.dom.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { KI_BUDDY_PRODUCT_CAPABILITY } from '@/common/platform/ki-buddy';
+
+const teamSectionRender = vi.hoisted(() => vi.fn());
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@renderer/hooks/context/AuthContext', () => ({
+  useAuth: () => ({ logout: vi.fn(), status: 'authenticated' }),
+}));
+vi.mock('@renderer/hooks/context/LayoutContext', () => ({ useLayoutContext: () => ({ isMobile: false }) }));
+vi.mock('@renderer/hooks/context/ThemeContext', () => ({
+  useThemeContext: () => ({ theme: 'light', setTheme: vi.fn() }),
+}));
+vi.mock('@renderer/pages/conversation/Preview/context/PreviewContext', () => ({
+  usePreviewContext: () => ({ closePreview: vi.fn(), clearPreviewForScope: vi.fn() }),
+}));
+vi.mock('@renderer/utils/ui/focus', () => ({ blurActiveElement: vi.fn() }));
+vi.mock('@renderer/utils/ui/siderTooltip', () => ({
+  cleanupSiderTooltips: vi.fn(),
+  getSiderTooltipProps: () => ({}),
+}));
+vi.mock('@renderer/components/layout/Sider/SiderNav', () => ({
+  SiderAssistantEntry: () => null,
+  SiderScheduledEntry: () => null,
+  SiderSearchEntry: () => null,
+  SiderToolbar: () => null,
+}));
+vi.mock('@renderer/components/layout/Sider/SiderFooter', () => ({
+  default: () => null,
+  shouldShowAionUiSiderLogout: () => false,
+}));
+vi.mock('@renderer/pages/conversation/GroupedHistory', () => ({
+  default: ({ afterPinnedContent }: { afterPinnedContent?: React.ReactNode }) => (
+    <div data-testid='history-host'>{afterPinnedContent}</div>
+  ),
+}));
+vi.mock('@renderer/pages/settings/components/SettingsSider', () => ({ default: () => null }));
+vi.mock('@renderer/components/layout/Sider/TeamSiderSection', () => ({
+  default: () => {
+    teamSectionRender();
+    return <div>team-navigation</div>;
+  },
+}));
+
+import Sider from '@/renderer/components/layout/Sider';
+
+describe('Product experience Sider host', () => {
+  beforeEach(() => {
+    teamSectionRender.mockClear();
+    window.__kiBuddyProductBootstrapError = null;
+    window.__kiBuddyProductPresentation = null;
+  });
+
+  it('does not mount Team navigation or its subscriptions in Ki-Buddy', async () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+
+    render(
+      <MemoryRouter initialEntries={['/guid']}>
+        <Sider />
+      </MemoryRouter>
+    );
+
+    await screen.findByTestId('history-host');
+    expect(screen.queryByText('team-navigation')).not.toBeInTheDocument();
+    expect(teamSectionRender).not.toHaveBeenCalled();
+  });
+
+  it('keeps Team navigation mounted for the AionUi adapter', async () => {
+    render(
+      <MemoryRouter initialEntries={['/guid']}>
+        <Sider />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('team-navigation')).toBeInTheDocument();
+    await waitFor(() => expect(teamSectionRender).toHaveBeenCalledOnce());
+  });
+});

--- a/tests/unit/assets/kiBuddyRelease.test.ts
+++ b/tests/unit/assets/kiBuddyRelease.test.ts
@@ -56,13 +56,45 @@ describe('Ki-Buddy product release identity', () => {
 
   it('keeps the Ki-Buddy defaults in the product configuration', () => {
     const config = readProductConfig(projectRoot);
+    expect(config.schemaVersion).toBe(3);
     expect(config.defaults).toEqual({
       agentsBaseUrl: 'https://ksapi.kingsware.cn',
       language: 'zh-CN',
     });
+    expect(config.experience.features.team).toBe('disabled');
+    expect(config.experience.behaviorDefaults.scheduledTaskExecutor).toBe('assistant');
     expect(config.brand.cliName).toBe('Ki CLI');
     expect(config.locale).toEqual({ namespace: 'kiBuddy' });
     expect(config.themes).toEqual({ light: 'ki-buddy-light', dark: 'ki-buddy-dark' });
+  });
+
+  it('rejects incomplete or invalid product experience policy at the build boundary', () => {
+    const source = JSON.parse(readFileSync(join(projectRoot, 'ki-buddy-product.json'), 'utf8'));
+    for (const mutate of [
+      (config: typeof source) => {
+        delete config.experience.features.team;
+      },
+      (config: typeof source) => {
+        config.experience.features.team = 'preview';
+      },
+      (config: typeof source) => {
+        config.experience.resources.skill.unexpected = 'manage';
+      },
+      (config: typeof source) => {
+        config.experience.features.guid = 'disabled';
+        config.experience.features.guidFeedback = 'enabled';
+      },
+    ]) {
+      const tempDir = mkdtempSync(join(tmpdir(), 'ki-buddy-product-config-'));
+      try {
+        const config = structuredClone(source);
+        mutate(config);
+        writeFileSync(join(tempDir, 'ki-buddy-product.json'), JSON.stringify(config));
+        expect(() => readProductConfig(tempDir)).toThrow();
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    }
   });
 
   it('declares existing independent platform and renderer brand resources', () => {

--- a/tests/unit/bootstrap/recoverCorruptedDatabasePreload.test.ts
+++ b/tests/unit/bootstrap/recoverCorruptedDatabasePreload.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { KI_BUDDY_PRODUCT_BOOTSTRAP_CHANNEL, KI_BUDDY_PRODUCT_CAPABILITY } from '@/common/platform/ki-buddy';
+import type { KiBuddyProductBootstrap } from '@/common/types/platform/kiBuddyProduct';
 
 vi.mock('@sentry/electron/preload', () => ({}));
 
@@ -6,10 +8,15 @@ const invoke = vi.fn();
 const send = vi.fn();
 const on = vi.fn();
 const off = vi.fn();
-let productRuntime: string | null = null;
 let productCsrfToken: string | null = null;
+let productBootstrap: KiBuddyProductBootstrap = {
+  status: 'absent',
+  productIdentity: null,
+  capability: null,
+  error: null,
+};
 const sendSync = vi.fn((channel: string) => {
-  if (channel === 'get-product-runtime-identity') return productRuntime;
+  if (channel === KI_BUDDY_PRODUCT_BOOTSTRAP_CHANNEL) return productBootstrap;
   if (channel === 'ki-buddy:core-transport:get-csrf-token') return productCsrfToken;
   if (channel === 'get-backend-port') return 25808;
   if (channel === 'get-initial-language') return null;
@@ -40,8 +47,8 @@ describe('recover corrupted database preload bridge', () => {
     vi.resetModules();
     vi.clearAllMocks();
     invoke.mockResolvedValue(undefined);
-    productRuntime = null;
     productCsrfToken = null;
+    productBootstrap = { status: 'absent', productIdentity: null, capability: null, error: null };
   });
 
   it('exposes a recovery method that invokes the main-process IPC channel', async () => {
@@ -56,8 +63,13 @@ describe('recover corrupted database preload bridge', () => {
   });
 
   it('exposes Ki-Buddy authentication only through the dedicated IPC channels', async () => {
-    productRuntime = 'ki-buddy';
     productCsrfToken = 'core-csrf-token';
+    productBootstrap = {
+      status: 'ready',
+      productIdentity: 'ki-buddy',
+      capability: KI_BUDDY_PRODUCT_CAPABILITY!,
+      error: null,
+    };
     await import('@/preload/main');
 
     const electronApiCall = exposeInMainWorld.mock.calls.find(([key]) => key === 'electronAPI');
@@ -93,10 +105,41 @@ describe('recover corrupted database preload bridge', () => {
     expect(invalidated).toHaveBeenCalledOnce();
     expect(off).toHaveBeenCalledWith('ki-buddy-auth:session-invalidated', subscription?.[1]);
     expect(electronApi?.kiBuddyCoreTransport).toEqual({ csrfToken: 'core-csrf-token' });
-    const productPresentationCall = exposeInMainWorld.mock.calls.find(
-      ([key]) => key === '__getKiBuddyProductPresentation'
-    );
-    expect(productPresentationCall?.[1]()).toMatchObject({ id: 'ki-buddy', schemaVersion: 2 });
+    const productBootstrapCall = exposeInMainWorld.mock.calls.find(([key]) => key === '__getKiBuddyProductBootstrap');
+    expect(productBootstrapCall?.[1]()).toMatchObject({
+      status: 'ready',
+      productIdentity: 'ki-buddy',
+      capability: {
+        id: 'ki-buddy',
+        schemaVersion: 3,
+        experience: { features: { team: 'disabled', scheduledTasks: 'enabled' } },
+      },
+    });
+  });
+
+  it('exposes a recognized Ki-Buddy configuration failure without auth or AionUi capability fallback', async () => {
+    productBootstrap = {
+      status: 'invalid',
+      productIdentity: 'ki-buddy',
+      capability: null,
+      error: 'Ki-Buddy product configuration is invalid: missing team',
+    };
+    await import('@/preload/main');
+
+    const electronApiCall = exposeInMainWorld.mock.calls.find(([key]) => key === 'electronAPI');
+    const electronApi = electronApiCall?.[1] as { kiBuddyAuth?: unknown } | undefined;
+    const productBootstrapCall = exposeInMainWorld.mock.calls.find(([key]) => key === '__getKiBuddyProductBootstrap');
+
+    expect(electronApi?.kiBuddyAuth).toBeUndefined();
+    expect(productBootstrapCall?.[1]()).toMatchObject({
+      status: 'invalid',
+      error: expect.stringContaining('missing team'),
+    });
+    expect(sendSync).not.toHaveBeenCalledWith('ki-buddy:core-transport:get-csrf-token');
+    expect(sendSync).not.toHaveBeenCalledWith('get-backend-port');
+    expect(sendSync).not.toHaveBeenCalledWith('get-initial-language');
+    expect(sendSync).not.toHaveBeenCalledWith('get-backend-startup-failed');
+    expect(sendSync).not.toHaveBeenCalledWith('get-backend-startup-failure');
   });
 
   it('does not expose Ki-Buddy authentication in the ordinary AionUi desktop runtime', async () => {
@@ -107,10 +150,13 @@ describe('recover corrupted database preload bridge', () => {
 
     expect(electronApi?.kiBuddyAuth).toBeUndefined();
     expect(electronApi?.kiBuddyCoreTransport).toBeUndefined();
-    const productPresentationCall = exposeInMainWorld.mock.calls.find(
-      ([key]) => key === '__getKiBuddyProductPresentation'
-    );
-    expect(productPresentationCall?.[1]()).toBeNull();
+    const productBootstrapCall = exposeInMainWorld.mock.calls.find(([key]) => key === '__getKiBuddyProductBootstrap');
+    expect(productBootstrapCall?.[1]()).toEqual({
+      status: 'absent',
+      productIdentity: null,
+      capability: null,
+      error: null,
+    });
     expect(sendSync).not.toHaveBeenCalledWith('ki-buddy:core-transport:get-csrf-token');
   });
 });

--- a/tests/unit/common-platform/kiBuddyProductConfig.test.ts
+++ b/tests/unit/common-platform/kiBuddyProductConfig.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { KI_BUDDY_DEFAULT_AGENTS_BASE_URL, parseKiBuddyProductConfig } from '@/common/platform/ki-buddy';
+import {
+  KI_BUDDY_DEFAULT_AGENTS_BASE_URL,
+  loadKiBuddyProductConfig,
+  parseKiBuddyProductConfig,
+} from '@/common/platform/ki-buddy';
 
 const validConfig = {
-  schemaVersion: 2,
+  schemaVersion: 3,
   runtimeIdentity: 'ki-buddy',
   defaults: { agentsBaseUrl: 'https://agents.example.com', language: 'zh-CN' },
   electronBuilder: {
@@ -39,6 +43,77 @@ const validConfig = {
     packaged: { icon: 'ki-buddy/app.png' },
     renderer: { logo: 'ki-buddy-app', mascot: 'ki-buddy-mascot' },
   },
+  experience: {
+    schemaVersion: 1,
+    features: {
+      account: 'enabled',
+      agents: 'enabled',
+      appearance: 'enabled',
+      assistants: 'enabled',
+      channels: 'disabled',
+      componentShowcase: 'disabled',
+      conversation: 'enabled',
+      desktopPet: 'disabled',
+      extensionMarketplace: 'disabled',
+      extensionRuntime: 'disabled',
+      extensionSettings: 'disabled',
+      guid: 'enabled',
+      guidFeedback: 'disabled',
+      guidGithubStar: 'disabled',
+      guidWebUi: 'disabled',
+      models: 'enabled',
+      scheduledTasks: 'enabled',
+      skills: 'enabled',
+      system: 'enabled',
+      team: 'disabled',
+      themeCustomEditor: 'disabled',
+      themeMarketplace: 'disabled',
+      themePresets: 'disabled',
+      tools: 'enabled',
+      webUi: 'disabled',
+    },
+    resources: {
+      agent: {
+        productBuiltin: 'use',
+        upstreamBuiltin: 'hidden',
+        custom: 'manage',
+        extension: 'hidden',
+        unclassified: 'hidden',
+      },
+      assistant: {
+        productBuiltin: 'use',
+        upstreamBuiltin: 'hidden',
+        custom: 'manage',
+        extension: 'hidden',
+        unclassified: 'hidden',
+      },
+      model: {
+        productBuiltin: 'manage',
+        upstreamBuiltin: 'manage',
+        custom: 'manage',
+        extension: 'hidden',
+        unclassified: 'hidden',
+      },
+      skill: {
+        productBuiltin: 'use',
+        upstreamBuiltin: 'hidden',
+        custom: 'manage',
+        extension: 'hidden',
+        unclassified: 'hidden',
+      },
+      mcp: {
+        productBuiltin: 'use',
+        upstreamBuiltin: 'hidden',
+        custom: 'manage',
+        extension: 'hidden',
+        unclassified: 'hidden',
+      },
+    },
+    behaviorDefaults: {
+      scheduledTaskExecutor: 'assistant',
+      autoInjectedSkillExclusions: ['aionui-config'],
+    },
+  },
 } as const;
 
 describe('Ki-Buddy product configuration', () => {
@@ -72,7 +147,7 @@ describe('Ki-Buddy product configuration', () => {
 
   it('exposes the validated brand and assets', () => {
     expect(parseKiBuddyProductConfig(validConfig)).toMatchObject({
-      schemaVersion: 2,
+      schemaVersion: 3,
       brand: {
         productName: 'Ki-Buddy',
         cliName: 'Ki CLI',
@@ -85,11 +160,47 @@ describe('Ki-Buddy product configuration', () => {
       electronBuilder: { appId: 'com.xlihub.ki-buddy', protocolScheme: 'ki-buddy' },
       locale: { namespace: 'kiBuddy' },
       themes: { light: 'ki-buddy-light', dark: 'ki-buddy-dark' },
+      experience: {
+        schemaVersion: 1,
+        features: { team: 'disabled', scheduledTasks: 'enabled' },
+      },
     });
+  });
+
+  it('deeply freezes the validated product configuration', () => {
+    const config = parseKiBuddyProductConfig(validConfig);
+
+    expect(Object.isFrozen(config)).toBe(true);
+    expect(Object.isFrozen(config.brand)).toBe(true);
+    expect(Object.isFrozen(config.brand.links)).toBe(true);
+    expect(Object.isFrozen(config.assets.renderer)).toBe(true);
+    expect(Object.isFrozen(config.experience.resources.assistant)).toBe(true);
   });
 
   it('rejects unknown runtime product fields', () => {
     expect(() => parseKiBuddyProductConfig({ ...validConfig, unexpected: true })).toThrow('unexpected unexpected');
+  });
+
+  it('rejects schema v2 instead of migrating the product policy at runtime', () => {
+    expect(() => parseKiBuddyProductConfig({ ...validConfig, schemaVersion: 2 })).toThrow('schema');
+  });
+
+  it('rejects a runtime identity that conflicts with the Ki-Buddy package marker', () => {
+    expect(() => parseKiBuddyProductConfig({ ...validConfig, runtimeIdentity: 'other-product' })).toThrow(
+      'runtime identity'
+    );
+  });
+
+  it('captures packaged policy errors so startup can show installation integrity', () => {
+    const result = loadKiBuddyProductConfig({
+      ...validConfig,
+      experience: { ...validConfig.experience, features: { team: 'disabled' } },
+    });
+
+    expect(result).toEqual({
+      config: null,
+      error: expect.stringContaining('missing'),
+    });
   });
 
   it('rejects missing theme resources at startup', () => {

--- a/tests/unit/common-platform/productCapability.test.ts
+++ b/tests/unit/common-platform/productCapability.test.ts
@@ -4,10 +4,14 @@ import { KI_BUDDY_PRODUCT_CAPABILITY } from '@/common/platform/ki-buddy/productC
 it('builds the renderer capability from the validated product configuration', () => {
   expect(KI_BUDDY_PRODUCT_CAPABILITY).toMatchObject({
     id: 'ki-buddy',
-    schemaVersion: 2,
+    schemaVersion: 3,
     brand: { productName: 'Ki-Buddy', cliName: 'Ki CLI' },
     assets: { logo: 'ki-buddy-app', mascot: 'ki-buddy-mascot' },
     locale: { namespace: 'kiBuddy' },
     themes: { light: 'ki-buddy-light', dark: 'ki-buddy-dark' },
+    experience: {
+      schemaVersion: 1,
+      features: { team: 'disabled', scheduledTasks: 'enabled' },
+    },
   });
 });

--- a/tests/unit/common-platform/productExperience.test.ts
+++ b/tests/unit/common-platform/productExperience.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createAionUiProductExperience,
+  createKiBuddyProductExperience,
+  parseProductExperiencePolicy,
+} from '@/common/platform/ki-buddy/productExperience';
+
+const validPolicy = {
+  schemaVersion: 1,
+  features: {
+    account: 'enabled',
+    agents: 'enabled',
+    appearance: 'enabled',
+    assistants: 'enabled',
+    channels: 'disabled',
+    componentShowcase: 'disabled',
+    conversation: 'enabled',
+    desktopPet: 'disabled',
+    extensionMarketplace: 'disabled',
+    extensionRuntime: 'disabled',
+    extensionSettings: 'disabled',
+    guid: 'enabled',
+    guidFeedback: 'disabled',
+    guidGithubStar: 'disabled',
+    guidWebUi: 'disabled',
+    models: 'enabled',
+    scheduledTasks: 'enabled',
+    skills: 'enabled',
+    system: 'enabled',
+    team: 'disabled',
+    themeCustomEditor: 'disabled',
+    themeMarketplace: 'disabled',
+    themePresets: 'disabled',
+    tools: 'enabled',
+    webUi: 'disabled',
+  },
+  resources: {
+    agent: {
+      productBuiltin: 'use',
+      upstreamBuiltin: 'hidden',
+      custom: 'manage',
+      extension: 'hidden',
+      unclassified: 'hidden',
+    },
+    assistant: {
+      productBuiltin: 'use',
+      upstreamBuiltin: 'hidden',
+      custom: 'manage',
+      extension: 'hidden',
+      unclassified: 'hidden',
+    },
+    model: {
+      productBuiltin: 'manage',
+      upstreamBuiltin: 'manage',
+      custom: 'manage',
+      extension: 'hidden',
+      unclassified: 'hidden',
+    },
+    skill: {
+      productBuiltin: 'use',
+      upstreamBuiltin: 'hidden',
+      custom: 'manage',
+      extension: 'hidden',
+      unclassified: 'hidden',
+    },
+    mcp: {
+      productBuiltin: 'use',
+      upstreamBuiltin: 'hidden',
+      custom: 'manage',
+      extension: 'hidden',
+      unclassified: 'hidden',
+    },
+  },
+  behaviorDefaults: {
+    scheduledTaskExecutor: 'assistant',
+    autoInjectedSkillExclusions: ['aionui-config'],
+  },
+} as const;
+
+describe('ProductExperience interface', () => {
+  it('keeps the complete AionUi feature and resource behavior when no product capability exists', () => {
+    const experience = createAionUiProductExperience();
+
+    expect(experience.featureState('team')).toBe('enabled');
+    expect(experience.resourceAccess('assistant', 'upstreamBuiltin')).toBe('manage');
+    expect(experience.behaviorDefaults()).toEqual({
+      scheduledTaskExecutor: 'assistant-or-team',
+      autoInjectedSkillExclusions: [],
+    });
+  });
+
+  it('provides feature, resource, and behavior decisions without exposing the product JSON', () => {
+    const experience = createKiBuddyProductExperience(validPolicy);
+
+    expect(experience.featureState('team')).toBe('disabled');
+    expect(experience.featureState('scheduledTasks')).toBe('enabled');
+    expect(experience.resourceAccess('assistant', 'productBuiltin')).toBe('use');
+    expect(experience.resourceAccess('assistant', 'custom')).toBe('manage');
+    expect(experience.behaviorDefaults()).toEqual({
+      scheduledTaskExecutor: 'assistant',
+      autoInjectedSkillExclusions: ['aionui-config'],
+    });
+    expect(experience).not.toHaveProperty('features');
+    expect(experience).not.toHaveProperty('resources');
+  });
+
+  it('returns a deeply immutable serializable snapshot', () => {
+    const snapshot = parseProductExperiencePolicy(validPolicy);
+
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.features)).toBe(true);
+    expect(Object.isFrozen(snapshot.resources.assistant)).toBe(true);
+    expect(Object.isFrozen(snapshot.behaviorDefaults.autoInjectedSkillExclusions)).toBe(true);
+    expect(JSON.parse(JSON.stringify(snapshot))).toEqual(validPolicy);
+  });
+
+  it.each([
+    {
+      name: 'missing feature',
+      policy: {
+        ...validPolicy,
+        features: Object.fromEntries(Object.entries(validPolicy.features).filter(([id]) => id !== 'team')),
+      },
+    },
+    {
+      name: 'unknown feature',
+      policy: { ...validPolicy, features: { ...validPolicy.features, secretFeature: 'enabled' } },
+    },
+    {
+      name: 'unknown feature state',
+      policy: { ...validPolicy, features: { ...validPolicy.features, team: 'preview' } },
+    },
+    {
+      name: 'unknown resource field',
+      policy: {
+        ...validPolicy,
+        resources: {
+          ...validPolicy.resources,
+          assistant: { ...validPolicy.resources.assistant, remote: 'use' },
+        },
+      },
+    },
+    {
+      name: 'unknown resource state',
+      policy: {
+        ...validPolicy,
+        resources: {
+          ...validPolicy.resources,
+          assistant: { ...validPolicy.resources.assistant, custom: 'read' },
+        },
+      },
+    },
+    {
+      name: 'unknown policy field',
+      policy: { ...validPolicy, rollout: 'remote' },
+    },
+  ])('rejects an incomplete or unknown $name', ({ policy }) => {
+    expect(() => parseProductExperiencePolicy(policy)).toThrow();
+  });
+
+  it('rejects enabled child features when their parent feature is disabled', () => {
+    expect(() =>
+      parseProductExperiencePolicy({
+        ...validPolicy,
+        features: {
+          ...validPolicy.features,
+          extensionRuntime: 'disabled',
+          extensionMarketplace: 'enabled',
+        },
+      })
+    ).toThrow('extensionMarketplace');
+  });
+});

--- a/tests/unit/process/ki-buddy/runtimeFacade.test.ts
+++ b/tests/unit/process/ki-buddy/runtimeFacade.test.ts
@@ -16,12 +16,20 @@ vi.mock('@/common/adapter/httpBridge', () => ({
 }));
 vi.mock('electron', () => ({
   app: { getPath: vi.fn() },
+  BrowserWindow: vi.fn(),
   ipcMain: { handle: vi.fn() },
   session: { defaultSession: { cookies: { remove: vi.fn(), set: vi.fn() } } },
 }));
 
-const { createKiBuddyRuntime } = await import('@/process/ki-buddy');
-const { KI_BUDDY_PRODUCT_CONFIG } = await import('@/common/platform/ki-buddy');
+const {
+  createKiBuddyProductBootstrap,
+  createKiBuddyProductIntegrityWindow,
+  createKiBuddyRuntime,
+  shouldStartProductBusinessLifecycle,
+  startProductFeatureLifecycles,
+} = await import('@/process/ki-buddy');
+const { BrowserWindow } = await import('electron');
+const { KI_BUDDY_PRODUCT_CONFIG_RESULT, createAionUiProductExperience } = await import('@/common/platform/ki-buddy');
 const { KiBuddyGitHubProvider } = await import('@/process/ki-buddy/update/githubUpdateProvider');
 
 function createAppPath(productRuntime?: string): string {
@@ -35,6 +43,7 @@ describe('Ki-Buddy main-process runtime facade', () => {
 
   afterEach(() => {
     installTransportMock.mockReset();
+    vi.mocked(BrowserWindow).mockReset();
     for (const appPath of appPaths.splice(0)) rmSync(appPath, { recursive: true, force: true });
   });
 
@@ -42,7 +51,12 @@ describe('Ki-Buddy main-process runtime facade', () => {
     const appPath = createAppPath();
     appPaths.push(appPath);
 
-    expect(createKiBuddyRuntime({ appPath, resetPassword: false, webUi: false })).toBeNull();
+    expect(createKiBuddyRuntime({ appPath, resetPassword: false, webUi: false })).toEqual({
+      status: 'absent',
+      productIdentity: null,
+      runtime: null,
+      error: null,
+    });
     expect(installTransportMock).not.toHaveBeenCalled();
   });
 
@@ -50,22 +64,37 @@ describe('Ki-Buddy main-process runtime facade', () => {
     const appPath = createAppPath('ki-buddy');
     appPaths.push(appPath);
 
-    const runtime = createKiBuddyRuntime({ appPath, resetPassword: false, webUi: false });
+    const selection = createKiBuddyRuntime({ appPath, resetPassword: false, webUi: false });
+    const runtime = selection.runtime!;
+    const bootstrap = createKiBuddyProductBootstrap(selection);
+    expect(selection.status).toBe('ready');
+    expect(bootstrap).toMatchObject({
+      status: 'ready',
+      productIdentity: 'ki-buddy',
+      capability: { experience: { features: { team: 'disabled' } } },
+      error: null,
+    });
     expect(runtime).toMatchObject({
       brand: {
         productName: 'Ki-Buddy',
       },
       productIdentity: 'ki-buddy',
     });
-    expect(runtime?.brand.iconPath).toBe(KI_BUDDY_PRODUCT_CONFIG.assets.packaged.icon);
-    expect(runtime?.updateBridge).toEqual({
+    expect(runtime.brand.iconPath).toBe(KI_BUDDY_PRODUCT_CONFIG_RESULT.config?.assets.packaged.icon);
+    expect(runtime.productCapability.experience).toBe(KI_BUDDY_PRODUCT_CONFIG_RESULT.config?.experience);
+    expect(Object.isFrozen(bootstrap)).toBe(true);
+    expect(Object.isFrozen(bootstrap.capability?.brand)).toBe(true);
+    expect(Object.isFrozen(bootstrap.capability?.brand.links)).toBe(true);
+    expect(Object.isFrozen(bootstrap.capability?.experience.resources.assistant)).toBe(true);
+    expect(runtime.productExperience.featureState('team')).toBe('disabled');
+    expect(runtime.updateBridge).toEqual({
       allowRepositoryOverride: false,
       repository: 'xlihub/Ki-Buddy',
       source: 'github',
       tagPrefix: 'ki-buddy-v',
       userAgent: 'Ki-Buddy',
     });
-    expect(runtime?.updateFeed).toEqual({
+    expect(runtime.updateFeed).toEqual({
       feedOptions: {
         owner: 'xlihub',
         provider: 'custom',
@@ -77,5 +106,116 @@ describe('Ki-Buddy main-process runtime facade', () => {
       updaterCacheDirName: 'com.xlihub.ki-buddy',
     });
     expect(installTransportMock).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a recognized Ki-Buddy runtime invalid without starting product side effects', () => {
+    const appPath = createAppPath('ki-buddy');
+    appPaths.push(appPath);
+
+    const selection = createKiBuddyRuntime(
+      { appPath, resetPassword: false, webUi: false },
+      { config: null, error: 'Product experience features has invalid fields: missing team' }
+    );
+
+    expect(selection).toEqual({
+      status: 'invalid',
+      productIdentity: 'ki-buddy',
+      runtime: null,
+      error: expect.stringContaining('missing team'),
+    });
+    const bootstrap = createKiBuddyProductBootstrap(selection);
+    expect(Object.isFrozen(bootstrap)).toBe(true);
+    expect(bootstrap).toMatchObject({
+      status: 'invalid',
+      capability: null,
+      error: expect.stringContaining('missing team'),
+    });
+    expect(shouldStartProductBusinessLifecycle(selection)).toBe(false);
+    expect(installTransportMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { mode: 'WebUI', resetPassword: false, webUi: true },
+    { mode: 'password reset', resetPassword: true, webUi: false },
+  ])('keeps invalid Ki-Buddy configuration isolated in $mode mode', ({ resetPassword, webUi }) => {
+    const appPath = createAppPath('ki-buddy');
+    appPaths.push(appPath);
+
+    const selection = createKiBuddyRuntime(
+      { appPath, resetPassword, webUi },
+      { config: null, error: 'Product runtime identity is invalid' }
+    );
+
+    expect(selection.status).toBe('invalid');
+    expect(createKiBuddyProductBootstrap(selection).status).toBe('invalid');
+    expect(shouldStartProductBusinessLifecycle(selection)).toBe(false);
+  });
+
+  it('starts the business lifecycle for valid Ki-Buddy and ordinary AionUi selections', () => {
+    const kiBuddyAppPath = createAppPath('ki-buddy');
+    const aionUiAppPath = createAppPath();
+    appPaths.push(kiBuddyAppPath, aionUiAppPath);
+
+    expect(
+      shouldStartProductBusinessLifecycle(
+        createKiBuddyRuntime({ appPath: kiBuddyAppPath, resetPassword: false, webUi: false })
+      )
+    ).toBe(true);
+    expect(
+      shouldStartProductBusinessLifecycle(
+        createKiBuddyRuntime({ appPath: aionUiAppPath, resetPassword: false, webUi: false })
+      )
+    ).toBe(true);
+  });
+
+  it('creates the product-owned integrity window without initializing a business host', () => {
+    const integrityWindow = {
+      isDestroyed: vi.fn(() => false),
+      loadFile: vi.fn(() => Promise.resolve()),
+      loadURL: vi.fn(() => Promise.resolve()),
+      once: vi.fn((_event: string, listener: () => void) => listener()),
+      show: vi.fn(),
+    };
+    vi.mocked(BrowserWindow).mockImplementation(function BrowserWindowMock() {
+      return integrityWindow as never;
+    });
+
+    const window = createKiBuddyProductIntegrityWindow({
+      isPackaged: true,
+      preloadPath: '/app/preload.js',
+      rendererFile: '/app/renderer/index.html',
+    });
+
+    expect(window).toBe(integrityWindow);
+    expect(BrowserWindow).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Ki-Buddy', webPreferences: { preload: '/app/preload.js' } })
+    );
+    expect(integrityWindow.loadFile).toHaveBeenCalledWith('/app/renderer/index.html');
+    expect(integrityWindow.loadURL).not.toHaveBeenCalled();
+    expect(integrityWindow.show).toHaveBeenCalledOnce();
+  });
+
+  it('skips disabled Team main lifecycles while retaining enabled Ki-Buddy lifecycles', () => {
+    const appPath = createAppPath('ki-buddy');
+    appPaths.push(appPath);
+    const runtime = createKiBuddyRuntime({ appPath, resetPassword: false, webUi: false }).runtime!;
+    const startTeam = vi.fn();
+    const startScheduledTasks = vi.fn();
+
+    runtime.startFeatureLifecycles([
+      { featureId: 'team', start: startTeam },
+      { featureId: 'scheduledTasks', start: startScheduledTasks },
+    ]);
+
+    expect(startTeam).not.toHaveBeenCalled();
+    expect(startScheduledTasks).toHaveBeenCalledOnce();
+  });
+
+  it('retains existing Team main lifecycles for the AionUi adapter', () => {
+    const startTeam = vi.fn();
+
+    startProductFeatureLifecycles(createAionUiProductExperience(), [{ featureId: 'team', start: startTeam }]);
+
+    expect(startTeam).toHaveBeenCalledOnce();
   });
 });

--- a/tests/unit/process/ki-buddy/runtimeIdentity.test.ts
+++ b/tests/unit/process/ki-buddy/runtimeIdentity.test.ts
@@ -45,6 +45,7 @@ describe('Ki-Buddy product runtime identity', () => {
       );
 
       expect(resolveKiBuddyProtocolScheme(productAppPath)).toBe('ki-buddy');
+      expect(resolveKiBuddyProtocolScheme(productAppPath, { config: null, error: 'missing team' })).toBeNull();
       expect(resolveKiBuddyProtocolScheme(resolve(productAppPath, 'missing'))).toBeNull();
     } finally {
       rmSync(productAppPath, { recursive: true });

--- a/tests/unit/process/ki-buddy/update/updateFeed.test.ts
+++ b/tests/unit/process/ki-buddy/update/updateFeed.test.ts
@@ -4,10 +4,13 @@ import {
   createKiBuddyUpdateBridgeConfiguration,
   createKiBuddyUpdateFeedConfiguration,
 } from '@/process/ki-buddy/update/updateFeed';
+import { KI_BUDDY_PRODUCT_CONFIG_RESULT } from '@/common/platform/ki-buddy';
+
+const productConfig = KI_BUDDY_PRODUCT_CONFIG_RESULT.config!;
 
 describe('Ki-Buddy update feed', () => {
   it('uses the product-owned custom provider and tag namespace', () => {
-    expect(createKiBuddyUpdateFeedConfiguration()).toEqual({
+    expect(createKiBuddyUpdateFeedConfiguration(productConfig)).toEqual({
       feedOptions: {
         owner: 'xlihub',
         provider: 'custom',
@@ -21,7 +24,7 @@ describe('Ki-Buddy update feed', () => {
   });
 
   it('uses the same product tag namespace for manual checks', () => {
-    expect(createKiBuddyUpdateBridgeConfiguration()).toMatchObject({
+    expect(createKiBuddyUpdateBridgeConfiguration(productConfig)).toMatchObject({
       allowRepositoryOverride: false,
       repository: 'xlihub/Ki-Buddy',
       tagPrefix: 'ki-buddy-v',

--- a/tests/unit/process/notificationBridge.test.ts
+++ b/tests/unit/process/notificationBridge.test.ts
@@ -115,6 +115,16 @@ describe('showNotification', () => {
     expect(FakeElectronNotification.instances).toHaveLength(0);
   });
 
+  it('does not use the AionUi notification path when product configuration is invalid', async () => {
+    configureNotificationBrandIcon(null);
+    setNotificationMainWindow(makeWindow(false) as never);
+
+    await showNotification({ title: 'Configuration error', body: 'invalid product configuration' });
+
+    expect(FakeElectronNotification.instances).toHaveLength(0);
+    expect(platformSend).not.toHaveBeenCalled();
+  });
+
   it('focuses the window and emits notification.clicked on click', async () => {
     const win = makeWindow(false);
     setNotificationMainWindow(win as never);

--- a/tests/unit/renderer/cron/CreateTaskDialog.dom.test.tsx
+++ b/tests/unit/renderer/cron/CreateTaskDialog.dom.test.tsx
@@ -11,6 +11,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Assistant } from '@/common/types/agent/assistantTypes';
 import type { ICronJob } from '@/common/adapter/ipcBridge';
 import type { TChatConversation } from '@/common/config/storage';
+import { KI_BUDDY_PRODUCT_CAPABILITY } from '@/common/platform/ki-buddy';
 
 let currentAssistants: Assistant[] = [];
 
@@ -145,6 +146,8 @@ describe('CreateTaskDialog', () => {
     vi.mocked(ipcBridge.cron.updateJob.invoke).mockResolvedValue(job());
     vi.mocked(ipcBridge.cron.createJob.invoke).mockResolvedValue(job());
     vi.mocked(ipcBridge.conversation.get.invoke).mockRejectedValue(new Error('not found'));
+    window.__kiBuddyProductBootstrapError = null;
+    window.__kiBuddyProductPresentation = null;
   });
 
   it('does not render the task description field', async () => {
@@ -314,6 +317,16 @@ describe('CreateTaskDialog', () => {
         extra: {},
       });
     });
+  });
+
+  it('uses the Ki-Buddy assistant-only default without resolving Team task ownership', async () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+
+    render(<CreateTaskDialog visible onClose={() => {}} editJob={teamOwnedJob()} />);
+
+    await screen.findByDisplayValue('original prompt');
+    expect(ipcBridge.conversation.get.invoke).not.toHaveBeenCalled();
+    expect(screen.queryByText('cron.page.form.teamTaskExecutionModeLockedReason')).not.toBeInTheDocument();
   });
 
   it('locks execution mode and assistant when editing a team-owned task', async () => {

--- a/tests/unit/renderer/ki-buddy/KiBuddyProductIntegrityGate.dom.test.tsx
+++ b/tests/unit/renderer/ki-buddy/KiBuddyProductIntegrityGate.dom.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@/renderer/components/layout/InstallationIntegrityDialog', () => ({
+  InstallationIntegrityModalHost: ({ description }: { description: string }) => <div>{description}</div>,
+}));
+
+import KiBuddyProductIntegrityGate from '@/renderer/pages/ki-buddy/KiBuddyProductIntegrityGate';
+
+it('shows an installation-integrity error instead of AionUi business content for an invalid Ki-Buddy policy', () => {
+  render(<KiBuddyProductIntegrityGate failure='Product experience features has invalid fields: missing team' />);
+
+  expect(screen.getByText('login.kiBuddy.productExperience.invalidPolicyDescription')).toBeInTheDocument();
+  expect(screen.queryByText('AionUi business content')).not.toBeInTheDocument();
+});

--- a/tests/unit/renderer/layout/TitlebarWorkspaceToggle.dom.test.tsx
+++ b/tests/unit/renderer/layout/TitlebarWorkspaceToggle.dom.test.tsx
@@ -1,18 +1,22 @@
 import { act, render, screen } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { KI_BUDDY_PRODUCT_CAPABILITY } from '@/common/platform/ki-buddy';
 
 const platform = vi.hoisted(() => ({ desktop: true, mac: false }));
+const route = vi.hoisted(() => ({ pathname: '/conversation/test' }));
+const layout = vi.hoisted(() => ({ mobile: false }));
+const teamGet = vi.hoisted(() => vi.fn().mockResolvedValue({ name: 'Team One' }));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 vi.mock('react-router-dom', () => ({
-  useLocation: () => ({ pathname: '/conversation/test', search: '', hash: '' }),
+  useLocation: () => ({ pathname: route.pathname, search: '', hash: '' }),
   useNavigate: () => vi.fn(),
 }));
 vi.mock('@/common', () => ({
-  ipcBridge: { conversation: { get: { invoke: vi.fn() } } },
+  ipcBridge: { conversation: { get: { invoke: vi.fn() } }, team: { get: { invoke: teamGet } } },
 }));
 vi.mock('@/common/config/constants', () => ({ TEAM_MODE_ENABLED: false }));
 vi.mock('@renderer/pages/conversation/GroupedHistory/ConversationSearchPopover', () => ({ default: () => null }));
@@ -21,7 +25,7 @@ vi.mock('@/renderer/components/layout/WindowControls', () => ({
   default: () => <div data-testid='window-controls' />,
 }));
 vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
-  useLayoutContext: () => ({ isMobile: false }),
+  useLayoutContext: () => ({ isMobile: layout.mobile }),
 }));
 vi.mock('@/renderer/hooks/context/NavigationHistoryContext', () => ({
   useNavigationHistory: () => null,
@@ -44,6 +48,11 @@ describe('Titlebar workspace toggle', () => {
   beforeEach(() => {
     platform.desktop = true;
     platform.mac = false;
+    route.pathname = '/conversation/test';
+    layout.mobile = false;
+    teamGet.mockClear();
+    window.__kiBuddyProductBootstrapError = null;
+    window.__kiBuddyProductPresentation = null;
   });
 
   it('places the Windows workspace toggle directly after Bug Report', () => {
@@ -86,5 +95,24 @@ describe('Titlebar workspace toggle', () => {
 
     expect(screen.queryByRole('button', { name: 'common.expandMore' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'common.collapse' })).not.toBeInTheDocument();
+  });
+
+  it('does not read Team state from a legacy Team address in Ki-Buddy', () => {
+    route.pathname = '/team/legacy-team';
+    layout.mobile = true;
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+
+    render(<Titlebar workspaceAvailable={false} />);
+
+    expect(teamGet).not.toHaveBeenCalled();
+  });
+
+  it('keeps the AionUi mobile Team title behavior', () => {
+    route.pathname = '/team/team-1';
+    layout.mobile = true;
+
+    render(<Titlebar workspaceAvailable={false} />);
+
+    expect(teamGet).toHaveBeenCalledWith({ id: 'team-1' });
   });
 });

--- a/tests/unit/renderer/services/runtime/kiBuddyRuntime.dom.test.ts
+++ b/tests/unit/renderer/services/runtime/kiBuddyRuntime.dom.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { KI_BUDDY_PRODUCT_CAPABILITY } from '@/common/platform/ki-buddy';
 import {
+  getProductExperience,
+  getKiBuddyProductBootstrapError,
   getKiBuddyProductRuntime,
   getKiBuddyRendererRuntime,
   getKiBuddyRouteComponents,
@@ -14,6 +16,7 @@ describe('Ki-Buddy renderer runtime selection', () => {
     window.electronAPI = { ...window.electronAPI, kiBuddyAuth: undefined };
     window.__kiBuddyProductPresentation = null;
     window.__kiBuddyProductBootstrapError = null;
+    window.__getKiBuddyProductBootstrap = undefined;
   });
 
   it('keeps product routes and settings absent without the product capability', () => {
@@ -30,6 +33,7 @@ describe('Ki-Buddy renderer runtime selection', () => {
       localeNamespace: 'kiBuddy',
       themes: { light: 'ki-buddy-light', dark: 'ki-buddy-dark' },
     });
+    expect(getProductExperience().featureState('team')).toBe('disabled');
     expect(getKiBuddyRendererRuntime()).toBeNull();
   });
 
@@ -49,17 +53,33 @@ describe('Ki-Buddy renderer runtime selection', () => {
 
   it('does not access the preload capability after bootstrap', () => {
     window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
-    window.__getKiBuddyProductPresentation = vi.fn(() => {
+    window.__getKiBuddyProductBootstrap = vi.fn(() => {
       throw new Error('bootstrap bridge must not be read after the first frame');
     });
 
     expect(getKiBuddyProductRuntime()).toMatchObject({ id: 'ki-buddy' });
-    expect(window.__getKiBuddyProductPresentation).not.toHaveBeenCalled();
+    expect(window.__getKiBuddyProductBootstrap).not.toHaveBeenCalled();
   });
 
   it('fails renderer startup when the first-frame product capability is invalid', () => {
     window.__kiBuddyProductBootstrapError = 'Invalid Ki-Buddy product presentation capability';
 
-    expect(() => getKiBuddyProductRuntime()).toThrow('Ki-Buddy product bootstrap failed');
+    expect(getKiBuddyProductRuntime()).toBeNull();
+    expect(getKiBuddyProductBootstrapError()).toContain('Invalid Ki-Buddy product presentation capability');
+    expect(() => getProductExperience()).toThrow('Ki-Buddy product bootstrap failed');
+  });
+
+  it('does not fall back to AionUi when a recognized Ki-Buddy policy is incomplete', () => {
+    window.__kiBuddyProductPresentation = {
+      ...KI_BUDDY_PRODUCT_CAPABILITY,
+      experience: {
+        ...KI_BUDDY_PRODUCT_CAPABILITY.experience,
+        features: { team: 'disabled' },
+      },
+    } as unknown as typeof KI_BUDDY_PRODUCT_CAPABILITY;
+
+    expect(getKiBuddyProductRuntime()).toBeNull();
+    expect(getKiBuddyProductBootstrapError()).toContain('invalid');
+    expect(() => getProductExperience()).toThrow('Ki-Buddy product bootstrap failed');
   });
 });

--- a/tests/unit/renderer/services/runtime/productBootstrap.dom.test.ts
+++ b/tests/unit/renderer/services/runtime/productBootstrap.dom.test.ts
@@ -9,15 +9,34 @@ const rendererHtml = readFileSync(
   'utf8'
 );
 
-function renderBootstrap(options?: { capability?: typeof KI_BUDDY_PRODUCT_CAPABILITY; appearance?: 'light' | 'dark' }) {
+function renderBootstrap(options?: {
+  appearance?: 'light' | 'dark';
+  bootstrapError?: string;
+  capability?: typeof KI_BUDDY_PRODUCT_CAPABILITY;
+}) {
   return new JSDOM(rendererHtml, {
     runScripts: 'dangerously',
     url: 'https://desktop.local',
     beforeParse(window) {
       if (options?.appearance) window.localStorage.setItem('__aionui_theme', options.appearance);
-      Object.defineProperty(window, '__getKiBuddyProductPresentation', {
+      Object.defineProperty(window, '__getKiBuddyProductBootstrap', {
         configurable: true,
-        value: () => options?.capability ?? null,
+        value: () =>
+          options?.bootstrapError
+            ? {
+                status: 'invalid',
+                productIdentity: 'ki-buddy',
+                capability: null,
+                error: options.bootstrapError,
+              }
+            : options?.capability
+              ? {
+                  status: 'ready',
+                  productIdentity: 'ki-buddy',
+                  capability: options.capability,
+                  error: null,
+                }
+              : { status: 'absent', productIdentity: null, capability: null, error: null },
       });
     },
   });
@@ -53,6 +72,7 @@ describe('renderer product bootstrap', () => {
       logo: 'configured-logo',
       mascot: 'configured-mascot',
     });
+    expect(dom.window.__kiBuddyProductPresentation?.experience.features.team).toBe('disabled');
   });
 
   it('keeps the AionUi document unchanged when the product capability is absent', () => {
@@ -74,5 +94,13 @@ describe('renderer product bootstrap', () => {
     expect(dom.window.__kiBuddyProductBootstrapError).toContain('Invalid Ki-Buddy product presentation capability');
     expect(dom.window.document.documentElement).not.toHaveAttribute('data-product');
     expect(dom.window.document.title).toBe('AionUi');
+  });
+
+  it('preserves a preload configuration failure before reading a product capability', () => {
+    const dom = renderBootstrap({ bootstrapError: 'Ki-Buddy product configuration is invalid: missing team' });
+
+    expect(dom.window.__kiBuddyProductPresentation).toBeNull();
+    expect(dom.window.__kiBuddyProductBootstrapError).toContain('missing team');
+    expect(dom.window.document.documentElement).not.toHaveAttribute('data-product');
   });
 });

--- a/tests/unit/updateBridgeCdnCheck.test.ts
+++ b/tests/unit/updateBridgeCdnCheck.test.ts
@@ -110,7 +110,7 @@ const GITHUB_RELEASES = [
   },
 ];
 
-const getCheckHandler = async (configuration?: UpdateBridgeConfiguration) => {
+const getCheckHandler = async (configuration?: UpdateBridgeConfiguration | null) => {
   vi.resetModules();
   const { configureUpdateBridge, initUpdateBridge } = await import('@process/bridge/updateBridge');
   const { ipcBridge } = await import('@/common');
@@ -154,6 +154,20 @@ describe('update.check CDN-first', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it('does not select an AionUi update source when product configuration is invalid', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const handler = await getCheckHandler(null);
+
+    const res = await handler({});
+
+    expect(res).toEqual({
+      success: false,
+      msg: 'Update service is unavailable because the product configuration is invalid.',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('reports an update from the CDN manifest and attaches GitHub notes', async () => {


### PR DESCRIPTION
# Pull Request

## Description

本 PR 为 Ki-Buddy 增加随安装包发布的产品体验策略，用同一份严格、不可变的 capability snapshot 统一控制功能、资源访问和默认行为。

主要变化：

- 将 `ki-buddy-product.json` 升级为 schema v3，穷举声明 feature、resource access 和 behavior defaults。
- 提供窄接口 `ProductExperience`，分别由 Ki-Buddy adapter 和保持完整能力的 AionUi adapter 实现。
- main、preload、renderer 使用单一、深度冻结的 bootstrap snapshot，并在首个业务画面前完成产品选择。
- 已识别 Ki-Buddy 但配置缺失、损坏、版本不支持或 identity 矛盾时，仅显示安装完整性错误，不回退 AionUi，也不启动业务生命周期。
- Ki-Buddy 停用 Team 导航、直接路由、订阅和 Scheduled Tasks Team 执行者；旧 Team 地址按认证状态跳转至 `/guid` 或 `/login`。
- 保持 AionUi 原有 Team、资源管理和 Scheduled Tasks 行为。
- 更新领域术语与 ADR，记录上游接缝、同步复查要求和删除条件。

## Related Issues

- Closes #43

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors（876 条仓库既有 warning）
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 467 个测试文件、3978 个测试通过，5 个测试跳过
- [x] i18n validated（`bun run i18n:types` + `node scripts/check-i18n.js`；仅有仓库既有 warning）
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

未进行三个桌面平台的人工运行验证；已完成 TypeScript、lint、格式、i18n、全量测试和打包验证。

## Screenshots

不适用。本 PR 主要调整产品能力边界、启动完整性路径和 Team 功能可用性。

## Additional Context

- 提交顺序保持为前置领域文档/ADR，再提交功能实现。
- 修复后由两个全新 subagent 分别执行 Standards 与 Spec 最终审查，均为零 finding。
- `bun run package` 通过；仍有仓库既有大 chunk warning。
