### PR TITLE
feat(mcp): apply Ki-Buddy product resource policy

### DIFF
--- a/docs/adr/0011-control-aionui-with-product-experience-policy.md
+++ b/docs/adr/0011-control-aionui-with-product-experience-policy.md
@@ -20,7 +20,7 @@ AionUi 与 Ki-Buddy 分别提供 adapter。产品 capability 完全缺失时使�
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | `packages/desktop/src/index.ts`                                                                                                                                                                                                           | 选择产品启动状态；配置损坏时只转发到 Ki-Buddy 完整性窗口，不进入业务生命周期                                   | capability 缺失时继续执行完整 AionUi 启动、更新、Tray 和 backend 流程                            |
 | `packages/desktop/src/preload/main.ts`、`packages/desktop/src/common/types/platform/electron.ts`                                                                                                                                          | 通过单一 getter 转发不可变 bootstrap snapshot；完整性启动不读取业务 IPC                                        | AionUi preload 继续暴露原有 backend 与 renderer bridge                                           |
-| `packages/desktop/src/renderer/index.html`、`packages/desktop/src/renderer/main.tsx`、`packages/desktop/src/renderer/services/i18n/index.ts`                                                                                              | 在首个业务画面前应用产品 capability；配置损坏时只显示完整性错误并停止业务初始化                                | capability 缺失时继续使用 AionUi 标题、主题、i18n 与应用 host                                    |
+| `packages/desktop/src/renderer/index.html`、`packages/desktop/src/renderer/main.tsx`、`packages/desktop/src/renderer/services/i18n/index.ts`                                                                                              | 在首个业务画面前应用产品 capability；配置损坏时停止业务初始化；登录后目录缺少已注册产品资源时显示完整性错误    | capability 缺失时继续使用 AionUi 标题、主题、i18n 与应用 host                                    |
 | `packages/desktop/src/renderer/components/layout/Layout.tsx`、`Router.tsx`、`Sider/index.tsx`、`Titlebar/index.tsx`                                                                                                                       | 从同一 feature ID 投影 Team 入口、直接路由、订阅和 workspace 控件                                              | `ProductExperience` 的 AionUi adapter 保持 Team 入口、路由与生命周期可用                         |
 | `packages/desktop/src/renderer/hooks/mcp/catalog.ts`、`useMcpServers.ts`、`packages/desktop/src/renderer/pages/settings/ToolsSettings/`、`packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx` | 按可信 catalog 通道和后端 `product_origin` 投影 MCP 的 `hidden`、`use`、`manage`；隐藏记录只保留非敏感诊断字段 | AionUi adapter 保持全部 MCP 来源可见；extension 原有只读交互和上游 image-generation 配置保持不变 |
 | `packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx`                                                                                                                                                        | 从 behavior defaults 决定 Scheduled Tasks 是否允许 Team 执行者                                                 | AionUi adapter 继续使用 `assistant-or-team`                                                      |
@@ -32,7 +32,8 @@ AionUi 原行为由以下测试保护：
 - `tests/integration/ProductExperienceSiderHost.dom.test.tsx`：AionUi adapter 保留 Team 导航，Ki-Buddy adapter 隐藏入口。
 - `tests/unit/renderer/layout/TitlebarWorkspaceToggle.dom.test.tsx`：AionUi 保留 workspace 切换能力。
 - `tests/unit/renderer/cron/CreateTaskDialog.dom.test.tsx`：AionUi 保留 Assistant/Team 执行者，Ki-Buddy 只允许 Assistant。
-- `tests/unit/renderer/hooks/mcpCatalog.dom.test.ts`、`useMcpServers.dom.test.ts`：Ki-Buddy 只保留 Custom 与 product built-in MCP，并为上游、extension 和未知来源生成结构化隐藏记录；AionUi 保持原 catalog。
+- `tests/unit/renderer/hooks/mcpCatalog.dom.test.ts`、`useMcpServers.dom.test.ts`：Ki-Buddy 只保留 Custom 与 product built-in MCP，并为上游、extension 和未知来源生成结构化隐藏记录；未注册产品 requirement 时不读取目录，已注册 requirement 使用稳定后端 ID 验证；AionUi 保持原 catalog。
+- `tests/unit/renderer/ki-buddy/KiBuddyProductIntegrityGate.dom.test.tsx`：只在登录后的 Ki-Buddy 产品路径验证 MCP requirement；目录已就绪但缺少已注册资源时显示结构化安装完整性错误。
 - `tests/unit/feedback/McpServerHeaderFeedback.dom.test.tsx`、`tests/unit/settings/ToolsModalContentImageGuide.dom.test.tsx`：`use` 允许连接检测但不提供管理操作；AionUi 的 `manage` 操作和 image-generation 配置保持可用。
 - `tests/unit/renderer/services/runtime/productBootstrap.dom.test.ts` 与 `kiBuddyRuntime.dom.test.ts`：capability 存在、缺失和损坏时使用对应启动路径。
 
@@ -45,6 +46,8 @@ AionUi 原行为由以下测试保护：
 5. capability 存在与缺失两组回归、AionUi 原行为保护测试以及完整测试是否通过。
 
 MCP 来源由 catalog 边界决定：extension bridge 固定产生 `extension`，本地 AionUi built-in 固定产生 `upstreamBuiltin`，后端普通 MCP 缺少来源字段时按现有 canonical `builtin` 字段区分 `upstreamBuiltin` 与 `custom`。后端可以通过只读响应字段 `product_origin: productBuiltin` 接入未来受信任产品资源；MCP create、import 和 update payload 不发送该字段。未知字段值归为 `unclassified`，不能按名称、ID 前缀或 renderer 输入提升为 product built-in。
+
+MCP requirement 使用独立注册表和稳定后端资源 ID。#41 接入前注册表为空，不读取目录也不要求 Agents Adapter MCP 存在；#41 启用对应能力时登记真实资源 ID。登录后的 Ki-Buddy 在后端目录可用后执行验证：读取失败保持 `pending`，明确缺失才进入安装完整性错误。`manage` 只保留上游 AionUi 当前已经提供的管理操作，不据此增加上游尚未具备的启停入口。
 
 当 AionUi 提供正式的产品策略注册、单一 preload bootstrap、首帧 capability 注入和按 capability 管理生命周期的公开扩展点后，应将对应职责迁移到上游接口，并删除本 ADR 列出的本地上游接缝。迁移只有在 Ki-Buddy invalid/ready 与 AionUi absent 三种状态的等价测试全部通过后才能完成。
 

--- a/docs/adr/0011-control-aionui-with-product-experience-policy.md
+++ b/docs/adr/0011-control-aionui-with-product-experience-policy.md
@@ -16,14 +16,15 @@ AionUi 与 Ki-Buddy 分别提供 adapter。产品 capability 完全缺失时使�
 
 现有 AionUi 扩展点只能分别控制页面或运行模块，不能在首个业务画面前向 main、preload 和 renderer 提供同一份产品能力快照，也不能保证导航、直接路由和生命周期同时停用。因此当前版本保留以下显式接缝：
 
-| 上游文件                                                                                                                                     | 产品职责                                                                        | AionUi 原行为保护                                                        |
-| -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `packages/desktop/src/index.ts`                                                                                                              | 选择产品启动状态；配置损坏时只转发到 Ki-Buddy 完整性窗口，不进入业务生命周期    | capability 缺失时继续执行完整 AionUi 启动、更新、Tray 和 backend 流程    |
-| `packages/desktop/src/preload/main.ts`、`packages/desktop/src/common/types/platform/electron.ts`                                             | 通过单一 getter 转发不可变 bootstrap snapshot；完整性启动不读取业务 IPC         | AionUi preload 继续暴露原有 backend 与 renderer bridge                   |
-| `packages/desktop/src/renderer/index.html`、`packages/desktop/src/renderer/main.tsx`、`packages/desktop/src/renderer/services/i18n/index.ts` | 在首个业务画面前应用产品 capability；配置损坏时只显示完整性错误并停止业务初始化 | capability 缺失时继续使用 AionUi 标题、主题、i18n 与应用 host            |
-| `packages/desktop/src/renderer/components/layout/Layout.tsx`、`Router.tsx`、`Sider/index.tsx`、`Titlebar/index.tsx`                          | 从同一 feature ID 投影 Team 入口、直接路由、订阅和 workspace 控件               | `ProductExperience` 的 AionUi adapter 保持 Team 入口、路由与生命周期可用 |
-| `packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx`                                                           | 从 behavior defaults 决定 Scheduled Tasks 是否允许 Team 执行者                  | AionUi adapter 继续使用 `assistant-or-team`                              |
-| `packages/desktop/src/process/bridge/updateBridge.ts`、`notificationBridge.ts`                                                               | 注入产品更新源和通知资源；完整性失败时禁用对应业务服务                          | capability 缺失时继续使用 AionUi 更新源、User-Agent 和通知图标           |
+| 上游文件                                                                                                                                                                                                                                  | 产品职责                                                                                                       | AionUi 原行为保护                                                                                |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `packages/desktop/src/index.ts`                                                                                                                                                                                                           | 选择产品启动状态；配置损坏时只转发到 Ki-Buddy 完整性窗口，不进入业务生命周期                                   | capability 缺失时继续执行完整 AionUi 启动、更新、Tray 和 backend 流程                            |
+| `packages/desktop/src/preload/main.ts`、`packages/desktop/src/common/types/platform/electron.ts`                                                                                                                                          | 通过单一 getter 转发不可变 bootstrap snapshot；完整性启动不读取业务 IPC                                        | AionUi preload 继续暴露原有 backend 与 renderer bridge                                           |
+| `packages/desktop/src/renderer/index.html`、`packages/desktop/src/renderer/main.tsx`、`packages/desktop/src/renderer/services/i18n/index.ts`                                                                                              | 在首个业务画面前应用产品 capability；配置损坏时只显示完整性错误并停止业务初始化                                | capability 缺失时继续使用 AionUi 标题、主题、i18n 与应用 host                                    |
+| `packages/desktop/src/renderer/components/layout/Layout.tsx`、`Router.tsx`、`Sider/index.tsx`、`Titlebar/index.tsx`                                                                                                                       | 从同一 feature ID 投影 Team 入口、直接路由、订阅和 workspace 控件                                              | `ProductExperience` 的 AionUi adapter 保持 Team 入口、路由与生命周期可用                         |
+| `packages/desktop/src/renderer/hooks/mcp/catalog.ts`、`useMcpServers.ts`、`packages/desktop/src/renderer/pages/settings/ToolsSettings/`、`packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx` | 按可信 catalog 通道和后端 `product_origin` 投影 MCP 的 `hidden`、`use`、`manage`；隐藏记录只保留非敏感诊断字段 | AionUi adapter 保持全部 MCP 来源可见；extension 原有只读交互和上游 image-generation 配置保持不变 |
+| `packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx`                                                                                                                                                        | 从 behavior defaults 决定 Scheduled Tasks 是否允许 Team 执行者                                                 | AionUi adapter 继续使用 `assistant-or-team`                                                      |
+| `packages/desktop/src/process/bridge/updateBridge.ts`、`notificationBridge.ts`                                                                                                                                                            | 注入产品更新源和通知资源；完整性失败时禁用对应业务服务                                                         | capability 缺失时继续使用 AionUi 更新源、User-Agent 和通知图标                                   |
 
 AionUi 原行为由以下测试保护：
 
@@ -31,6 +32,8 @@ AionUi 原行为由以下测试保护：
 - `tests/integration/ProductExperienceSiderHost.dom.test.tsx`：AionUi adapter 保留 Team 导航，Ki-Buddy adapter 隐藏入口。
 - `tests/unit/renderer/layout/TitlebarWorkspaceToggle.dom.test.tsx`：AionUi 保留 workspace 切换能力。
 - `tests/unit/renderer/cron/CreateTaskDialog.dom.test.tsx`：AionUi 保留 Assistant/Team 执行者，Ki-Buddy 只允许 Assistant。
+- `tests/unit/renderer/hooks/mcpCatalog.dom.test.ts`、`useMcpServers.dom.test.ts`：Ki-Buddy 只保留 Custom 与 product built-in MCP，并为上游、extension 和未知来源生成结构化隐藏记录；AionUi 保持原 catalog。
+- `tests/unit/feedback/McpServerHeaderFeedback.dom.test.tsx`、`tests/unit/settings/ToolsModalContentImageGuide.dom.test.tsx`：`use` 允许连接检测但不提供管理操作；AionUi 的 `manage` 操作和 image-generation 配置保持可用。
 - `tests/unit/renderer/services/runtime/productBootstrap.dom.test.ts` 与 `kiBuddyRuntime.dom.test.ts`：capability 存在、缺失和损坏时使用对应启动路径。
 
 每次同步 AionUi 基线时必须复查：
@@ -40,6 +43,8 @@ AionUi 原行为由以下测试保护：
 3. AionUi 新增的完整产品能力是否已经加入稳定 feature ID，并在 Ki-Buddy 策略中明确声明启用或停用。
 4. 更新、通知、Tray、菜单、backend 和后台订阅是否仍在 invalid 路径之外启动。
 5. capability 存在与缺失两组回归、AionUi 原行为保护测试以及完整测试是否通过。
+
+MCP 来源由 catalog 边界决定：extension bridge 固定产生 `extension`，本地 AionUi built-in 固定产生 `upstreamBuiltin`，后端普通 MCP 缺少来源字段时按现有 canonical `builtin` 字段区分 `upstreamBuiltin` 与 `custom`。后端可以通过只读响应字段 `product_origin: productBuiltin` 接入未来受信任产品资源；MCP create、import 和 update payload 不发送该字段。未知字段值归为 `unclassified`，不能按名称、ID 前缀或 renderer 输入提升为 product built-in。
 
 当 AionUi 提供正式的产品策略注册、单一 preload bootstrap、首帧 capability 注入和按 capability 管理生命周期的公开扩展点后，应将对应职责迁移到上游接口，并删除本 ADR 列出的本地上游接缝。迁移只有在 Ki-Buddy invalid/ready 与 AionUi absent 三种状态的等价测试全部通过后才能完成。
 

--- a/packages/desktop/src/common/platform/ki-buddy/index.ts
+++ b/packages/desktop/src/common/platform/ki-buddy/index.ts
@@ -20,7 +20,9 @@ export {
   createAionUiProductExperience,
   createKiBuddyProductExperience,
   deepFreeze,
+  evaluateProductBuiltinResourceState,
   parseProductExperiencePolicy,
+  projectProductResources,
 } from './productExperience';
 export type {
   DeepReadonly,
@@ -32,6 +34,12 @@ export type {
   ProductResourceAccess,
   ProductResourceKind,
   ProductResourceOrigin,
+  ProductResourceDescriptor,
+  ProductResourceHiddenRecord,
+  ProductResourceProjection,
+  ProductBuiltinResourceRequirement,
+  ProductBuiltinResourceState,
+  MissingProductBuiltinResourceRecord,
 } from './productExperience';
 export {
   KI_BUDDY_CORE_TRANSPORT_CHANNEL,

--- a/packages/desktop/src/common/platform/ki-buddy/productExperience.ts
+++ b/packages/desktop/src/common/platform/ki-buddy/productExperience.ts
@@ -66,6 +66,45 @@ export type ProductExperience = Readonly<{
   resourceAccess: (kind: ProductResourceKind, origin: ProductResourceOrigin) => ProductResourceAccess;
 }>;
 
+export type ProductResourceDescriptor = Readonly<{
+  id: string;
+  name?: string;
+  origin: ProductResourceOrigin;
+}>;
+
+export type ProductResourceHiddenRecord = Readonly<{
+  access: 'hidden';
+  code: 'product_resource_hidden';
+  kind: ProductResourceKind;
+  origin: ProductResourceOrigin;
+  resourceId: string;
+  resourceName?: string;
+}>;
+
+export type ProductResourceProjection<Resource extends ProductResourceDescriptor> = Readonly<{
+  hidden: readonly ProductResourceHiddenRecord[];
+  visible: ReadonlyArray<Readonly<{ access: Exclude<ProductResourceAccess, 'hidden'>; resource: Resource }>>;
+}>;
+
+export type ProductBuiltinResourceRequirement = Readonly<{
+  featureId: ProductFeatureId;
+  resourceId: string;
+  resourceName?: string;
+}>;
+
+export type MissingProductBuiltinResourceRecord = Readonly<{
+  code: 'required_product_resource_missing';
+  featureId: ProductFeatureId;
+  kind: ProductResourceKind;
+  origin: 'productBuiltin';
+  resourceId: string;
+  resourceName?: string;
+}>;
+
+export type ProductBuiltinResourceState =
+  | Readonly<{ missing: readonly []; status: 'pending' | 'ready' }>
+  | Readonly<{ missing: readonly MissingProductBuiltinResourceRecord[]; status: 'invalid' }>;
+
 const FEATURE_DEPENDENCIES: ReadonlyArray<readonly [ProductFeatureId, ProductFeatureId]> = [
   ['extensionMarketplace', 'extensionRuntime'],
   ['extensionSettings', 'extensionRuntime'],
@@ -186,6 +225,65 @@ function createProductExperience(snapshot: ProductExperienceSnapshot): ProductEx
     resourceAccess: (kind: ProductResourceKind, origin: ProductResourceOrigin) => snapshot.resources[kind][origin],
     behaviorDefaults: () => snapshot.behaviorDefaults,
   });
+}
+
+/** Projects a resource catalog through the active product policy without retaining resource configuration in diagnostics. */
+export function projectProductResources<Resource extends ProductResourceDescriptor>(
+  experience: ProductExperience,
+  kind: ProductResourceKind,
+  resources: readonly Resource[]
+): ProductResourceProjection<Resource> {
+  const visible: Array<{ access: Exclude<ProductResourceAccess, 'hidden'>; resource: Resource }> = [];
+  const hidden: ProductResourceHiddenRecord[] = [];
+
+  for (const resource of resources) {
+    const access = experience.resourceAccess(kind, resource.origin);
+    if (access === 'hidden') {
+      hidden.push({
+        code: 'product_resource_hidden',
+        kind,
+        resourceId: resource.id,
+        resourceName: resource.name,
+        origin: resource.origin,
+        access,
+      });
+      continue;
+    }
+    visible.push({ resource, access });
+  }
+
+  return { visible, hidden };
+}
+
+/** Evaluates stable product resource requirements once the owning backend catalog becomes available. */
+export function evaluateProductBuiltinResourceState(
+  experience: ProductExperience,
+  kind: ProductResourceKind,
+  options: Readonly<{
+    availableResourceIds: readonly string[];
+    catalogReady: boolean;
+    requirements: readonly ProductBuiltinResourceRequirement[];
+  }>
+): ProductBuiltinResourceState {
+  const activeRequirements = options.requirements.filter(
+    ({ featureId }) => experience.featureState(featureId) === 'enabled'
+  );
+  if (activeRequirements.length === 0) return { status: 'ready', missing: [] };
+  if (!options.catalogReady) return { status: 'pending', missing: [] };
+
+  const availableResourceIds = new Set(options.availableResourceIds);
+  const missing = activeRequirements
+    .filter(({ resourceId }) => !availableResourceIds.has(resourceId))
+    .map(({ featureId, resourceId, resourceName }) => ({
+      code: 'required_product_resource_missing' as const,
+      featureId,
+      kind,
+      origin: 'productBuiltin' as const,
+      resourceId,
+      resourceName,
+    }));
+
+  return missing.length > 0 ? { status: 'invalid', missing } : { status: 'ready', missing: [] };
 }
 
 /** Creates the adapter for the strict, packaged Ki-Buddy policy. */

--- a/packages/desktop/src/renderer/components/layout/InstallationIntegrityDialog.tsx
+++ b/packages/desktop/src/renderer/components/layout/InstallationIntegrityDialog.tsx
@@ -351,6 +351,7 @@ type InstallationIntegrityModalOptions = {
   closable?: boolean;
 };
 
+/** Opens a structured installation-integrity dialog with blocking behavior by default. */
 export function showInstallationIntegrityModal(
   modal: InstallationIntegrityModalController,
   t: TFunction,
@@ -375,6 +376,7 @@ export function showInstallationIntegrityModal(
   });
 }
 
+/** Hosts a single installation-integrity dialog in the current React tree. */
 export const InstallationIntegrityModalHost: React.FC<{
   closable?: boolean;
   description: string;

--- a/packages/desktop/src/renderer/components/layout/InstallationIntegrityDialog.tsx
+++ b/packages/desktop/src/renderer/components/layout/InstallationIntegrityDialog.tsx
@@ -347,12 +347,17 @@ export const InstallationIntegrityFooter: React.FC<{
 
 type InstallationIntegrityModalController = ReturnType<typeof Modal.useModal>[0];
 
+type InstallationIntegrityModalOptions = {
+  closable?: boolean;
+};
+
 export function showInstallationIntegrityModal(
   modal: InstallationIntegrityModalController,
   t: TFunction,
   description: string,
   diagnostics?: InstallationIntegrityDiagnostics,
-  diagnosticsKind: InstallationIntegrityDialogKind = 'incomplete_installation'
+  diagnosticsKind: InstallationIntegrityDialogKind = 'incomplete_installation',
+  options: InstallationIntegrityModalOptions = {}
 ): ReturnType<InstallationIntegrityModalController['error']> {
   const diagnosticsHint =
     diagnosticsKind === 'recoverable_database_corruption'
@@ -365,16 +370,17 @@ export function showInstallationIntegrityModal(
     title: getInstallationIntegrityTitle(t, diagnosticsKind),
     content: <InstallationIntegrityContent description={description} diagnosticsHint={diagnosticsHint} />,
     footer: <InstallationIntegrityFooter diagnostics={diagnostics} diagnosticsKind={diagnosticsKind} />,
-    closable: false,
+    closable: options.closable ?? false,
     maskClosable: false,
   });
 }
 
 export const InstallationIntegrityModalHost: React.FC<{
+  closable?: boolean;
   description: string;
   diagnostics?: InstallationIntegrityDiagnostics;
   diagnosticsKind?: InstallationIntegrityDialogKind;
-}> = ({ description, diagnostics, diagnosticsKind = 'incomplete_installation' }) => {
+}> = ({ closable = false, description, diagnostics, diagnosticsKind = 'incomplete_installation' }) => {
   const [modal, modalContextHolder] = Modal.useModal();
   const { t } = useTranslation();
   const shownRef = useRef(false);
@@ -382,8 +388,8 @@ export const InstallationIntegrityModalHost: React.FC<{
   useEffect(() => {
     if (shownRef.current) return;
     shownRef.current = true;
-    showInstallationIntegrityModal(modal, t, description, diagnostics, diagnosticsKind);
-  }, [description, diagnostics, diagnosticsKind, modal, t]);
+    showInstallationIntegrityModal(modal, t, description, diagnostics, diagnosticsKind, { closable });
+  }, [closable, description, diagnostics, diagnosticsKind, modal, t]);
 
   return <>{modalContextHolder}</>;
 };

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
@@ -34,6 +34,8 @@ import {
 } from '@/renderer/services/clientBusinessSettings';
 import classNames from 'classnames';
 import { getProductDocumentationUrl } from '@/renderer/services/runtime/productBrandRuntime';
+import { getProductExperience } from '@/renderer/services/runtime/kiBuddyRuntime';
+import type { McpCatalogEntry } from '@/renderer/hooks/mcp/catalog';
 import { useSettingsTabNavigate, useSettingsViewMode } from '../settingsViewContext';
 
 type MessageInstance = ReturnType<typeof Message.useMessage>[0];
@@ -48,16 +50,25 @@ const areEnvRecordsEqual = (a: Record<string, string>, b: Record<string, string>
 const ModalMcpManagementSection: React.FC<{
   message: MessageInstance;
   mcpServers: IMcpServer[];
-  extensionMcpServers: IMcpServer[];
+  mcpCatalogEntries: readonly McpCatalogEntry[];
+  extensionMcpCatalogEntries: readonly McpCatalogEntry[];
   setMcpServers: React.Dispatch<React.SetStateAction<IMcpServer[]>>;
   saveMcpServers: (serversOrUpdater: IMcpServer[] | ((prev: IMcpServer[]) => IMcpServer[])) => Promise<void>;
   isPageMode?: boolean;
-}> = ({ message, mcpServers, extensionMcpServers, setMcpServers, saveMcpServers, isPageMode }) => {
+}> = ({
+  message,
+  mcpServers,
+  mcpCatalogEntries,
+  extensionMcpCatalogEntries,
+  setMcpServers,
+  saveMcpServers,
+  isPageMode,
+}) => {
   const { t } = useTranslation();
   const { oauthStatus, loggingIn, checkOAuthStatus, markLoginRequired, clearLoginRequired, login } = useMcpOAuth();
-  const visibleMcpServers = useMemo(
-    () => mcpServers.filter((server) => !isBuiltinImageGenServer(server)),
-    [mcpServers]
+  const visibleMcpEntries = useMemo(
+    () => mcpCatalogEntries.filter(({ server }) => !isBuiltinImageGenServer(server)),
+    [mcpCatalogEntries]
   );
 
   const handleAuthRequired = useCallback(
@@ -195,7 +206,7 @@ const ModalMcpManagementSection: React.FC<{
       </div>
 
       <div className='flex-1 min-h-0'>
-        {visibleMcpServers.length === 0 && extensionMcpServers.length === 0 ? (
+        {visibleMcpEntries.length === 0 && extensionMcpCatalogEntries.length === 0 ? (
           <div className='py-24px text-center text-t-secondary text-14px border border-dashed border-border-2 rd-12px'>
             {t('settings.mcpNoServersFound')}
           </div>
@@ -205,10 +216,11 @@ const ModalMcpManagementSection: React.FC<{
             disableOverflow={isPageMode}
           >
             <div className='space-y-12px'>
-              {visibleMcpServers.map((server) => (
+              {visibleMcpEntries.map(({ server, access }) => (
                 <McpServerItem
                   key={server.id}
                   server={server}
+                  access={access}
                   isCollapsed={mcpCollapseKey[server.id] || false}
                   isTestingConnection={testingServers[server.id] || false}
                   oauthStatus={oauthStatus[server.id]}
@@ -220,10 +232,11 @@ const ModalMcpManagementSection: React.FC<{
                   onOAuthLogin={handleOAuthLogin}
                 />
               ))}
-              {extensionMcpServers.map((server) => (
+              {extensionMcpCatalogEntries.map(({ server, access }) => (
                 <McpServerItem
                   key={server.id}
                   server={server}
+                  access={access}
                   isCollapsed={mcpCollapseKey[server.id] || false}
                   isTestingConnection={false}
                   onToggleCollapse={() => toggleServerCollapse(server.id)}
@@ -268,6 +281,7 @@ const ModalMcpManagementSection: React.FC<{
 };
 
 const ToolsModalContent: React.FC = () => {
+  const canUseUpstreamBuiltinMcp = getProductExperience().resourceAccess('mcp', 'upstreamBuiltin') !== 'hidden';
   const imageGenerationGuideUrl = getProductDocumentationUrl(
     'https://github.com/iOfficeAI/AionUi/wiki/AionUi-Image-Generation-Tool-Model-Configuration-Guide'
   );
@@ -279,7 +293,14 @@ const ToolsModalContent: React.FC = () => {
   const [imageGenerationModel, setImageGenerationModel] = useState<ImageGenerationModelSetting | undefined>();
   const [isUpdatingImageGeneration, setIsUpdatingImageGeneration] = useState(false);
   const { modelListWithImage: data } = useConfigModelListWithImage();
-  const { mcpServers, extensionMcpServers, saveMcpServers, setMcpServers, isMcpServersLoading } = useMcpServers();
+  const {
+    mcpServers,
+    mcpCatalogEntries,
+    extensionMcpCatalogEntries,
+    saveMcpServers,
+    setMcpServers,
+    isMcpServersLoading,
+  } = useMcpServers();
   const builtinImageGenServer = useMemo(() => mcpServers.find(isBuiltinImageGenServer), [mcpServers]);
   const isImageGenerationServerLoading = isMcpServersLoading && !builtinImageGenServer;
 
@@ -294,6 +315,7 @@ const ToolsModalContent: React.FC = () => {
   }, [data]);
 
   useEffect(() => {
+    if (!canUseUpstreamBuiltinMcp) return;
     const loadConfigs = async () => {
       try {
         const storedModel = await getClientBusinessSetting('tools.imageGenerationModel');
@@ -306,11 +328,12 @@ const ToolsModalContent: React.FC = () => {
     };
 
     void loadConfigs();
-  }, []);
+  }, [canUseUpstreamBuiltinMcp]);
 
   // Sync image generation model config to the built-in MCP server's transport.env
   const syncMcpServerEnv = useCallback(
     async (model: Partial<ImageGenerationModelSetting>) => {
+      if (!canUseUpstreamBuiltinMcp) return;
       const builtinServer = mcpServers.find(isBuiltinImageGenServer);
       if (!builtinServer || builtinServer.transport.type !== 'stdio') return;
 
@@ -375,12 +398,12 @@ const ToolsModalContent: React.FC = () => {
         prevServers.map((server) => (server.id === updatedServer.id ? { ...server, ...updatedServer } : server))
       );
     },
-    [data, mcpServers, saveMcpServers]
+    [canUseUpstreamBuiltinMcp, data, mcpServers, saveMcpServers]
   );
 
   // Keep the saved image model as a provider/model reference. Secrets stay in providers.
   useEffect(() => {
-    if (!imageGenerationModel || !data) return;
+    if (!canUseUpstreamBuiltinMcp || !imageGenerationModel || !data) return;
 
     const currentProvider = data.find((p) => p.id === imageGenerationModel.id);
 
@@ -413,7 +436,7 @@ const ToolsModalContent: React.FC = () => {
     void syncMcpServerEnv(sanitizedModel).catch((error) => {
       console.error('Failed to sync image generation MCP env after provider change:', error);
     });
-  }, [data, imageGenerationModel, syncMcpServerEnv]);
+  }, [canUseUpstreamBuiltinMcp, data, imageGenerationModel, syncMcpServerEnv]);
 
   const handleImageGenerationModelChange = useCallback(
     (value: Partial<ImageGenerationModelSetting>) => {
@@ -504,7 +527,8 @@ const ToolsModalContent: React.FC = () => {
                 <ModalMcpManagementSection
                   message={mcpMessage}
                   mcpServers={mcpServers}
-                  extensionMcpServers={extensionMcpServers}
+                  mcpCatalogEntries={mcpCatalogEntries}
+                  extensionMcpCatalogEntries={extensionMcpCatalogEntries}
                   setMcpServers={setMcpServers}
                   saveMcpServers={saveMcpServers}
                   isPageMode={isPageMode}
@@ -513,7 +537,10 @@ const ToolsModalContent: React.FC = () => {
             </div>
           </div>
           {/* 图像生成 */}
-          <div className='px-[12px] md:px-[32px] py-[24px] bg-2 rd-12px md:rd-16px border border-border-2'>
+          <div
+            hidden={!canUseUpstreamBuiltinMcp}
+            className='px-[12px] md:px-[32px] py-[24px] bg-2 rd-12px md:rd-16px border border-border-2'
+          >
             <div className='flex items-center justify-between mb-16px'>
               <span className='text-14px text-t-primary'>{t('settings.imageGeneration')}</span>
               <Switch

--- a/packages/desktop/src/renderer/hooks/mcp/catalog.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/catalog.ts
@@ -51,8 +51,10 @@ const resolveBackendMcpOrigin = (server: ProductAwareMcpServer): ProductResource
 
 const normalizeServerName = (name: string) => name.trim().toLowerCase();
 
+/** Product-owned MCP requirements registered by features such as the future Agents Adapter integration. */
 export const PRODUCT_BUILTIN_MCP_REQUIREMENTS: readonly ProductBuiltinResourceRequirement[] = [];
 
+/** Returns the stable key used to reconcile MCP catalog entries across backend and local sources. */
 export const getMcpCatalogServerKey = (server: Pick<IMcpServer, 'id' | 'name' | 'builtin'>) => {
   const normalizedName = normalizeServerName(server.name);
   if (server.builtin === true) {
@@ -93,6 +95,7 @@ const normalizeTransportForBackend = (transport: IMcpServerTransport): BackendMc
   return transport;
 };
 
+/** Converts a renderer MCP record into the transport shape accepted by the backend service. */
 export const toBackendMcpPayload = (
   server: Pick<IMcpServer, 'name' | 'description' | 'transport' | 'original_json' | 'builtin'>
 ): BackendMcpPayload => ({
@@ -103,12 +106,14 @@ export const toBackendMcpPayload = (
   builtin: Boolean(server.builtin),
 });
 
+/** Selects the MCP fields forwarded to conversation session configuration. */
 export const toSessionMcpServer = (server: Pick<IMcpServer, 'id' | 'name' | 'transport'>): ISessionMcpServer => ({
   id: server.id,
   name: server.name,
   transport: server.transport,
 });
 
+/** Applies the active product resource policy to trusted MCP catalog candidates. */
 export const projectMcpCatalogCandidates = (
   candidates: readonly McpCatalogCandidate[],
   experience: ProductExperience
@@ -128,6 +133,7 @@ export const projectMcpCatalogCandidates = (
   };
 };
 
+/** Emits non-sensitive diagnostics for MCP resources hidden by the product policy. */
 export const reportHiddenMcpResources = (hiddenResources: readonly ProductResourceHiddenRecord[]): void => {
   if (hiddenResources.length === 0) return;
   console.info('[ProductExperience] MCP resources hidden by product policy', {
@@ -164,6 +170,7 @@ export async function loadProductBuiltinMcpResourceState(
   }
 }
 
+/** Loads, deduplicates, and projects backend and local built-in MCP records into one catalog. */
 export const ensureBackendMcpCatalog = async (
   experience: ProductExperience = getProductExperience()
 ): Promise<{

--- a/packages/desktop/src/renderer/hooks/mcp/catalog.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/catalog.ts
@@ -1,6 +1,15 @@
 import { mcpService } from '@/common/adapter/ipcBridge';
 import type { IMcpServer, IMcpServerTransport, ISessionMcpServer } from '@/common/config/storage';
+import {
+  PRODUCT_RESOURCE_ORIGINS,
+  projectProductResources,
+  type ProductExperience,
+  type ProductResourceAccess,
+  type ProductResourceHiddenRecord,
+  type ProductResourceOrigin,
+} from '@/common/platform/ki-buddy';
 import { getClientBusinessSetting } from '@/renderer/services/clientBusinessSettings';
+import { getProductExperience } from '@/renderer/services/runtime/kiBuddyRuntime';
 
 type BackendMcpTransport = Exclude<IMcpServerTransport, { type: 'streamable_http' }>;
 
@@ -12,11 +21,34 @@ type BackendMcpPayload = {
   builtin?: boolean;
 };
 
+type ProductAwareMcpServer = IMcpServer & { product_origin?: unknown };
+
+export type McpCatalogEntry = Readonly<{
+  access: Exclude<ProductResourceAccess, 'hidden'>;
+  origin: ProductResourceOrigin;
+  server: IMcpServer;
+}>;
+
+type McpCatalogCandidate = Readonly<{
+  origin: ProductResourceOrigin;
+  server: IMcpServer;
+}>;
+
 const isBuiltinServer = (server: IMcpServer) => server.builtin === true;
+
+const isProductResourceOrigin = (value: unknown): value is ProductResourceOrigin =>
+  typeof value === 'string' && PRODUCT_RESOURCE_ORIGINS.includes(value as ProductResourceOrigin);
+
+const resolveBackendMcpOrigin = (server: ProductAwareMcpServer): ProductResourceOrigin => {
+  if (server.product_origin !== undefined) {
+    return isProductResourceOrigin(server.product_origin) ? server.product_origin : 'unclassified';
+  }
+  return server.builtin === true ? 'upstreamBuiltin' : 'custom';
+};
 
 const normalizeServerName = (name: string) => name.trim().toLowerCase();
 
-const getCatalogServerKey = (server: Pick<IMcpServer, 'id' | 'name' | 'builtin'>) => {
+export const getMcpCatalogServerKey = (server: Pick<IMcpServer, 'id' | 'name' | 'builtin'>) => {
   const normalizedName = normalizeServerName(server.name);
   if (server.builtin === true) {
     return `builtin:${normalizedName || server.id}`;
@@ -29,12 +61,28 @@ const dedupeServers = (servers: IMcpServer[]) => {
   const deduped: IMcpServer[] = [];
 
   for (const server of servers) {
-    const key = getCatalogServerKey(server);
+    const key = getMcpCatalogServerKey(server);
     if (seen.has(key)) {
       continue;
     }
     seen.add(key);
     deduped.push(server);
+  }
+
+  return deduped;
+};
+
+const dedupeCandidates = (candidates: readonly McpCatalogCandidate[]): McpCatalogCandidate[] => {
+  const seen = new Set<string>();
+  const deduped: McpCatalogCandidate[] = [];
+
+  for (const candidate of candidates) {
+    const key = getMcpCatalogServerKey(candidate.server);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(candidate);
   }
 
   return deduped;
@@ -67,21 +115,65 @@ export const toSessionMcpServer = (server: Pick<IMcpServer, 'id' | 'name' | 'tra
   transport: server.transport,
 });
 
-export const ensureBackendMcpCatalog = async (): Promise<{
+export const projectMcpCatalogCandidates = (
+  candidates: readonly McpCatalogCandidate[],
+  experience: ProductExperience
+): Readonly<{ entries: readonly McpCatalogEntry[]; hiddenResources: readonly ProductResourceHiddenRecord[] }> => {
+  const projection = projectProductResources(
+    experience,
+    'mcp',
+    candidates.map(({ server, origin }) => ({ id: server.id, name: server.name, origin, server }))
+  );
+  return {
+    entries: projection.visible.map(({ resource, access }) => ({
+      server: resource.server,
+      origin: resource.origin,
+      access,
+    })),
+    hiddenResources: projection.hidden,
+  };
+};
+
+export const reportHiddenMcpResources = (hiddenResources: readonly ProductResourceHiddenRecord[]): void => {
+  if (hiddenResources.length === 0) return;
+  console.info('[ProductExperience] MCP resources hidden by product policy', {
+    code: 'product_resource_projection',
+    resources: hiddenResources,
+  });
+};
+
+export const ensureBackendMcpCatalog = async (
+  experience: ProductExperience = getProductExperience()
+): Promise<{
   userServers: IMcpServer[];
   builtinServers: IMcpServer[];
   allServers: IMcpServer[];
+  entries: readonly McpCatalogEntry[];
+  hiddenResources: readonly ProductResourceHiddenRecord[];
 }> => {
   const localServers = ((await getClientBusinessSetting('mcp.config').catch((): IMcpServer[] => [])) ||
     []) as IMcpServer[];
-  const builtinServers = dedupeServers(localServers.filter(isBuiltinServer));
-  const userServers = dedupeServers(await mcpService.listServers.invoke());
+  const allBuiltinServers = dedupeServers(localServers.filter(isBuiltinServer));
+  const allBackendServers = dedupeServers(await mcpService.listServers.invoke());
+  const projection = projectMcpCatalogCandidates(
+    dedupeCandidates([
+      ...allBackendServers.map((server) => ({ server, origin: resolveBackendMcpOrigin(server) })),
+      ...allBuiltinServers.map((server) => ({ server, origin: 'upstreamBuiltin' as const })),
+    ]),
+    experience
+  );
+  reportHiddenMcpResources(projection.hiddenResources);
 
-  const allServers = dedupeServers([...userServers, ...builtinServers]);
+  const visibleServers = new Set(projection.entries.map(({ server }) => server));
+  const userServers = allBackendServers.filter((server) => visibleServers.has(server));
+  const builtinServers = allBuiltinServers.filter((server) => visibleServers.has(server));
+  const allServers = projection.entries.map(({ server }) => server);
 
   return {
     userServers,
     builtinServers,
     allServers,
+    entries: projection.entries,
+    hiddenResources: projection.hiddenResources,
   };
 };

--- a/packages/desktop/src/renderer/hooks/mcp/catalog.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/catalog.ts
@@ -2,7 +2,10 @@ import { mcpService } from '@/common/adapter/ipcBridge';
 import type { IMcpServer, IMcpServerTransport, ISessionMcpServer } from '@/common/config/storage';
 import {
   PRODUCT_RESOURCE_ORIGINS,
+  evaluateProductBuiltinResourceState,
   projectProductResources,
+  type ProductBuiltinResourceRequirement,
+  type ProductBuiltinResourceState,
   type ProductExperience,
   type ProductResourceAccess,
   type ProductResourceHiddenRecord,
@@ -48,6 +51,8 @@ const resolveBackendMcpOrigin = (server: ProductAwareMcpServer): ProductResource
 
 const normalizeServerName = (name: string) => name.trim().toLowerCase();
 
+export const PRODUCT_BUILTIN_MCP_REQUIREMENTS: readonly ProductBuiltinResourceRequirement[] = [];
+
 export const getMcpCatalogServerKey = (server: Pick<IMcpServer, 'id' | 'name' | 'builtin'>) => {
   const normalizedName = normalizeServerName(server.name);
   if (server.builtin === true) {
@@ -56,37 +61,26 @@ export const getMcpCatalogServerKey = (server: Pick<IMcpServer, 'id' | 'name' | 
   return `user:${normalizedName || server.id}`;
 };
 
-const dedupeServers = (servers: IMcpServer[]) => {
+const dedupeBy = <Item>(items: readonly Item[], getKey: (item: Item) => string): Item[] => {
   const seen = new Set<string>();
-  const deduped: IMcpServer[] = [];
+  const deduped: Item[] = [];
 
-  for (const server of servers) {
-    const key = getMcpCatalogServerKey(server);
+  for (const item of items) {
+    const key = getKey(item);
     if (seen.has(key)) {
       continue;
     }
     seen.add(key);
-    deduped.push(server);
+    deduped.push(item);
   }
 
   return deduped;
 };
 
-const dedupeCandidates = (candidates: readonly McpCatalogCandidate[]): McpCatalogCandidate[] => {
-  const seen = new Set<string>();
-  const deduped: McpCatalogCandidate[] = [];
+const dedupeServers = (servers: readonly IMcpServer[]) => dedupeBy<IMcpServer>(servers, getMcpCatalogServerKey);
 
-  for (const candidate of candidates) {
-    const key = getMcpCatalogServerKey(candidate.server);
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    deduped.push(candidate);
-  }
-
-  return deduped;
-};
+const dedupeCandidates = (candidates: readonly McpCatalogCandidate[]) =>
+  dedupeBy(candidates, ({ server }) => getMcpCatalogServerKey(server));
 
 const normalizeTransportForBackend = (transport: IMcpServerTransport): BackendMcpTransport => {
   if (transport.type === 'streamable_http') {
@@ -141,6 +135,34 @@ export const reportHiddenMcpResources = (hiddenResources: readonly ProductResour
     resources: hiddenResources,
   });
 };
+
+/** Evaluates registered product MCP requirements once the backend catalog can authoritatively answer. */
+export async function loadProductBuiltinMcpResourceState(
+  experience: ProductExperience = getProductExperience(),
+  requirements: readonly ProductBuiltinResourceRequirement[] = PRODUCT_BUILTIN_MCP_REQUIREMENTS
+): Promise<ProductBuiltinResourceState> {
+  const pendingState = evaluateProductBuiltinResourceState(experience, 'mcp', {
+    availableResourceIds: [],
+    catalogReady: false,
+    requirements,
+  });
+  if (pendingState.status !== 'pending') return pendingState;
+
+  try {
+    const backendServers = await mcpService.listServers.invoke();
+    const availableResourceIds = backendServers
+      .filter((server) => resolveBackendMcpOrigin(server) === 'productBuiltin')
+      .map(({ id }) => id);
+    return evaluateProductBuiltinResourceState(experience, 'mcp', {
+      availableResourceIds,
+      catalogReady: true,
+      requirements,
+    });
+  } catch (error) {
+    console.error('[ProductExperience] Failed to load the MCP catalog for product integrity validation', error);
+    return pendingState;
+  }
+}
 
 export const ensureBackendMcpCatalog = async (
   experience: ProductExperience = getProductExperience()

--- a/packages/desktop/src/renderer/hooks/mcp/useMcpServers.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/useMcpServers.ts
@@ -1,7 +1,15 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ipcBridge } from '@/common';
 import type { IMcpServer } from '@/common/config/storage';
-import { ensureBackendMcpCatalog } from './catalog';
+import type { ProductResourceHiddenRecord, ProductResourceOrigin } from '@/common/platform/ki-buddy';
+import { getProductExperience } from '@/renderer/services/runtime/kiBuddyRuntime';
+import {
+  ensureBackendMcpCatalog,
+  getMcpCatalogServerKey,
+  projectMcpCatalogCandidates,
+  reportHiddenMcpResources,
+  type McpCatalogEntry,
+} from './catalog';
 
 /**
  * MCP server state hook.
@@ -10,16 +18,25 @@ import { ensureBackendMcpCatalog } from './catalog';
 export const useMcpServers = () => {
   const [mcpServers, setMcpServers] = useState<IMcpServer[]>([]);
   const [extensionMcpServers, setExtensionMcpServers] = useState<IMcpServer[]>([]);
+  const [mcpOrigins, setMcpOrigins] = useState<Record<string, ProductResourceOrigin>>({});
+  const [backendHiddenResources, setBackendHiddenResources] = useState<readonly ProductResourceHiddenRecord[]>([]);
+  const [extensionHiddenResources, setExtensionHiddenResources] = useState<readonly ProductResourceHiddenRecord[]>([]);
   const [isMcpServersLoading, setIsMcpServersLoading] = useState(true);
 
   useEffect(() => {
     void ensureBackendMcpCatalog()
-      .then(({ allServers }) => {
+      .then(({ allServers, entries = [], hiddenResources = [] }) => {
         setMcpServers(allServers);
+        setMcpOrigins(
+          Object.fromEntries(entries.map(({ server, origin }) => [getMcpCatalogServerKey(server), origin]))
+        );
+        setBackendHiddenResources(hiddenResources);
       })
       .catch((error) => {
         console.error('[useMcpServers] Failed to load MCP catalog:', error);
         setMcpServers([]);
+        setMcpOrigins({});
+        setBackendHiddenResources([]);
       })
       .finally(() => {
         setIsMcpServersLoading(false);
@@ -44,11 +61,18 @@ export const useMcpServers = () => {
           original_json: String(server.original_json || '{}'),
           builtin: false,
         }));
-        setExtensionMcpServers(converted);
+        const projection = projectMcpCatalogCandidates(
+          converted.map((server) => ({ server, origin: 'extension' as const })),
+          getProductExperience()
+        );
+        reportHiddenMcpResources(projection.hiddenResources);
+        setExtensionMcpServers(projection.entries.map(({ server }) => server));
+        setExtensionHiddenResources(projection.hiddenResources);
       })
       .catch((error) => {
         console.error('[useMcpServers] Failed to load extension MCP servers:', error);
         setExtensionMcpServers([]);
+        setExtensionHiddenResources([]);
       });
   }, []);
 
@@ -59,11 +83,35 @@ export const useMcpServers = () => {
     return Promise.resolve();
   }, []);
 
+  const mcpCatalogEntries = useMemo<readonly McpCatalogEntry[]>(
+    () =>
+      projectMcpCatalogCandidates(
+        mcpServers.map((server) => ({ server, origin: mcpOrigins[getMcpCatalogServerKey(server)] ?? 'custom' })),
+        getProductExperience()
+      ).entries,
+    [mcpOrigins, mcpServers]
+  );
+  const extensionMcpCatalogEntries = useMemo<readonly McpCatalogEntry[]>(
+    () =>
+      projectMcpCatalogCandidates(
+        extensionMcpServers.map((server) => ({ server, origin: 'extension' })),
+        getProductExperience()
+      ).entries,
+    [extensionMcpServers]
+  );
+  const hiddenResources = useMemo(
+    () => [...backendHiddenResources, ...extensionHiddenResources],
+    [backendHiddenResources, extensionHiddenResources]
+  );
+
   return {
     mcpServers,
+    mcpCatalogEntries,
     isMcpServersLoading,
     allMcpServers: [...mcpServers, ...extensionMcpServers],
     extensionMcpServers,
+    extensionMcpCatalogEntries,
+    hiddenResources,
     setMcpServers,
     saveMcpServers,
   };

--- a/packages/desktop/src/renderer/hooks/mcp/useMcpServers.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/useMcpServers.ts
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type SetStateAction } from 'react';
 import { ipcBridge } from '@/common';
 import type { IMcpServer } from '@/common/config/storage';
-import type { ProductResourceHiddenRecord, ProductResourceOrigin } from '@/common/platform/ki-buddy';
+import type { ProductResourceHiddenRecord } from '@/common/platform/ki-buddy';
 import { getProductExperience } from '@/renderer/services/runtime/kiBuddyRuntime';
 import {
   ensureBackendMcpCatalog,
@@ -16,26 +16,21 @@ import {
  * Combines backend-managed user servers with extension-contributed servers.
  */
 export const useMcpServers = () => {
-  const [mcpServers, setMcpServers] = useState<IMcpServer[]>([]);
-  const [extensionMcpServers, setExtensionMcpServers] = useState<IMcpServer[]>([]);
-  const [mcpOrigins, setMcpOrigins] = useState<Record<string, ProductResourceOrigin>>({});
+  const [mcpCatalogEntries, setMcpCatalogEntries] = useState<readonly McpCatalogEntry[]>([]);
+  const [extensionMcpCatalogEntries, setExtensionMcpCatalogEntries] = useState<readonly McpCatalogEntry[]>([]);
   const [backendHiddenResources, setBackendHiddenResources] = useState<readonly ProductResourceHiddenRecord[]>([]);
   const [extensionHiddenResources, setExtensionHiddenResources] = useState<readonly ProductResourceHiddenRecord[]>([]);
   const [isMcpServersLoading, setIsMcpServersLoading] = useState(true);
 
   useEffect(() => {
     void ensureBackendMcpCatalog()
-      .then(({ allServers, entries = [], hiddenResources = [] }) => {
-        setMcpServers(allServers);
-        setMcpOrigins(
-          Object.fromEntries(entries.map(({ server, origin }) => [getMcpCatalogServerKey(server), origin]))
-        );
+      .then(({ entries = [], hiddenResources = [] }) => {
+        setMcpCatalogEntries(entries);
         setBackendHiddenResources(hiddenResources);
       })
       .catch((error) => {
         console.error('[useMcpServers] Failed to load MCP catalog:', error);
-        setMcpServers([]);
-        setMcpOrigins({});
+        setMcpCatalogEntries([]);
         setBackendHiddenResources([]);
       })
       .finally(() => {
@@ -46,7 +41,7 @@ export const useMcpServers = () => {
       .invoke()
       .then((extServers) => {
         if (!extServers || extServers.length === 0) {
-          setExtensionMcpServers([]);
+          setExtensionMcpCatalogEntries([]);
           return;
         }
 
@@ -66,38 +61,56 @@ export const useMcpServers = () => {
           getProductExperience()
         );
         reportHiddenMcpResources(projection.hiddenResources);
-        setExtensionMcpServers(projection.entries.map(({ server }) => server));
+        setExtensionMcpCatalogEntries(projection.entries);
         setExtensionHiddenResources(projection.hiddenResources);
       })
       .catch((error) => {
         console.error('[useMcpServers] Failed to load extension MCP servers:', error);
-        setExtensionMcpServers([]);
+        setExtensionMcpCatalogEntries([]);
         setExtensionHiddenResources([]);
       });
   }, []);
 
-  const saveMcpServers = useCallback((serversOrUpdater: IMcpServer[] | ((prev: IMcpServer[]) => IMcpServer[])) => {
-    setMcpServers((prevServers) =>
-      typeof serversOrUpdater === 'function' ? serversOrUpdater(prevServers) : serversOrUpdater
-    );
-    return Promise.resolve();
+  const setMcpServers = useCallback((serversOrUpdater: SetStateAction<IMcpServer[]>) => {
+    setMcpCatalogEntries((previousEntries) => {
+      const previousServers = previousEntries.map(({ server }) => server);
+      const nextServers = typeof serversOrUpdater === 'function' ? serversOrUpdater(previousServers) : serversOrUpdater;
+      const previousEntriesByKey = new Map(
+        previousEntries.map((entry) => [getMcpCatalogServerKey(entry.server), entry])
+      );
+      const newServers = nextServers.filter((server) => !previousEntriesByKey.has(getMcpCatalogServerKey(server)));
+      const newEntriesByKey =
+        newServers.length === 0
+          ? new Map<string, McpCatalogEntry>()
+          : new Map(
+              projectMcpCatalogCandidates(
+                newServers.map((server) => ({ server, origin: 'custom' })),
+                getProductExperience()
+              ).entries.map((entry) => [getMcpCatalogServerKey(entry.server), entry])
+            );
+
+      return nextServers.flatMap((server) => {
+        const key = getMcpCatalogServerKey(server);
+        const existingEntry = previousEntriesByKey.get(key);
+        if (existingEntry) return [{ ...existingEntry, server }];
+        const newEntry = newEntriesByKey.get(key);
+        return newEntry ? [newEntry] : [];
+      });
+    });
   }, []);
 
-  const mcpCatalogEntries = useMemo<readonly McpCatalogEntry[]>(
-    () =>
-      projectMcpCatalogCandidates(
-        mcpServers.map((server) => ({ server, origin: mcpOrigins[getMcpCatalogServerKey(server)] ?? 'custom' })),
-        getProductExperience()
-      ).entries,
-    [mcpOrigins, mcpServers]
+  const saveMcpServers = useCallback(
+    (serversOrUpdater: SetStateAction<IMcpServer[]>) => {
+      setMcpServers(serversOrUpdater);
+      return Promise.resolve();
+    },
+    [setMcpServers]
   );
-  const extensionMcpCatalogEntries = useMemo<readonly McpCatalogEntry[]>(
-    () =>
-      projectMcpCatalogCandidates(
-        extensionMcpServers.map((server) => ({ server, origin: 'extension' })),
-        getProductExperience()
-      ).entries,
-    [extensionMcpServers]
+
+  const mcpServers = useMemo(() => mcpCatalogEntries.map(({ server }) => server), [mcpCatalogEntries]);
+  const extensionMcpServers = useMemo(
+    () => extensionMcpCatalogEntries.map(({ server }) => server),
+    [extensionMcpCatalogEntries]
   );
   const hiddenResources = useMemo(
     () => [...backendHiddenResources, ...extensionHiddenResources],

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -107,7 +107,9 @@ import { bootstrapRendererConfig } from '@renderer/services/bootstrapRenderer';
 // Components and utilities
 import BackendStartingView from './components/layout/BackendStartingView';
 import BackendStartupGate from './components/layout/BackendStartupGate';
-import KiBuddyProductIntegrityGate from './pages/ki-buddy/KiBuddyProductIntegrityGate';
+import KiBuddyProductIntegrityGate, {
+  KiBuddyMcpProductIntegrityGate,
+} from './pages/ki-buddy/KiBuddyProductIntegrityGate';
 import GpuAutoDisableNotice from './components/layout/GpuAutoDisableNotice';
 import Layout from './components/layout/Layout';
 import Router from './components/layout/Router';
@@ -328,7 +330,7 @@ const Config: React.FC<PropsWithChildren> = ({ children }) => {
 };
 
 const Main = () => {
-  const { ready } = useAuth();
+  const { ready, status } = useAuth();
   const [configReady, setConfigReady] = useState(false);
 
   useEffect(() => {
@@ -346,13 +348,15 @@ const Main = () => {
   }
 
   return (
-    <Router
-      layout={
-        <ConversationHistoryProvider>
-          <Layout sider={<Sider />} />
-        </ConversationHistoryProvider>
-      }
-    />
+    <KiBuddyMcpProductIntegrityGate enabled={Boolean(kiBuddyRuntime) && status === 'authenticated'}>
+      <Router
+        layout={
+          <ConversationHistoryProvider>
+            <Layout sider={<Sider />} />
+          </ConversationHistoryProvider>
+        }
+      />
+    </KiBuddyMcpProductIntegrityGate>
   );
 };
 

--- a/packages/desktop/src/renderer/pages/ki-buddy/KiBuddyProductIntegrityGate.tsx
+++ b/packages/desktop/src/renderer/pages/ki-buddy/KiBuddyProductIntegrityGate.tsx
@@ -1,6 +1,11 @@
-import React from 'react';
+import React, { useEffect, useState, type PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
-import { InstallationIntegrityModalHost } from '@/renderer/components/layout/InstallationIntegrityDialog';
+import {
+  InstallationIntegrityModalHost,
+  getRuntimeComponentInstallationDescription,
+} from '@/renderer/components/layout/InstallationIntegrityDialog';
+import type { ProductBuiltinResourceState } from '@/common/platform/ki-buddy';
+import { loadProductBuiltinMcpResourceState } from '@/renderer/hooks/mcp/catalog';
 
 type KiBuddyProductIntegrityGateProps = {
   failure: string;
@@ -27,6 +32,56 @@ const KiBuddyProductIntegrityGate: React.FC<KiBuddyProductIntegrityGateProps> = 
         }}
       />
     </div>
+  );
+};
+
+/** Validates product-owned MCP requirements after Ki-Buddy authentication and catalog startup. */
+export const KiBuddyMcpProductIntegrityGate: React.FC<PropsWithChildren<{ enabled: boolean }>> = ({
+  children,
+  enabled,
+}) => {
+  const { t } = useTranslation();
+  const [resourceState, setResourceState] = useState<ProductBuiltinResourceState>({ status: 'pending', missing: [] });
+
+  useEffect(() => {
+    if (!enabled) return;
+    let active = true;
+    void loadProductBuiltinMcpResourceState()
+      .then((state) => {
+        if (active) setResourceState(state);
+      })
+      .catch((error) => {
+        console.error('[Ki-Buddy] Failed to validate product MCP resources:', error);
+      });
+    return () => {
+      active = false;
+    };
+  }, [enabled]);
+
+  const missingResource = enabled && resourceState.status === 'invalid' ? resourceState.missing[0] : undefined;
+  if (!missingResource) return children;
+
+  const resourceLabel = missingResource.resourceName || missingResource.resourceId;
+  const description = getRuntimeComponentInstallationDescription(t, resourceLabel);
+  return (
+    <>
+      {children}
+      <InstallationIntegrityModalHost
+        closable
+        description={description}
+        diagnostics={{
+          source: 'runtime_status',
+          description,
+          runtime: {
+            failureKind: missingResource.code,
+            message: missingResource.code,
+            resource: 'product-builtin-mcp',
+            resourceId: missingResource.resourceId,
+            scopeKind: 'application',
+          },
+        }}
+      />
+    </>
   );
 };
 

--- a/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpManagement.tsx
+++ b/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpManagement.tsx
@@ -19,8 +19,11 @@ const isOAuthCapableServer = (server: IMcpServer) =>
 
 const McpManagement: React.FC<McpManagementProps> = ({ message }) => {
   const { t } = useTranslation();
-  const { mcpServers, extensionMcpServers, saveMcpServers, setMcpServers } = useMcpServers();
-  const visibleMcpServers = React.useMemo(() => mcpServers.filter(isVisibleMcpServer), [mcpServers]);
+  const { mcpServers, mcpCatalogEntries, extensionMcpCatalogEntries, saveMcpServers, setMcpServers } = useMcpServers();
+  const visibleMcpEntries = React.useMemo(
+    () => mcpCatalogEntries.filter(({ server }) => isVisibleMcpServer(server)),
+    [mcpCatalogEntries]
+  );
   const { oauthStatus, loggingIn, checkOAuthStatus, markLoginRequired, clearLoginRequired, login } = useMcpOAuth();
   const handleAuthRequired = React.useCallback(
     (server: IMcpServer) => {
@@ -167,13 +170,14 @@ const McpManagement: React.FC<McpManagementProps> = ({ message }) => {
         name='mcp-servers'
       >
         <div>
-          {visibleMcpServers.length === 0 && extensionMcpServers.length === 0 ? (
+          {visibleMcpEntries.length === 0 && extensionMcpCatalogEntries.length === 0 ? (
             <div className='py-8 text-center text-t-secondary'>{t('settings.mcpNoServersFound')}</div>
           ) : (
-            visibleMcpServers.map((server) => (
+            visibleMcpEntries.map(({ server, access }) => (
               <McpServerItem
                 key={server.id}
                 server={server}
+                access={access}
                 isCollapsed={mcpCollapseKey[server.id] || false}
                 isTestingConnection={testingServers[server.id] || false}
                 oauthStatus={oauthStatus[server.id]}
@@ -186,10 +190,11 @@ const McpManagement: React.FC<McpManagementProps> = ({ message }) => {
               />
             ))
           )}
-          {extensionMcpServers.map((server) => (
+          {extensionMcpCatalogEntries.map(({ server, access }) => (
             <McpServerItem
               key={server.id}
               server={server}
+              access={access}
               isCollapsed={mcpCollapseKey[server.id] || false}
               isTestingConnection={false}
               onToggleCollapse={() => toggleServerCollapse(server.id)}

--- a/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpServerHeader.tsx
+++ b/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpServerHeader.tsx
@@ -6,9 +6,11 @@ import { useTranslation } from 'react-i18next';
 import type { McpOAuthStatus } from '@/renderer/hooks/mcp/useMcpOAuth';
 import FeedbackButton from '@/renderer/components/base/FeedbackButton';
 import { iconColors } from '@/renderer/styles/colors';
+import type { ProductResourceAccess } from '@/common/platform/ki-buddy';
 
 interface McpServerHeaderProps {
   server: IMcpServer;
+  access?: ProductResourceAccess;
   isTestingConnection: boolean;
   oauthStatus?: McpOAuthStatus;
   isLoggingIn?: boolean;
@@ -144,6 +146,7 @@ const supportsOAuth = (server: IMcpServer) =>
 
 const McpServerHeader: React.FC<McpServerHeaderProps> = ({
   server,
+  access = 'manage',
   isTestingConnection,
   oauthStatus,
   isLoggingIn,
@@ -162,6 +165,8 @@ const McpServerHeader: React.FC<McpServerHeaderProps> = ({
   const statusPopoverContent = getStatusPopoverContent(server, t);
 
   const isError = server.last_test_status === 'error';
+  const canManage = access === 'manage' && !isReadOnly;
+  const canTest = access === 'use' || canManage;
 
   return (
     <div className='flex items-center justify-between group'>
@@ -177,7 +182,7 @@ const McpServerHeader: React.FC<McpServerHeaderProps> = ({
           </Tooltip>
         )}
         {isError && <FeedbackButton module='mcp-tools' />}
-        {!isReadOnly && needsLogin && onOAuthLogin && (
+        {canManage && needsLogin && onOAuthLogin && (
           <Button
             size='mini'
             type='primary'
@@ -189,7 +194,7 @@ const McpServerHeader: React.FC<McpServerHeaderProps> = ({
             {t('settings.mcpLogin') || 'Login'}
           </Button>
         )}
-        {!isReadOnly && !needsLogin && (
+        {canTest && (!needsLogin || access === 'use') && (
           <Button
             size='mini'
             icon={<Refresh size={'14'} />}
@@ -199,7 +204,7 @@ const McpServerHeader: React.FC<McpServerHeaderProps> = ({
           />
         )}
       </div>
-      {!isReadOnly && (
+      {canManage && (
         <div className='flex items-center gap-2 invisible group-hover:visible' onClick={(e) => e.stopPropagation()}>
           {!server.builtin && (
             <Dropdown

--- a/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpServerItem.tsx
+++ b/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpServerItem.tsx
@@ -4,9 +4,11 @@ import type { IMcpServer } from '@/common/config/storage';
 import McpServerHeader from './McpServerHeader';
 import McpServerToolsList from './McpServerToolsList';
 import type { McpOAuthStatus } from '@/renderer/hooks/mcp/useMcpOAuth';
+import type { ProductResourceAccess } from '@/common/platform/ki-buddy';
 
 interface McpServerItemProps {
   server: IMcpServer;
+  access?: ProductResourceAccess;
   isCollapsed: boolean;
   isTestingConnection: boolean;
   oauthStatus?: McpOAuthStatus;
@@ -22,6 +24,7 @@ interface McpServerItemProps {
 
 const McpServerItem: React.FC<McpServerItemProps> = ({
   server,
+  access,
   isCollapsed,
   isTestingConnection,
   oauthStatus,
@@ -44,6 +47,7 @@ const McpServerItem: React.FC<McpServerItemProps> = ({
         header={
           <McpServerHeader
             server={server}
+            access={access}
             isTestingConnection={isTestingConnection}
             oauthStatus={oauthStatus}
             isLoggingIn={isLoggingIn}

--- a/tests/unit/common-platform/kiBuddyProductConfig.test.ts
+++ b/tests/unit/common-platform/kiBuddyProductConfig.test.ts
@@ -162,7 +162,7 @@ describe('Ki-Buddy product configuration', () => {
       themes: { light: 'ki-buddy-light', dark: 'ki-buddy-dark' },
       experience: {
         schemaVersion: 1,
-        features: { team: 'disabled', scheduledTasks: 'enabled' },
+        features: { team: 'disabled', scheduledTasks: 'enabled', tools: 'enabled' },
       },
     });
   });

--- a/tests/unit/common-platform/productExperience.test.ts
+++ b/tests/unit/common-platform/productExperience.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+  PRODUCT_RESOURCE_ORIGINS,
   createAionUiProductExperience,
   createKiBuddyProductExperience,
+  evaluateProductBuiltinResourceState,
   parseProductExperiencePolicy,
+  projectProductResources,
 } from '@/common/platform/ki-buddy/productExperience';
 
 const validPolicy = {
@@ -78,6 +81,105 @@ const validPolicy = {
 } as const;
 
 describe('ProductExperience interface', () => {
+  it('projects visible MCP resources and records hidden resources without exposing their configuration', () => {
+    const experience = createKiBuddyProductExperience(validPolicy);
+    const projection = projectProductResources(experience, 'mcp', [
+      { id: 'agents-adapter', name: 'Agents Adapter', origin: 'productBuiltin' },
+      { id: 'custom-server', name: 'Custom server', origin: 'custom' },
+      { id: 'upstream-server', name: 'Upstream server', origin: 'upstreamBuiltin' },
+      { id: 'unknown-server', name: 'Unknown server', origin: 'unclassified' },
+    ]);
+
+    expect(projection.visible).toEqual([
+      {
+        resource: { id: 'agents-adapter', name: 'Agents Adapter', origin: 'productBuiltin' },
+        access: 'use',
+      },
+      {
+        resource: { id: 'custom-server', name: 'Custom server', origin: 'custom' },
+        access: 'manage',
+      },
+    ]);
+    expect(projection.hidden).toEqual([
+      {
+        code: 'product_resource_hidden',
+        kind: 'mcp',
+        resourceId: 'upstream-server',
+        resourceName: 'Upstream server',
+        origin: 'upstreamBuiltin',
+        access: 'hidden',
+      },
+      {
+        code: 'product_resource_hidden',
+        kind: 'mcp',
+        resourceId: 'unknown-server',
+        resourceName: 'Unknown server',
+        origin: 'unclassified',
+        access: 'hidden',
+      },
+    ]);
+  });
+
+  it('reports installation integrity when an enabled feature requires a missing product built-in MCP', () => {
+    const experience = createKiBuddyProductExperience(validPolicy);
+
+    expect(
+      evaluateProductBuiltinResourceState(experience, 'mcp', {
+        availableResourceIds: [],
+        catalogReady: true,
+        requirements: [{ featureId: 'agents', resourceId: 'agents-adapter', resourceName: 'Agents Adapter' }],
+      })
+    ).toEqual({
+      status: 'invalid',
+      missing: [
+        {
+          code: 'required_product_resource_missing',
+          featureId: 'agents',
+          kind: 'mcp',
+          origin: 'productBuiltin',
+          resourceId: 'agents-adapter',
+          resourceName: 'Agents Adapter',
+        },
+      ],
+    });
+  });
+
+  it('does not require an Agents Adapter MCP before a product resource requirement is declared', () => {
+    const experience = createKiBuddyProductExperience(validPolicy);
+
+    expect(
+      evaluateProductBuiltinResourceState(experience, 'mcp', {
+        availableResourceIds: [],
+        catalogReady: false,
+        requirements: [],
+      })
+    ).toEqual({ status: 'ready', missing: [] });
+  });
+
+  it('waits for the backend catalog before judging a declared product built-in MCP requirement', () => {
+    const experience = createKiBuddyProductExperience(validPolicy);
+
+    expect(
+      evaluateProductBuiltinResourceState(experience, 'mcp', {
+        availableResourceIds: [],
+        catalogReady: false,
+        requirements: [{ featureId: 'agents', resourceId: 'agents-adapter' }],
+      })
+    ).toEqual({ status: 'pending', missing: [] });
+  });
+
+  it('accepts a declared product built-in MCP when the backend catalog contains its stable ID', () => {
+    const experience = createKiBuddyProductExperience(validPolicy);
+
+    expect(
+      evaluateProductBuiltinResourceState(experience, 'mcp', {
+        availableResourceIds: ['agents-adapter'],
+        catalogReady: true,
+        requirements: [{ featureId: 'agents', resourceId: 'agents-adapter' }],
+      })
+    ).toEqual({ status: 'ready', missing: [] });
+  });
+
   it('keeps the complete AionUi feature and resource behavior when no product capability exists', () => {
     const experience = createAionUiProductExperience();
 
@@ -87,6 +189,27 @@ describe('ProductExperience interface', () => {
       scheduledTaskExecutor: 'assistant-or-team',
       autoInjectedSkillExclusions: [],
     });
+  });
+
+  it('keeps every MCP origin visible and manageable in the AionUi adapter', () => {
+    const experience = createAionUiProductExperience();
+    const projection = projectProductResources(
+      experience,
+      'mcp',
+      PRODUCT_RESOURCE_ORIGINS.map((origin) => ({
+        id: origin,
+        origin,
+      }))
+    );
+
+    expect(projection.visible.map(({ resource, access }) => ({ id: resource.id, access }))).toEqual([
+      { id: 'productBuiltin', access: 'manage' },
+      { id: 'upstreamBuiltin', access: 'manage' },
+      { id: 'custom', access: 'manage' },
+      { id: 'extension', access: 'manage' },
+      { id: 'unclassified', access: 'manage' },
+    ]);
+    expect(projection.hidden).toEqual([]);
   });
 
   it('provides feature, resource, and behavior decisions without exposing the product JSON', () => {

--- a/tests/unit/feedback/McpServerHeaderFeedback.dom.test.tsx
+++ b/tests/unit/feedback/McpServerHeaderFeedback.dom.test.tsx
@@ -24,6 +24,7 @@ vi.mock('@/renderer/hooks/context/FeedbackContext', () => ({
 
 import McpServerHeader from '@/renderer/pages/settings/ToolsSettings/McpServerHeader';
 import type { IMcpServer } from '@/common/config/storage';
+import type { ProductResourceAccess } from '@/common/platform/ki-buddy';
 
 const buildServer = (last_test_status: IMcpServer['last_test_status']): IMcpServer =>
   ({
@@ -44,10 +45,10 @@ const commonProps = {
   onDeleteServer: vi.fn(),
 };
 
-const renderHeader = (last_test_status: IMcpServer['last_test_status']) =>
+const renderHeader = (last_test_status: IMcpServer['last_test_status'], access?: ProductResourceAccess) =>
   render(
     <ConfigProvider>
-      <McpServerHeader server={buildServer(last_test_status)} {...commonProps} />
+      <McpServerHeader server={buildServer(last_test_status)} access={access} {...commonProps} />
     </ConfigProvider>
   );
 
@@ -85,5 +86,35 @@ describe('McpServerHeader — FeedbackButton wiring', () => {
       module: 'mcp-tools',
       autoScreenshot: true,
     });
+  });
+
+  it('allows product built-in use access to run a connection test without exposing management actions', () => {
+    renderHeader('connected', 'use');
+
+    expect(screen.getByTitle('settings.mcpTestConnection')).toBeInTheDocument();
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+  });
+
+  it('keeps connection testing and management actions for manage access', () => {
+    renderHeader('connected', 'manage');
+
+    expect(screen.getByTitle('settings.mcpTestConnection')).toBeInTheDocument();
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+  });
+
+  it('keeps connection testing available for use access when the last test requested authentication', () => {
+    render(
+      <ConfigProvider>
+        <McpServerHeader
+          server={buildServer('disconnected')}
+          access='use'
+          oauthStatus={{ needsLogin: true, isChecking: false, isAuthenticated: false }}
+          {...commonProps}
+        />
+      </ConfigProvider>
+    );
+
+    expect(screen.getByTitle('settings.mcpTestConnection')).toBeInTheDocument();
+    expect(screen.queryByTitle('settings.mcpLogin')).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/renderer/hooks/mcpCatalog.dom.test.ts
+++ b/tests/unit/renderer/hooks/mcpCatalog.dom.test.ts
@@ -22,6 +22,8 @@ vi.mock('@/common/adapter/ipcBridge', () => ({
 }));
 
 import { ensureBackendMcpCatalog } from '@/renderer/hooks/mcp/catalog';
+import { createKiBuddyProductExperience } from '@/common/platform/ki-buddy';
+import productConfig from '../../../../ki-buddy-product.json';
 
 describe('ensureBackendMcpCatalog', () => {
   beforeEach(() => {
@@ -82,5 +84,94 @@ describe('ensureBackendMcpCatalog', () => {
     expect(result.userServers).toEqual([]);
     expect(result.builtinServers).toEqual([]);
     expect(result.allServers).toEqual([]);
+  });
+
+  it('preserves AionUi cross-source deduplication for the same built-in MCP name', async () => {
+    getClientBusinessSettingMock.mockResolvedValue([
+      {
+        id: 'local-builtin',
+        name: 'shared builtin',
+        enabled: true,
+        transport: { type: 'stdio', command: 'local', args: [] },
+        created_at: 1,
+        updated_at: 1,
+        original_json: '{}',
+        builtin: true,
+      },
+    ]);
+    mcpServiceMock.listServers.invoke.mockResolvedValue([
+      {
+        id: 'backend-builtin',
+        name: 'shared builtin',
+        enabled: true,
+        transport: { type: 'stdio', command: 'backend', args: [] },
+        created_at: 2,
+        updated_at: 2,
+        original_json: '{}',
+        builtin: true,
+      },
+    ]);
+
+    const result = await ensureBackendMcpCatalog();
+
+    expect(result.allServers.map(({ id }) => id)).toEqual(['backend-builtin']);
+  });
+
+  it('keeps custom and product built-in MCP entries while recording disallowed and unknown origins', async () => {
+    getClientBusinessSettingMock.mockResolvedValue([
+      {
+        id: 'upstream-1',
+        name: 'upstream one',
+        enabled: true,
+        transport: { type: 'stdio', command: 'upstream', args: [] },
+        created_at: 1,
+        updated_at: 1,
+        original_json: '{}',
+        builtin: true,
+      },
+    ]);
+    mcpServiceMock.listServers.invoke.mockResolvedValue([
+      {
+        id: 'agents-adapter',
+        name: 'Agents Adapter',
+        enabled: true,
+        transport: { type: 'stdio', command: 'managed-adapter', args: [] },
+        created_at: 2,
+        updated_at: 2,
+        original_json: '{}',
+        product_origin: 'productBuiltin',
+      },
+      {
+        id: 'custom-1',
+        name: 'custom one',
+        enabled: true,
+        transport: { type: 'http', url: 'https://example.com/mcp' },
+        created_at: 3,
+        updated_at: 3,
+        original_json: '{}',
+      },
+      {
+        id: 'unknown-1',
+        name: 'unknown one',
+        enabled: true,
+        transport: { type: 'stdio', command: 'unknown', args: [] },
+        created_at: 4,
+        updated_at: 4,
+        original_json: '{}',
+        product_origin: 'future-origin',
+      },
+    ]);
+
+    const result = await ensureBackendMcpCatalog(createKiBuddyProductExperience(productConfig.experience));
+
+    expect(result.entries.map(({ server, origin, access }) => ({ id: server.id, origin, access }))).toEqual([
+      { id: 'agents-adapter', origin: 'productBuiltin', access: 'use' },
+      { id: 'custom-1', origin: 'custom', access: 'manage' },
+    ]);
+    expect(result.allServers.map(({ id }) => id)).toEqual(['agents-adapter', 'custom-1']);
+    expect(result.hiddenResources).toEqual([
+      expect.objectContaining({ resourceId: 'unknown-1', origin: 'unclassified' }),
+      expect.objectContaining({ resourceId: 'upstream-1', origin: 'upstreamBuiltin' }),
+    ]);
   });
 });

--- a/tests/unit/renderer/hooks/mcpCatalog.dom.test.ts
+++ b/tests/unit/renderer/hooks/mcpCatalog.dom.test.ts
@@ -21,7 +21,7 @@ vi.mock('@/common/adapter/ipcBridge', () => ({
   mcpService: mcpServiceMock,
 }));
 
-import { ensureBackendMcpCatalog } from '@/renderer/hooks/mcp/catalog';
+import { ensureBackendMcpCatalog, loadProductBuiltinMcpResourceState } from '@/renderer/hooks/mcp/catalog';
 import { createKiBuddyProductExperience } from '@/common/platform/ki-buddy';
 import productConfig from '../../../../ki-buddy-product.json';
 
@@ -173,5 +173,68 @@ describe('ensureBackendMcpCatalog', () => {
       expect.objectContaining({ resourceId: 'unknown-1', origin: 'unclassified' }),
       expect.objectContaining({ resourceId: 'upstream-1', origin: 'upstreamBuiltin' }),
     ]);
+  });
+});
+
+describe('loadProductBuiltinMcpResourceState', () => {
+  const experience = createKiBuddyProductExperience(productConfig.experience);
+  const requirements = [{ featureId: 'agents' as const, resourceId: 'agents-adapter', resourceName: 'Agents Adapter' }];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not require a product MCP before its owning feature registers one', async () => {
+    const result = await loadProductBuiltinMcpResourceState(experience);
+
+    expect(result).toEqual({ status: 'ready', missing: [] });
+    expect(mcpServiceMock.listServers.invoke).not.toHaveBeenCalled();
+  });
+
+  it('reports an installation-integrity failure after a ready catalog omits a required product MCP', async () => {
+    mcpServiceMock.listServers.invoke.mockResolvedValue([]);
+
+    const result = await loadProductBuiltinMcpResourceState(experience, requirements);
+
+    expect(result).toEqual({
+      status: 'invalid',
+      missing: [
+        {
+          code: 'required_product_resource_missing',
+          featureId: 'agents',
+          kind: 'mcp',
+          origin: 'productBuiltin',
+          resourceId: 'agents-adapter',
+          resourceName: 'Agents Adapter',
+        },
+      ],
+    });
+  });
+
+  it('accepts a required product MCP by stable backend ID instead of display name', async () => {
+    mcpServiceMock.listServers.invoke.mockResolvedValue([
+      {
+        id: 'agents-adapter',
+        name: 'Renamed by backend',
+        enabled: true,
+        transport: { type: 'stdio', command: 'managed-adapter', args: [] },
+        created_at: 1,
+        updated_at: 1,
+        original_json: '{}',
+        product_origin: 'productBuiltin',
+      },
+    ]);
+
+    const result = await loadProductBuiltinMcpResourceState(experience, requirements);
+
+    expect(result).toEqual({ status: 'ready', missing: [] });
+  });
+
+  it('keeps the requirement pending when the backend catalog cannot be read', async () => {
+    mcpServiceMock.listServers.invoke.mockRejectedValue(new Error('catalog unavailable'));
+
+    const result = await loadProductBuiltinMcpResourceState(experience, requirements);
+
+    expect(result).toEqual({ status: 'pending', missing: [] });
   });
 });

--- a/tests/unit/renderer/hooks/useMcpServers.dom.test.ts
+++ b/tests/unit/renderer/hooks/useMcpServers.dom.test.ts
@@ -7,20 +7,27 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 
-const { ensureBackendMcpCatalogMock } = vi.hoisted(() => ({
+const { ensureBackendMcpCatalogMock, getExtensionMcpServersMock, getProductExperienceMock } = vi.hoisted(() => ({
   ensureBackendMcpCatalogMock: vi.fn(),
+  getExtensionMcpServersMock: vi.fn(),
+  getProductExperienceMock: vi.fn(),
 }));
 
 vi.mock('@/common', () => ({
   ipcBridge: {
     extensions: {
-      getMcpServers: { invoke: vi.fn().mockResolvedValue([]) },
+      getMcpServers: { invoke: getExtensionMcpServersMock },
     },
   },
 }));
 
-vi.mock('@/renderer/hooks/mcp/catalog', () => ({
+vi.mock('@/renderer/hooks/mcp/catalog', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/renderer/hooks/mcp/catalog')>()),
   ensureBackendMcpCatalog: ensureBackendMcpCatalogMock,
+}));
+
+vi.mock('@/renderer/services/runtime/kiBuddyRuntime', () => ({
+  getProductExperience: getProductExperienceMock,
 }));
 
 import { useMcpServers } from '@/renderer/hooks/mcp/useMcpServers';
@@ -28,10 +35,19 @@ import { useMcpServers } from '@/renderer/hooks/mcp/useMcpServers';
 describe('useMcpServers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getExtensionMcpServersMock.mockResolvedValue([]);
+    getProductExperienceMock.mockReturnValue({
+      behaviorDefaults: () => ({ scheduledTaskExecutor: 'assistant', autoInjectedSkillExclusions: [] }),
+      featureState: () => 'enabled',
+      resourceAccess: (_kind: string, origin: string) =>
+        origin === 'custom' ? 'manage' : origin === 'productBuiltin' ? 'use' : 'hidden',
+    });
     ensureBackendMcpCatalogMock.mockResolvedValue({
       userServers: [],
       builtinServers: [],
       allServers: [],
+      entries: [],
+      hiddenResources: [],
     });
   });
 
@@ -75,5 +91,98 @@ describe('useMcpServers', () => {
     });
 
     await waitFor(() => expect(result.current.mcpServers).toHaveLength(1));
+  });
+
+  it('hides extension MCP servers and retains a structured diagnostic record in Ki-Buddy', async () => {
+    getExtensionMcpServersMock.mockResolvedValue([
+      {
+        id: 'extension-1',
+        name: 'extension server',
+        enabled: true,
+        transport: { type: 'stdio', command: 'extension', args: [] },
+        created_at: 1,
+        updated_at: 1,
+        original_json: '{}',
+      },
+    ]);
+
+    const { result } = renderHook(() => useMcpServers());
+
+    await waitFor(() => expect(getExtensionMcpServersMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.hiddenResources).toHaveLength(1));
+
+    expect(result.current.extensionMcpServers).toEqual([]);
+    expect(result.current.hiddenResources).toEqual([
+      expect.objectContaining({
+        code: 'product_resource_hidden',
+        kind: 'mcp',
+        resourceId: 'extension-1',
+        origin: 'extension',
+      }),
+    ]);
+  });
+
+  it('keeps extension MCP servers visible under the complete AionUi resource policy', async () => {
+    getProductExperienceMock.mockReturnValue({
+      behaviorDefaults: () => ({ scheduledTaskExecutor: 'assistant-or-team', autoInjectedSkillExclusions: [] }),
+      featureState: () => 'enabled',
+      resourceAccess: () => 'manage',
+    });
+    getExtensionMcpServersMock.mockResolvedValue([
+      {
+        id: 'extension-1',
+        name: 'extension server',
+        enabled: true,
+        transport: { type: 'stdio', command: 'extension', args: [] },
+        created_at: 1,
+        updated_at: 1,
+        original_json: '{}',
+      },
+    ]);
+
+    const { result } = renderHook(() => useMcpServers());
+
+    await waitFor(() => expect(result.current.extensionMcpServers).toHaveLength(1));
+
+    expect(result.current.extensionMcpCatalogEntries).toEqual([
+      expect.objectContaining({ origin: 'extension', access: 'manage' }),
+    ]);
+    expect(result.current.hiddenResources).toEqual([]);
+  });
+
+  it('keeps access decisions separate when backend entries reuse an ID with different names', async () => {
+    const customServer = {
+      id: 'shared-id',
+      name: 'custom server',
+      enabled: true,
+      transport: { type: 'stdio', command: 'custom', args: [] },
+      created_at: 1,
+      updated_at: 1,
+      original_json: '{}',
+    };
+    const productServer = {
+      ...customServer,
+      name: 'product server',
+      transport: { type: 'stdio' as const, command: 'product', args: [] },
+    };
+    ensureBackendMcpCatalogMock.mockResolvedValue({
+      userServers: [customServer, productServer],
+      builtinServers: [],
+      allServers: [customServer, productServer],
+      entries: [
+        { server: customServer, origin: 'custom', access: 'manage' },
+        { server: productServer, origin: 'productBuiltin', access: 'use' },
+      ],
+      hiddenResources: [],
+    });
+
+    const { result } = renderHook(() => useMcpServers());
+
+    await waitFor(() => expect(result.current.mcpCatalogEntries).toHaveLength(2));
+
+    expect(result.current.mcpCatalogEntries.map(({ server, access }) => ({ name: server.name, access }))).toEqual([
+      { name: 'custom server', access: 'manage' },
+      { name: 'product server', access: 'use' },
+    ]);
   });
 });

--- a/tests/unit/renderer/hooks/useMcpServers.dom.test.ts
+++ b/tests/unit/renderer/hooks/useMcpServers.dom.test.ts
@@ -7,10 +7,16 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 
-const { ensureBackendMcpCatalogMock, getExtensionMcpServersMock, getProductExperienceMock } = vi.hoisted(() => ({
+const {
+  ensureBackendMcpCatalogMock,
+  getExtensionMcpServersMock,
+  getProductExperienceMock,
+  projectMcpCatalogCandidatesMock,
+} = vi.hoisted(() => ({
   ensureBackendMcpCatalogMock: vi.fn(),
   getExtensionMcpServersMock: vi.fn(),
   getProductExperienceMock: vi.fn(),
+  projectMcpCatalogCandidatesMock: vi.fn(),
 }));
 
 vi.mock('@/common', () => ({
@@ -21,10 +27,17 @@ vi.mock('@/common', () => ({
   },
 }));
 
-vi.mock('@/renderer/hooks/mcp/catalog', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@/renderer/hooks/mcp/catalog')>()),
-  ensureBackendMcpCatalog: ensureBackendMcpCatalogMock,
-}));
+vi.mock('@/renderer/hooks/mcp/catalog', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/renderer/hooks/mcp/catalog')>();
+  return {
+    ...original,
+    ensureBackendMcpCatalog: ensureBackendMcpCatalogMock,
+    projectMcpCatalogCandidates: (...args: Parameters<typeof original.projectMcpCatalogCandidates>) => {
+      projectMcpCatalogCandidatesMock(...args);
+      return original.projectMcpCatalogCandidates(...args);
+    },
+  };
+});
 
 vi.mock('@/renderer/services/runtime/kiBuddyRuntime', () => ({
   getProductExperience: getProductExperienceMock,
@@ -58,6 +71,30 @@ describe('useMcpServers', () => {
 
     expect(ensureBackendMcpCatalogMock).toHaveBeenCalledTimes(1);
     expect(result.current.mcpServers).toEqual([]);
+  });
+
+  it('keeps backend catalog entries authoritative without reapplying product policy', async () => {
+    const server = {
+      id: 'product-1',
+      name: 'product server',
+      enabled: true,
+      transport: { type: 'stdio' as const, command: 'product', args: [] },
+      created_at: 1,
+      updated_at: 1,
+      original_json: '{}',
+    };
+    ensureBackendMcpCatalogMock.mockResolvedValue({
+      userServers: [server],
+      builtinServers: [],
+      allServers: [server],
+      entries: [{ server, origin: 'productBuiltin', access: 'use' }],
+      hiddenResources: [],
+    });
+
+    const { result } = renderHook(() => useMcpServers());
+
+    await waitFor(() => expect(result.current.mcpCatalogEntries).toHaveLength(1));
+    expect(projectMcpCatalogCandidatesMock).not.toHaveBeenCalled();
   });
 
   it('does not fall back to configService business data when MCP catalog loading fails', async () => {
@@ -147,7 +184,40 @@ describe('useMcpServers', () => {
     expect(result.current.extensionMcpCatalogEntries).toEqual([
       expect.objectContaining({ origin: 'extension', access: 'manage' }),
     ]);
+    expect(projectMcpCatalogCandidatesMock).toHaveBeenCalledTimes(1);
     expect(result.current.hiddenResources).toEqual([]);
+  });
+
+  it('preserves access for an existing backend entry when its server state changes', async () => {
+    const server = {
+      id: 'product-1',
+      name: 'product server',
+      enabled: true,
+      transport: { type: 'stdio' as const, command: 'product', args: [] },
+      created_at: 1,
+      updated_at: 1,
+      original_json: '{}',
+    };
+    ensureBackendMcpCatalogMock.mockResolvedValue({
+      userServers: [server],
+      builtinServers: [],
+      allServers: [server],
+      entries: [{ server, origin: 'productBuiltin', access: 'use' }],
+      hiddenResources: [],
+    });
+    const { result } = renderHook(() => useMcpServers());
+    await waitFor(() => expect(result.current.mcpCatalogEntries).toHaveLength(1));
+    projectMcpCatalogCandidatesMock.mockClear();
+
+    act(() => {
+      void result.current.saveMcpServers((servers) =>
+        servers.map((current) => (current.id === server.id ? { ...current, last_test_status: 'connected' } : current))
+      );
+    });
+
+    await waitFor(() => expect(result.current.mcpServers[0].last_test_status).toBe('connected'));
+    expect(result.current.mcpCatalogEntries[0].access).toBe('use');
+    expect(projectMcpCatalogCandidatesMock).not.toHaveBeenCalled();
   });
 
   it('keeps access decisions separate when backend entries reuse an ID with different names', async () => {

--- a/tests/unit/renderer/ki-buddy/KiBuddyProductIntegrityGate.dom.test.tsx
+++ b/tests/unit/renderer/ki-buddy/KiBuddyProductIntegrityGate.dom.test.tsx
@@ -1,17 +1,117 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { expect, it, vi } from 'vitest';
+import { beforeEach, expect, it, vi } from 'vitest';
 
-vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
-vi.mock('@/renderer/components/layout/InstallationIntegrityDialog', () => ({
-  InstallationIntegrityModalHost: ({ description }: { description: string }) => <div>{description}</div>,
+const { loadProductBuiltinMcpResourceStateMock } = vi.hoisted(() => ({
+  loadProductBuiltinMcpResourceStateMock: vi.fn(),
 }));
 
-import KiBuddyProductIntegrityGate from '@/renderer/pages/ki-buddy/KiBuddyProductIntegrityGate';
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { resource?: string }) => (options?.resource ? `${key}:${options.resource}` : key),
+  }),
+}));
+vi.mock('@/renderer/components/layout/InstallationIntegrityDialog', () => ({
+  getRuntimeComponentInstallationDescription: (_t: unknown, resource: string) =>
+    `common.backendStartup.incompleteInstallation.runtimeComponentDescription:${resource}`,
+  InstallationIntegrityModalHost: ({
+    closable,
+    description,
+    diagnostics,
+  }: {
+    closable?: boolean;
+    description: string;
+    diagnostics?: { runtime?: { resourceId?: string } };
+  }) => (
+    <div>
+      <span>{description}</span>
+      <span>{diagnostics?.runtime?.resourceId}</span>
+      <span>{closable ? 'closable integrity notice' : 'blocking integrity notice'}</span>
+    </div>
+  ),
+}));
+vi.mock('@/renderer/hooks/mcp/catalog', () => ({
+  loadProductBuiltinMcpResourceState: loadProductBuiltinMcpResourceStateMock,
+}));
+
+import KiBuddyProductIntegrityGate, {
+  KiBuddyMcpProductIntegrityGate,
+} from '@/renderer/pages/ki-buddy/KiBuddyProductIntegrityGate';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  loadProductBuiltinMcpResourceStateMock.mockResolvedValue({ status: 'ready', missing: [] });
+});
 
 it('shows an installation-integrity error instead of AionUi business content for an invalid Ki-Buddy policy', () => {
   render(<KiBuddyProductIntegrityGate failure='Product experience features has invalid fields: missing team' />);
 
   expect(screen.getByText('login.kiBuddy.productExperience.invalidPolicyDescription')).toBeInTheDocument();
   expect(screen.queryByText('AionUi business content')).not.toBeInTheDocument();
+});
+
+it('does not load the MCP catalog outside the authenticated Ki-Buddy product path', () => {
+  render(
+    <KiBuddyMcpProductIntegrityGate enabled={false}>
+      <div>AionUi business content</div>
+    </KiBuddyMcpProductIntegrityGate>
+  );
+
+  expect(screen.getByText('AionUi business content')).toBeInTheDocument();
+  expect(loadProductBuiltinMcpResourceStateMock).not.toHaveBeenCalled();
+});
+
+it('keeps business content available when registered product MCP resources are present', async () => {
+  render(
+    <KiBuddyMcpProductIntegrityGate enabled>
+      <div>Ki-Buddy business content</div>
+    </KiBuddyMcpProductIntegrityGate>
+  );
+
+  await waitFor(() => expect(loadProductBuiltinMcpResourceStateMock).toHaveBeenCalledOnce());
+  expect(screen.getByText('Ki-Buddy business content')).toBeInTheDocument();
+});
+
+it('shows installation integrity diagnostics when a required product MCP is missing', async () => {
+  loadProductBuiltinMcpResourceStateMock.mockResolvedValue({
+    status: 'invalid',
+    missing: [
+      {
+        code: 'required_product_resource_missing',
+        featureId: 'agents',
+        kind: 'mcp',
+        origin: 'productBuiltin',
+        resourceId: 'agents-adapter',
+        resourceName: 'Agents Adapter',
+      },
+    ],
+  });
+
+  render(
+    <KiBuddyMcpProductIntegrityGate enabled>
+      <div>Ki-Buddy business content</div>
+    </KiBuddyMcpProductIntegrityGate>
+  );
+
+  expect(
+    await screen.findByText('common.backendStartup.incompleteInstallation.runtimeComponentDescription:Agents Adapter')
+  ).toBeInTheDocument();
+  expect(screen.getByText('agents-adapter')).toBeInTheDocument();
+  expect(screen.getByText('closable integrity notice')).toBeInTheDocument();
+  expect(screen.getByText('Ki-Buddy business content')).toBeInTheDocument();
+});
+
+it('does not misreport an installation failure when catalog loading throws', async () => {
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  loadProductBuiltinMcpResourceStateMock.mockRejectedValue(new Error('catalog unavailable'));
+
+  render(
+    <KiBuddyMcpProductIntegrityGate enabled>
+      <div>Ki-Buddy business content</div>
+    </KiBuddyMcpProductIntegrityGate>
+  );
+
+  await waitFor(() => expect(consoleError).toHaveBeenCalled());
+  expect(screen.getByText('Ki-Buddy business content')).toBeInTheDocument();
+  consoleError.mockRestore();
 });

--- a/tests/unit/renderer/layout/InstallationIntegrityDialog.dom.test.tsx
+++ b/tests/unit/renderer/layout/InstallationIntegrityDialog.dom.test.tsx
@@ -43,6 +43,7 @@ vi.mock('@/renderer/services/feedback/submitFeedbackReport', () => ({
 import {
   type InstallationIntegrityDiagnostics,
   InstallationIntegrityFooter,
+  showInstallationIntegrityModal,
 } from '@/renderer/components/layout/InstallationIntegrityDialog';
 
 const diagnostics: InstallationIntegrityDiagnostics = { source: 'backend_startup_failure' };
@@ -145,4 +146,26 @@ describe('InstallationIntegrityDialog — recoverable_database_corruption recove
     // by scripts/check-i18n.js.
     expect(COPY[`${RDC}.description`].toLowerCase()).not.toContain('for now');
   });
+});
+
+it('allows product resource integrity notices to request a close button', () => {
+  const error = vi.fn().mockReturnValue({ close: vi.fn(), update: vi.fn() });
+  const modal = { error } as unknown as Parameters<typeof showInstallationIntegrityModal>[0];
+  const t = ((key: string) => key) as unknown as Parameters<typeof showInstallationIntegrityModal>[1];
+
+  showInstallationIntegrityModal(modal, t, 'Missing product MCP', diagnostics, 'incomplete_installation', {
+    closable: true,
+  });
+
+  expect(error).toHaveBeenCalledWith(expect.objectContaining({ closable: true, maskClosable: false }));
+});
+
+it('keeps installation integrity dialogs blocking by default', () => {
+  const error = vi.fn().mockReturnValue({ close: vi.fn(), update: vi.fn() });
+  const modal = { error } as unknown as Parameters<typeof showInstallationIntegrityModal>[0];
+  const t = ((key: string) => key) as unknown as Parameters<typeof showInstallationIntegrityModal>[1];
+
+  showInstallationIntegrityModal(modal, t, 'Missing runtime component', diagnostics);
+
+  expect(error).toHaveBeenCalledWith(expect.objectContaining({ closable: false, maskClosable: false }));
 });

--- a/tests/unit/settings/ToolsModalContentImageGuide.dom.test.tsx
+++ b/tests/unit/settings/ToolsModalContentImageGuide.dom.test.tsx
@@ -12,7 +12,9 @@ import { SettingsTabNavigateProvider } from '@/renderer/components/settings/Sett
 const hooks = vi.hoisted(() => ({
   modelListWithImage: [] as unknown[],
   mcpServers: [] as unknown[],
+  mcpCatalogEntries: [] as unknown[],
   getClientBusinessSetting: vi.fn(() => Promise.resolve(undefined)),
+  resourceAccess: vi.fn(() => 'manage'),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -37,7 +39,9 @@ vi.mock('@/renderer/pages/settings/components/AddMcpServerModal', () => ({
 }));
 
 vi.mock('@/renderer/pages/settings/ToolsSettings/McpServerItem', () => ({
-  default: () => null,
+  default: ({ server, access }: { server: { id: string }; access?: string }) => (
+    <div data-testid={`mcp-server-${server.id}`}>{access ?? 'missing-access'}</div>
+  ),
 }));
 
 vi.mock('@/renderer/hooks/agent/useConfigModelListWithImage', () => ({
@@ -47,7 +51,9 @@ vi.mock('@/renderer/hooks/agent/useConfigModelListWithImage', () => ({
 vi.mock('@/renderer/hooks/mcp', () => ({
   useMcpServers: () => ({
     mcpServers: hooks.mcpServers,
+    mcpCatalogEntries: hooks.mcpCatalogEntries,
     extensionMcpServers: [],
+    extensionMcpCatalogEntries: [],
     saveMcpServers: vi.fn(() => Promise.resolve()),
     setMcpServers: vi.fn(),
     isMcpServersLoading: false,
@@ -89,6 +95,11 @@ vi.mock('@/renderer/services/clientBusinessSettings', () => ({
   removeClientBusinessSetting: vi.fn(() => Promise.resolve()),
 }));
 
+vi.mock('@/renderer/services/runtime/kiBuddyRuntime', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/renderer/services/runtime/kiBuddyRuntime')>()),
+  getProductExperience: () => ({ resourceAccess: hooks.resourceAccess }),
+}));
+
 vi.mock('@/common/adapter/ipcBridge', () => ({
   mcpService: {},
 }));
@@ -99,6 +110,9 @@ describe('ToolsModalContent image model guide', () => {
   beforeEach(() => {
     hooks.modelListWithImage = [];
     hooks.mcpServers = [];
+    hooks.mcpCatalogEntries = [];
+    hooks.resourceAccess.mockReset();
+    hooks.resourceAccess.mockReturnValue('manage');
     hooks.getClientBusinessSetting.mockClear();
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
@@ -144,5 +158,34 @@ describe('ToolsModalContent image model guide', () => {
       (a) => a.textContent === 'settings.goToModelSettings'
     );
     expect(links).toHaveLength(0);
+  });
+
+  it('passes product built-in use access to the MCP item rendered on the Tools page', async () => {
+    const server = {
+      id: 'agents-adapter',
+      name: 'Agents Adapter',
+      enabled: true,
+      transport: { type: 'stdio', command: 'managed-adapter', args: [] },
+      created_at: 1,
+      updated_at: 1,
+      original_json: '{}',
+    };
+    hooks.mcpServers = [server];
+    hooks.mcpCatalogEntries = [{ server, origin: 'productBuiltin', access: 'use' }];
+
+    render(<ToolsModalContent />);
+
+    expect(await screen.findByTestId('mcp-server-agents-adapter')).toHaveTextContent('use');
+  });
+
+  it('hides upstream built-in MCP configuration when the product policy denies that origin', async () => {
+    hooks.resourceAccess.mockImplementation((_kind: string, origin: string) =>
+      origin === 'upstreamBuiltin' ? 'hidden' : 'manage'
+    );
+
+    render(<ToolsModalContent />);
+
+    expect(screen.getByText('settings.imageGeneration')).not.toBeVisible();
+    expect(hooks.getClientBusinessSetting).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description

为 Ki-Buddy 建立统一的 MCP 产品资源访问规则，并为 #41 的 Agents Adapter MCP 预留稳定的 `productBuiltin` 接入形式。

主要变化：

- Tools 与 Custom MCP 保持上游 AionUi 当前已有的管理能力。
- 产品内置 MCP 使用 `use` 权限，可查看状态与执行连接测试，但不能编辑、删除或修改环境配置。
- 未列入策略的 upstream、extension 与未知来源 MCP 在 Ki-Buddy 中隐藏，并生成不含敏感配置的结构化诊断。
- 增加产品资源 requirement 验证路径；#41 接入前注册表为空，后端目录明确缺少已注册资源时显示安装完整性提示。
- AionUi fallback 保持原有 MCP catalog 与管理行为。
- `useMcpServers` 直接保存权威 `McpCatalogEntry`，避免重复执行产品策略。

## Related Issues

- Closes #44
- Related to #41

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

不适用。本次没有新增视觉样式或页面布局。

## Additional Context

- 上游 AionUi 当前没有 Custom MCP 启停入口，本 PR 不扩展该能力。
- #41 接入前不会要求 Agents Adapter MCP 已存在，也不会使用名称匹配或假资源模拟。
- 最终 Standards 与 Spec 双轴审查均为 0 finding。
