### PR TITLE
feat(skills): apply Ki-Buddy resource policy

### DIFF
--- a/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
+++ b/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
@@ -51,6 +51,10 @@ import { allSupportedExts } from '@renderer/services/FileService';
 import SpeechInputButton from '@/renderer/components/chat/SpeechInputButton';
 import { appendSpeechTranscript } from '@/renderer/hooks/system/useSpeechInput';
 import { createChainedDispatch, useLiveTranscriptInsertion } from '@/renderer/hooks/system/useLiveTranscriptInsertion';
+import {
+  filterProductVisibleSkillNames,
+  loadProductSkillCatalog,
+} from '@/renderer/services/runtime/kiBuddySkillCatalog';
 import { getConversationInputHistory, isCaretOnFirstLine } from '@/renderer/utils/chat/messageHistory';
 import './sendbox.css';
 
@@ -480,17 +484,16 @@ const SendBox: React.FC<{
     return commands;
   }, [conversationContext?.conversation_id, enableBtw, onSlashBuiltinCommand, t]);
 
-  // Skills loaded into this conversation are also invokable via slash. We reuse
-  // the global skills index (shared SWR key `skills-index`) purely to attach a
-  // human-readable description; the loadedSkills snapshot decides which appear.
+  // Skills loaded into this conversation are invokable only when the active
+  // product catalog keeps them visible. Runtime injection remains unchanged.
   const loadedSkills = conversationContext?.loadedSkills;
-  const { data: skillIndex } = useSWR(loadedSkills && loadedSkills.length > 0 ? 'skills-index' : null, () =>
-    ipcBridge.fs.listAvailableSkills.invoke()
+  const { data: skillIndex } = useSWR(loadedSkills && loadedSkills.length > 0 ? 'product-skills-index' : null, () =>
+    loadProductSkillCatalog().then(({ visibleSkills }) => visibleSkills)
   );
   const skillSlashCommands = useMemo<SlashCommandItem[]>(() => {
     const descriptionByName = new Map((skillIndex ?? []).map((s) => [s.name, s.description]));
     return buildSkillSlashCommands(
-      loadedSkills,
+      filterProductVisibleSkillNames(loadedSkills, skillIndex),
       descriptionByName,
       t('conversation.skills.slashHint', { defaultValue: 'Skill' })
     );

--- a/packages/desktop/src/renderer/components/media/FileAttachButton.tsx
+++ b/packages/desktop/src/renderer/components/media/FileAttachButton.tsx
@@ -5,7 +5,6 @@
  */
 
 import type { IConversationMcpStatus, IConversationMcpStatusKind } from '@/common/config/storage';
-import { ipcBridge } from '@/common';
 import { Button, Message, Trigger } from '@arco-design/web-react';
 import { FolderOpen, Lightning, Paperclip, Plus, Right, Shield } from '@icon-park/react';
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
@@ -14,6 +13,10 @@ import { isElectronDesktop } from '@/renderer/utils/platform';
 import { FileService } from '@/renderer/services/FileService';
 import type { FileMetadata } from '@/renderer/services/FileService';
 import { emitter } from '@/renderer/utils/emitter';
+import {
+  filterProductVisibleSkillNames,
+  loadProductSkillCatalog,
+} from '@/renderer/services/runtime/kiBuddySkillCatalog';
 import React, { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -87,15 +90,15 @@ const FileAttachButton: React.FC<FileAttachButtonProps> = ({
   const [skillsOpen, setSkillsOpen] = useState(false);
   const [mcpOpen, setMcpOpen] = useState(false);
 
-  const skillNames = loadedSkills ?? conversationContext?.loadedSkills ?? [];
+  const loadedSkillNames = loadedSkills ?? conversationContext?.loadedSkills ?? [];
   const mcpStatuses = buildLoadedMcpStatuses(
     loadedMcpStatuses ?? conversationContext?.loadedMcpStatuses,
     conversationContext?.loadedMcpServers
   );
-  const { data: skillIndex } = useSWR(skillNames.length > 0 ? 'skills-index' : null, () =>
-    ipcBridge.fs.listAvailableSkills.invoke()
+  const { data: skillIndex } = useSWR(loadedSkillNames.length > 0 ? 'product-skills-index' : null, () =>
+    loadProductSkillCatalog().then(({ visibleSkills }) => visibleSkills)
   );
-  const descriptionByName = new Map((skillIndex ?? []).map((s) => [s.name, s.description]));
+  const skillNames = filterProductVisibleSkillNames(loadedSkillNames, skillIndex);
 
   const handleSkillClick = useCallback((name: string) => {
     setOpen(false);

--- a/packages/desktop/src/renderer/hooks/assistant/useAssistantEditor.ts
+++ b/packages/desktop/src/renderer/hooks/assistant/useAssistantEditor.ts
@@ -9,6 +9,7 @@ import type {
   SkillInfo,
 } from '@/renderer/pages/settings/AssistantSettings/types';
 import { ensureBackendMcpCatalog } from '@/renderer/hooks/mcp/catalog';
+import { loadProductSkillCatalog } from '@/renderer/services/runtime/kiBuddySkillCatalog';
 import { getSkillImportErrorMessage } from '@/renderer/pages/settings/SkillsSettings/skillImportMessages';
 import { emitter } from '@/renderer/utils/emitter';
 import { assistantOrderAfterToggle, selectableAssistants } from '@/renderer/utils/model/assistantSelection';
@@ -131,7 +132,7 @@ export const useAssistantEditor = ({
     async (assistantId: string) => {
       const [detail, skillsList, mcpServers] = await Promise.all([
         loadAssistantDetail(assistantId),
-        ipcBridge.fs.listAvailableSkills.invoke(),
+        loadProductSkillCatalog().then(({ visibleSkills }) => [...visibleSkills]),
         ensureBackendMcpCatalog().then(({ allServers }) => allServers),
       ]);
       return { detail, skillsList, autoSkills: deriveBuiltinAutoSkills(skillsList), mcpServers };
@@ -297,7 +298,7 @@ export const useAssistantEditor = ({
 
     try {
       const [skillsList, mcpServers] = await Promise.all([
-        ipcBridge.fs.listAvailableSkills.invoke(),
+        loadProductSkillCatalog().then(({ visibleSkills }) => [...visibleSkills]),
         ensureBackendMcpCatalog().then(({ allServers }) => allServers),
       ]);
       setAvailableSkills(skillsList);
@@ -421,8 +422,8 @@ export const useAssistantEditor = ({
         }
 
         if (skillsToImport.length > 0) {
-          const skillsList = await ipcBridge.fs.listAvailableSkills.invoke();
-          setAvailableSkills(skillsList);
+          const { visibleSkills } = await loadProductSkillCatalog();
+          setAvailableSkills([...visibleSkills]);
         }
       }
 

--- a/packages/desktop/src/renderer/pages/conversation/components/ConversationSkillsIndicator.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ConversationSkillsIndicator.tsx
@@ -4,8 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/config/storage';
+import {
+  filterProductVisibleSkillNames,
+  loadProductSkillCatalog,
+} from '@/renderer/services/runtime/kiBuddySkillCatalog';
 import { iconColors } from '@/renderer/styles/colors';
 import { Popover } from '@arco-design/web-react';
 import { Lightning } from '@icon-park/react';
@@ -27,11 +30,12 @@ const ConversationSkillsIndicator: React.FC<ConversationSkillsIndicatorProps> = 
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const names = (conversation?.extra as { skills?: string[] } | undefined)?.skills ?? [];
+  const loadedNames = (conversation?.extra as { skills?: string[] } | undefined)?.skills ?? [];
 
-  const { data: skillIndex } = useSWR(names.length > 0 ? 'skills-index' : null, () =>
-    ipcBridge.fs.listAvailableSkills.invoke()
+  const { data: skillIndex } = useSWR(loadedNames.length > 0 ? 'product-skills-index' : null, () =>
+    loadProductSkillCatalog().then(({ visibleSkills }) => visibleSkills)
   );
+  const names = filterProductVisibleSkillNames(loadedNames, skillIndex);
 
   if (names.length === 0) return null;
 

--- a/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
+++ b/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
@@ -28,6 +28,7 @@ import { useGuidModelSelection } from './hooks/useGuidModelSelection';
 import { useGuidSend } from './hooks/useGuidSend';
 import { useTypewriterPlaceholder } from './hooks/useTypewriterPlaceholder';
 import { ensureBackendMcpCatalog } from '@/renderer/hooks/mcp/catalog';
+import { loadProductSkillCatalog } from '@/renderer/services/runtime/kiBuddySkillCatalog';
 import { resolveGuidAssistantDefaults } from './utils/assistantDefaults';
 import SpeechInputButton from '@/renderer/components/chat/SpeechInputButton';
 import { chatFileRefPath, uploadFileRef } from '@/common/types/chatFile';
@@ -83,11 +84,10 @@ const GuidPage: React.FC = () => {
   const [guidSelectedMcpServerIds, setGuidSelectedMcpServerIds] = useState<string[] | undefined>(undefined);
 
   useEffect(() => {
-    ipcBridge.fs.listAvailableSkills
-      .invoke()
-      .then((availableSkills) => {
+    loadProductSkillCatalog()
+      .then(({ visibleSkills }) => {
         setAllSkills(
-          availableSkills.map((s) => ({
+          visibleSkills.map((s) => ({
             name: s.name,
             description: s.description,
             isAuto: s.source === 'builtin' && s.is_auto_inject,

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -16,6 +16,7 @@ import { type TFunction } from 'i18next';
 import type { NavigateFunction } from 'react-router-dom';
 import { mutate as swrMutate } from 'swr';
 import { getConversationCreateErrorMessage } from '@/renderer/pages/conversation/utils/conversationCreateError';
+import { getProductExperience } from '@/renderer/services/runtime/kiBuddyRuntime';
 import type { AcpModelInfo } from '../types';
 
 export type GuidSendDeps = {
@@ -114,6 +115,14 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     const assistantBackend = selectedAssistantBackend;
     const enabled_skills_to_send = guidEnabledSkills ?? assistantDefaultSkillIds;
     const excludeBuiltinSkills = guidDisabledBuiltinSkills ?? assistantDefaultDisabledBuiltinSkillIds;
+    const productAutoInjectExclusions = getProductExperience().behaviorDefaults().autoInjectedSkillExclusions;
+    const productAutoInjectExclusionsToSend =
+      productAutoInjectExclusions.length > 0 ? [...productAutoInjectExclusions] : undefined;
+    // Product exclusions are merged by AionCore with current Guid choices.
+    // Omission preserves the Assistant's normal default resolution.
+    const disabledBuiltinSkillsToSend = productAutoInjectExclusionsToSend
+      ? guidDisabledBuiltinSkills
+      : excludeBuiltinSkills;
     const selectedAllMcpServerIds = selectedMcpServerIds ?? [];
     const selectedMcpServerIdSet = new Set(selectedAllMcpServerIds);
     const selectedUserMcpServerIds = availableMcpServers
@@ -162,7 +171,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
       permission: selectedMode || undefined,
       thought_level: selectedThoughtLevelValue || undefined,
       skill_ids: enabled_skills_to_send,
-      disabled_builtin_skill_ids: excludeBuiltinSkills,
+      disabled_builtin_skill_ids: disabledBuiltinSkillsToSend,
       mcp_ids: assistantOverrideMcpIds,
     };
 
@@ -186,6 +195,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
             custom_workspace: isCustomWorkspace,
             selected_mcp_server_ids: selectedUserMcpServerIdsToSend,
             selected_session_mcp_servers: selectedSessionMcpServersToSend,
+            exclude_auto_inject_skills: productAutoInjectExclusionsToSend,
           },
         });
 
@@ -236,6 +246,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
           selected_mcp_server_ids: selectedUserMcpServerIdsToSend,
           selected_session_mcp_servers:
             selectedMcpServerIds !== undefined ? selectedSessionMcpServers : selectedSessionMcpServersToSend,
+          exclude_auto_inject_skills: productAutoInjectExclusionsToSend,
         },
       });
       if (!conversation || !conversation.id) {

--- a/packages/desktop/src/renderer/pages/settings/SkillsSettings/SkillDetailPage.tsx
+++ b/packages/desktop/src/renderer/pages/settings/SkillsSettings/SkillDetailPage.tsx
@@ -29,15 +29,13 @@ import useSWR, { mutate as swrMutate } from 'swr';
 import SettingsPageWrapper from '../components/SettingsPageWrapper';
 import SkillFileBrowser from './SkillFileBrowser';
 import { getAssistantsUsingSkill } from './SkillUsedByStack';
+import {
+  loadProductSkillCatalog,
+  type AvailableSkill,
+  type ProductSkillCatalog,
+} from '@/renderer/services/runtime/kiBuddySkillCatalog';
 
-interface SkillInfo {
-  name: string;
-  description: string;
-  location: string;
-  is_auto_inject: boolean;
-  is_custom: boolean;
-  source?: 'builtin' | 'custom' | 'cron' | 'extension';
-}
+type SkillInfo = AvailableSkill;
 
 const getAvatarColorClass = (name: string) => {
   if (!name) return 'bg-[#165DFF] text-white';
@@ -81,8 +79,9 @@ const SkillDetailPage: React.FC = () => {
   const decodedName = decodeURIComponent(skillName);
   const [saving, setSaving] = useState(false);
 
-  const { data: skills, isLoading: skillsLoading } = useSWR<SkillInfo[]>('skills.list', () =>
-    ipcBridge.fs.listAvailableSkills.invoke()
+  const { data: skillCatalog, isLoading: skillsLoading } = useSWR<ProductSkillCatalog>(
+    ['product-skills.list', decodedName],
+    () => loadProductSkillCatalog()
   );
   const {
     data: assistants,
@@ -90,7 +89,11 @@ const SkillDetailPage: React.FC = () => {
     mutate: mutateAssistants,
   } = useSWR<Assistant[]>('assistants.list', () => ipcBridge.assistants.list.invoke());
 
-  const skill = useMemo(() => (skills ?? []).find((s) => s.name === decodedName), [skills, decodedName]);
+  const skillEntry = useMemo(
+    () => skillCatalog?.entries.find(({ skill }) => skill.name === decodedName),
+    [decodedName, skillCatalog]
+  );
+  const skill = skillEntry?.skill;
   const usingAssistants = useMemo(
     () => getAssistantsUsingSkill(decodedName, assistants ?? []),
     [assistants, decodedName]
@@ -326,15 +329,17 @@ const SkillDetailPage: React.FC = () => {
               title={t('settings.skillsHub.detailFilesTitle', { defaultValue: 'Skill files' })}
               data-testid='skill-detail-files'
               extra={
-                <Button
-                  size='mini'
-                  type='text'
-                  data-testid='btn-edit-skill-via-chat'
-                  onClick={editViaChat}
-                  className='!h-24px !px-8px !text-12px !text-t-secondary hover:!text-t-primary'
-                >
-                  {t('settings.skillsHub.editViaChat.buttonLabel', { defaultValue: 'Edit via chat' })}
-                </Button>
+                skillEntry.access === 'manage' ? (
+                  <Button
+                    size='mini'
+                    type='text'
+                    data-testid='btn-edit-skill-via-chat'
+                    onClick={editViaChat}
+                    className='!h-24px !px-8px !text-12px !text-t-secondary hover:!text-t-primary'
+                  >
+                    {t('settings.skillsHub.editViaChat.buttonLabel', { defaultValue: 'Edit via chat' })}
+                  </Button>
+                ) : undefined
               }
             >
               <SkillFileBrowser skill={skill} />

--- a/packages/desktop/src/renderer/pages/settings/SkillsSettings/SkillsHubSettings.tsx
+++ b/packages/desktop/src/renderer/pages/settings/SkillsSettings/SkillsHubSettings.tsx
@@ -13,22 +13,10 @@ import SettingsPageHeader from '../components/SettingsPageHeader';
 import TalkToButlerButton from '@/renderer/components/base/TalkToButlerButton';
 import { AionSearchInput } from '@/renderer/components/base';
 import { buildSkillImportNotice, getSkillImportErrorMessage } from './skillImportMessages';
+import { loadProductSkillCatalog, type AvailableSkill } from '@/renderer/services/runtime/kiBuddySkillCatalog';
 
 // Skill 信息类型 / Skill info type
-interface SkillInfo {
-  name: string;
-  description: string;
-  location: string;
-  /**
-   * Relative location under the builtin-skills corpus (e.g.
-   * `auto-inject/cron/SKILL.md`). Present only for built-in sources; the
-   * export-to-external-source flow still uses absolute `location` paths.
-   */
-  relative_location?: string;
-  is_auto_inject: boolean;
-  is_custom: boolean;
-  source?: 'builtin' | 'custom' | 'cron' | 'extension';
-}
+type SkillInfo = AvailableSkill;
 
 const isAutoInjectedBuiltinSkill = (skill: SkillInfo) => skill.source === 'builtin' && skill.is_auto_inject;
 
@@ -201,8 +189,8 @@ const SkillsHubSettings: React.FC<SkillsHubSettingsProps> = ({ withWrapper = tru
   const fetchData = useCallback(async () => {
     setLoading(true);
     try {
-      const skills = await ipcBridge.fs.listAvailableSkills.invoke();
-      setAvailableSkills(skills);
+      const { visibleSkills } = await loadProductSkillCatalog();
+      setAvailableSkills([...visibleSkills]);
 
       const history = await ipcBridge.fs.listSkillImportHistory.invoke();
       setImportHistory(history as SkillImportRecord[]);

--- a/packages/desktop/src/renderer/services/runtime/kiBuddySkillCatalog.ts
+++ b/packages/desktop/src/renderer/services/runtime/kiBuddySkillCatalog.ts
@@ -1,0 +1,137 @@
+import { ipcBridge } from '@/common';
+import {
+  projectProductResources,
+  type ProductExperience,
+  type ProductResourceAccess,
+  type ProductResourceHiddenRecord,
+  type ProductResourceOrigin,
+} from '@/common/platform/ki-buddy';
+import { getProductExperience } from './kiBuddyRuntime';
+
+export type AvailableSkill = Awaited<ReturnType<typeof ipcBridge.fs.listAvailableSkills.invoke>>[number];
+
+export type ProductSkillCatalogEntry = Readonly<{
+  access: Exclude<ProductResourceAccess, 'hidden'>;
+  origin: ProductResourceOrigin;
+  resourceId: string;
+  skill: AvailableSkill;
+}>;
+
+export type ProductSkillCatalog = Readonly<{
+  entries: readonly ProductSkillCatalogEntry[];
+  hiddenResources: readonly ProductResourceHiddenRecord[];
+  visibleSkills: readonly AvailableSkill[];
+}>;
+
+const PRODUCT_OFFICE_SKILL_RELATIVE_LOCATIONS = new Set([
+  'officecli-docx/SKILL.md',
+  'officecli-pptx/SKILL.md',
+  'officecli-xlsx/SKILL.md',
+]);
+
+const resolveSkillIdentity = (
+  skill: AvailableSkill
+): Readonly<{ id: string; name: string; origin: ProductResourceOrigin; skill: AvailableSkill }> => {
+  if (skill.source === 'custom') {
+    return { id: `custom:${skill.name}`, name: skill.name, origin: 'custom', skill };
+  }
+  if (skill.source === 'extension') {
+    return { id: `extension:${skill.name}`, name: skill.name, origin: 'extension', skill };
+  }
+  if (skill.source === 'builtin' && skill.relative_location) {
+    const origin = PRODUCT_OFFICE_SKILL_RELATIVE_LOCATIONS.has(skill.relative_location)
+      ? 'productBuiltin'
+      : 'upstreamBuiltin';
+    return { id: `builtin:${skill.relative_location}`, name: skill.name, origin, skill };
+  }
+  return { id: `unclassified:${skill.name}`, name: skill.name, origin: 'unclassified', skill };
+};
+
+/** Applies product resource access to stable Skill identities supplied by AionCore. */
+export const projectProductSkillCatalog = (
+  skills: readonly AvailableSkill[],
+  experience: ProductExperience
+): ProductSkillCatalog => {
+  const resources = skills.map(resolveSkillIdentity);
+  const projection = projectProductResources(experience, 'skill', resources);
+  const projectedVisible = new Map(projection.visible.map(({ resource, access }) => [resource.id, access]));
+  const autoInjectExclusions = new Set(experience.behaviorDefaults().autoInjectedSkillExclusions);
+  const visibleAutoInjectIds = new Set(
+    resources
+      .filter(
+        ({ skill }) =>
+          experience.resourceAccess('skill', 'upstreamBuiltin') === 'hidden' &&
+          skill.source === 'builtin' &&
+          skill.is_auto_inject &&
+          !autoInjectExclusions.has(skill.name)
+      )
+      .map(({ id }) => id)
+  );
+  const entries = resources.flatMap((resource): ProductSkillCatalogEntry[] => {
+    const projectedAccess = projectedVisible.get(resource.id);
+    if (projectedAccess) {
+      return [
+        {
+          skill: resource.skill,
+          resourceId: resource.id,
+          origin: resource.origin,
+          access: projectedAccess,
+        },
+      ];
+    }
+    // Auto-injected Skills remain visible and read-only unless the product
+    // behavior policy excludes them from injection.
+    if (visibleAutoInjectIds.has(resource.id)) {
+      return [
+        {
+          skill: resource.skill,
+          resourceId: resource.id,
+          origin: resource.origin,
+          access: 'use',
+        },
+      ];
+    }
+    return [];
+  });
+  return {
+    entries,
+    hiddenResources: projection.hidden.filter(({ resourceId }) => !visibleAutoInjectIds.has(resourceId)),
+    visibleSkills: entries.map(({ skill }) => skill),
+  };
+};
+
+/** Emits non-sensitive diagnostics for Skill resources hidden by the product policy. */
+export const reportHiddenProductSkills = (hiddenResources: readonly ProductResourceHiddenRecord[]): void => {
+  if (hiddenResources.length === 0) return;
+  console.info('[ProductExperience] Skill resources hidden by product policy', {
+    code: 'product_resource_projection',
+    resources: hiddenResources,
+  });
+};
+
+/** Keeps runtime-loaded Skill names that remain visible in the active product catalog. */
+export const filterProductVisibleSkillNames = (
+  names: readonly string[] | undefined,
+  visibleSkills: readonly AvailableSkill[] | undefined,
+  experience: ProductExperience = getProductExperience()
+): string[] => {
+  if (!names) return [];
+  if (!visibleSkills) {
+    const productFiltersSkillOrigins = (
+      ['productBuiltin', 'custom', 'upstreamBuiltin', 'extension', 'unclassified'] as const
+    ).some((origin) => experience.resourceAccess('skill', origin) === 'hidden');
+    return productFiltersSkillOrigins ? [] : [...names];
+  }
+  const visibleNames = new Set(visibleSkills.map(({ name }) => name));
+  return names.filter((name) => visibleNames.has(name));
+};
+
+/** Loads the AionCore Skill catalog and applies the active product policy once for renderer consumers. */
+export const loadProductSkillCatalog = async (
+  experience: ProductExperience = getProductExperience()
+): Promise<ProductSkillCatalog> => {
+  const skills = await ipcBridge.fs.listAvailableSkills.invoke();
+  const catalog = projectProductSkillCatalog(skills, experience);
+  reportHiddenProductSkills(catalog.hiddenResources);
+  return catalog;
+};

--- a/tests/unit/assistants/useAssistantEditor.dom.test.ts
+++ b/tests/unit/assistants/useAssistantEditor.dom.test.ts
@@ -10,6 +10,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 
+const loadProductSkillCatalogMock = vi.hoisted(() => vi.fn());
+
 // Mock @/common
 vi.mock('@/common', () => ({
   ipcBridge: {
@@ -51,6 +53,10 @@ vi.mock('@/renderer/hooks/mcp/catalog', () => ({
     builtinServers: [],
     allServers: [{ id: 'mcp-a', name: 'Server A', enabled: true }],
   })),
+}));
+
+vi.mock('@/renderer/services/runtime/kiBuddySkillCatalog', () => ({
+  loadProductSkillCatalog: loadProductSkillCatalogMock,
 }));
 
 import { useAssistantEditor } from '@/renderer/hooks/assistant/useAssistantEditor';
@@ -129,6 +135,8 @@ describe('useAssistantEditor', () => {
     vi.clearAllMocks();
     (ipcBridge.assistants.get.invoke as any).mockResolvedValue(mockAssistantDetail);
     (ipcBridge.fs.listAvailableSkills.invoke as any).mockResolvedValue([]);
+    loadProductSkillCatalogMock.mockReset();
+    loadProductSkillCatalogMock.mockResolvedValue({ entries: [], hiddenResources: [], visibleSkills: [] });
     (ipcBridge.mcpService.listServers.invoke as any).mockResolvedValue([
       { id: 'mcp-a', name: 'Server A', enabled: true },
     ]);
@@ -324,6 +332,32 @@ describe('useAssistantEditor', () => {
     expect(result.current.defaultPermissionMode).toBe('auto');
     expect((result.current as any).defaultThoughtLevelMode).toBe('auto');
     expect(result.current.defaultMcpMode).toBe('auto');
+  });
+
+  it('loads only product-projected Skills for assistant management', async () => {
+    const projectedSkill = {
+      name: 'officecli-docx',
+      description: 'Word documents',
+      location: '/skills/officecli-docx/SKILL.md',
+      relative_location: 'officecli-docx/SKILL.md',
+      is_auto_inject: false,
+      is_custom: false,
+      source: 'builtin',
+    };
+    loadProductSkillCatalogMock.mockResolvedValue({
+      entries: [],
+      hiddenResources: [],
+      visibleSkills: [projectedSkill],
+    });
+
+    const { result } = renderHook(() => useAssistantEditor(defaultParams));
+
+    await act(async () => {
+      await result.current.handleCreate();
+    });
+
+    expect(result.current.availableSkills).toEqual([projectedSkill]);
+    expect(loadProductSkillCatalogMock).toHaveBeenCalledTimes(1);
   });
 
   it('calls handleSave for creating new assistant', async () => {

--- a/tests/unit/renderer/GuidActionRow.dom.test.tsx
+++ b/tests/unit/renderer/GuidActionRow.dom.test.tsx
@@ -224,6 +224,20 @@ describe('GuidActionRow skill/MCP submenu search', () => {
     expect(screen.getByText('server-4')).toBeInTheDocument();
   });
 
+  it('checks auto-injected skills by default while leaving opt-in skills unchecked', () => {
+    renderActionRow({
+      allSkills: [
+        { name: 'cron', description: '', isAuto: true },
+        { name: 'officecli-docx', description: '', isAuto: false },
+      ],
+      disabledBuiltinSkills: [],
+      enabledSkills: [],
+    });
+
+    expect(screen.getByLabelText('cron')).toBeChecked();
+    expect(screen.getByLabelText('officecli-docx')).not.toBeChecked();
+  });
+
   it('filters skills case-insensitively and keeps other items hidden', () => {
     renderActionRow();
 

--- a/tests/unit/renderer/components/ConversationSkillsIndicator.dom.test.tsx
+++ b/tests/unit/renderer/components/ConversationSkillsIndicator.dom.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { projectedSkills, preserveLoadedSkillNames, catalogError, useSWRMock } = vi.hoisted(() => ({
+  projectedSkills: { current: [] as Array<{ name: string; description: string }> | undefined },
+  preserveLoadedSkillNames: { current: false },
+  catalogError: { current: undefined as Error | undefined },
+  useSWRMock: vi.fn(),
+}));
+
+vi.mock('swr', () => ({
+  default: (...args: unknown[]) => useSWRMock(...args),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/renderer/services/runtime/kiBuddySkillCatalog', () => ({
+  loadProductSkillCatalog: vi.fn(),
+  filterProductVisibleSkillNames: (
+    names: readonly string[] | undefined,
+    skills: readonly { name: string }[] | undefined
+  ) => {
+    if (!skills) return preserveLoadedSkillNames.current ? [...(names ?? [])] : [];
+    const visibleNames = new Set(skills.map(({ name }) => name));
+    return (names ?? []).filter((name) => visibleNames.has(name));
+  },
+}));
+
+import ConversationSkillsIndicator from '@/renderer/pages/conversation/components/ConversationSkillsIndicator';
+
+describe('ConversationSkillsIndicator product Skill catalog', () => {
+  beforeEach(() => {
+    projectedSkills.current = [];
+    preserveLoadedSkillNames.current = false;
+    catalogError.current = undefined;
+    useSWRMock.mockReset();
+    useSWRMock.mockImplementation((key: string | null) => ({
+      data: key ? projectedSkills.current : undefined,
+      error: key ? catalogError.current : undefined,
+    }));
+  });
+
+  it('shows only product-visible loaded Skills', () => {
+    projectedSkills.current = [{ name: 'officecli-docx', description: 'Word documents' }];
+
+    render(
+      <ConversationSkillsIndicator conversation={{ extra: { skills: ['officecli-docx', 'aionui-config'] } } as never} />
+    );
+
+    expect(screen.getByTestId('skills-indicator')).toHaveTextContent('1');
+    expect(screen.queryByText('aionui-config')).not.toBeInTheDocument();
+  });
+
+  it('stays hidden for Ki-Buddy when catalog loading fails', () => {
+    projectedSkills.current = undefined;
+    preserveLoadedSkillNames.current = false;
+    catalogError.current = new Error('catalog unavailable');
+
+    render(
+      <ConversationSkillsIndicator conversation={{ extra: { skills: ['officecli-docx', 'aionui-config'] } } as never} />
+    );
+
+    expect(screen.queryByTestId('skills-indicator')).not.toBeInTheDocument();
+  });
+
+  it('preserves the AionUi Skill snapshot when catalog loading fails', () => {
+    projectedSkills.current = undefined;
+    preserveLoadedSkillNames.current = true;
+    catalogError.current = new Error('catalog unavailable');
+
+    render(
+      <ConversationSkillsIndicator conversation={{ extra: { skills: ['officecli-docx', 'aionui-config'] } } as never} />
+    );
+
+    expect(screen.getByTestId('skills-indicator')).toHaveTextContent('2');
+  });
+});

--- a/tests/unit/renderer/components/FileAttachButton.dom.test.tsx
+++ b/tests/unit/renderer/components/FileAttachButton.dom.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { projectedSkills, preserveLoadedSkillNames, catalogError, useSWRMock } = vi.hoisted(() => ({
+  projectedSkills: { current: [] as Array<{ name: string; description: string }> | undefined },
+  preserveLoadedSkillNames: { current: false },
+  catalogError: { current: undefined as Error | undefined },
+  useSWRMock: vi.fn(),
+}));
+
+vi.mock('swr', () => ({
+  default: (...args: unknown[]) => useSWRMock(...args),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/renderer/hooks/context/ConversationContext', () => ({
+  useConversationContextSafe: () => null,
+}));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  isElectronDesktop: () => false,
+}));
+
+vi.mock('@/renderer/services/runtime/kiBuddySkillCatalog', () => ({
+  loadProductSkillCatalog: vi.fn(),
+  filterProductVisibleSkillNames: (
+    names: readonly string[] | undefined,
+    skills: readonly { name: string }[] | undefined
+  ) => {
+    if (!skills) return preserveLoadedSkillNames.current ? [...(names ?? [])] : [];
+    const visibleNames = new Set(skills.map(({ name }) => name));
+    return (names ?? []).filter((name) => visibleNames.has(name));
+  },
+}));
+
+import FileAttachButton from '@/renderer/components/media/FileAttachButton';
+
+describe('FileAttachButton product Skill catalog', () => {
+  beforeEach(() => {
+    projectedSkills.current = [];
+    preserveLoadedSkillNames.current = false;
+    catalogError.current = undefined;
+    useSWRMock.mockReset();
+    useSWRMock.mockImplementation((key: string | null) => ({
+      data: key ? projectedSkills.current : undefined,
+      error: key ? catalogError.current : undefined,
+    }));
+  });
+
+  it('filters the attachment Skill menu to the product-visible catalog', async () => {
+    projectedSkills.current = [{ name: 'officecli-docx', description: 'Word documents' }];
+
+    render(
+      <FileAttachButton
+        openFileSelector={vi.fn()}
+        loadedSkills={['officecli-docx', 'aionui-config']}
+        loadedMcpStatuses={[]}
+      />
+    );
+    fireEvent.click(screen.getByTestId('aionrs-attach-folder-btn'));
+
+    expect(await screen.findByText('Selected skills · 1')).toBeInTheDocument();
+    expect(screen.queryByText('aionui-config')).not.toBeInTheDocument();
+  });
+
+  it('preserves the AionUi Skill snapshot when catalog loading fails', async () => {
+    projectedSkills.current = undefined;
+    preserveLoadedSkillNames.current = true;
+    catalogError.current = new Error('catalog unavailable');
+
+    render(
+      <FileAttachButton
+        openFileSelector={vi.fn()}
+        loadedSkills={['officecli-docx', 'aionui-config']}
+        loadedMcpStatuses={[]}
+      />
+    );
+    fireEvent.click(screen.getByTestId('aionrs-attach-folder-btn'));
+
+    expect(await screen.findByText('Selected skills · 2')).toBeInTheDocument();
+  });
+
+  it('does not expose Ki-Buddy Skill names when catalog loading fails', async () => {
+    projectedSkills.current = undefined;
+    preserveLoadedSkillNames.current = false;
+    catalogError.current = new Error('catalog unavailable');
+
+    render(
+      <FileAttachButton
+        openFileSelector={vi.fn()}
+        loadedSkills={['officecli-docx', 'aionui-config']}
+        loadedMcpStatuses={[]}
+      />
+    );
+    fireEvent.click(screen.getByTestId('aionrs-attach-folder-btn'));
+
+    expect(await screen.findByText('Upload from device')).toBeInTheDocument();
+    expect(screen.queryByText(/Selected skills/)).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/renderer/conversation/sendBoxActiveFocus.dom.test.tsx
+++ b/tests/unit/renderer/conversation/sendBoxActiveFocus.dom.test.tsx
@@ -6,10 +6,26 @@
 
 import { act, render, screen, waitFor } from '@testing-library/react';
 import React, { useState } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { layoutState } = vi.hoisted(() => ({
+type ConversationExportResult = ReturnType<
+  typeof import('@/renderer/hooks/file/useConversationExport').useConversationExport
+>;
+
+const { layoutState, conversationState, projectedSkills, catalogError, useSWRMock } = vi.hoisted(() => ({
   layoutState: { isMobile: false },
+  conversationState: {
+    conversation_id: 'sendbox-active-focus-conversation',
+    type: 'acp',
+    loadedSkills: [] as string[],
+  },
+  projectedSkills: { current: [] as Array<{ name: string; description: string }> | undefined },
+  catalogError: { current: undefined as Error | undefined },
+  useSWRMock: vi.fn(),
+}));
+
+vi.mock('swr', () => ({
+  default: (...args: unknown[]) => useSWRMock(...args),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -36,10 +52,7 @@ vi.mock('@/renderer/hooks/chat/useInputFocusRing', () => ({
 }));
 
 vi.mock('@/renderer/hooks/context/ConversationContext', () => ({
-  useConversationContextSafe: () => ({
-    conversation_id: 'sendbox-active-focus-conversation',
-    type: 'acp',
-  }),
+  useConversationContextSafe: () => conversationState,
 }));
 
 vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
@@ -60,10 +73,10 @@ vi.mock('@/renderer/pages/conversation/Messages/hooks', () => ({
 }));
 
 vi.mock('@/renderer/hooks/file/useConversationExport', () => ({
-  useConversationExport: () => ({
+  useConversationExport: (): ConversationExportResult => ({
     isOpen: false,
-    showMenu: false,
-    step: 'menu',
+    showMenu: vi.fn(),
+    step: 'closed',
     filename: '',
     pathPreview: '',
     menuItems: [],
@@ -124,6 +137,17 @@ vi.mock('@/renderer/components/chat/SpeechInputButton', () => ({ default: () => 
 vi.mock('@/renderer/components/media/UploadProgressBar', () => ({ default: () => null }));
 
 import SendBox from '@/renderer/components/chat/SendBox';
+
+beforeEach(() => {
+  conversationState.loadedSkills = [];
+  projectedSkills.current = [];
+  catalogError.current = undefined;
+  useSWRMock.mockReset();
+  useSWRMock.mockImplementation((key: string | null) => ({
+    data: key ? projectedSkills.current : undefined,
+    error: key ? catalogError.current : undefined,
+  }));
+});
 
 const SendBoxHarness = ({
   active,
@@ -200,6 +224,29 @@ describe('SendBox active-controlled focus', () => {
       textarea.focus();
     });
     expect(onFocused).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SendBox product Skill projection', () => {
+  it('offers slash commands only for loaded Skills visible in the product catalog', async () => {
+    conversationState.loadedSkills = ['officecli-docx', 'aionui-config'];
+    projectedSkills.current = [{ name: 'officecli-docx', description: 'Word documents' }];
+
+    render(<SendBoxHarness active={false} initialValue='/' />);
+
+    expect(await screen.findByText('/officecli-docx')).toBeInTheDocument();
+    expect(screen.queryByText('/aionui-config')).not.toBeInTheDocument();
+  });
+
+  it('keeps loaded Skill slash commands available in AionUi when the catalog request fails', async () => {
+    conversationState.loadedSkills = ['officecli-docx', 'aionui-config'];
+    projectedSkills.current = undefined;
+    catalogError.current = new Error('catalog unavailable');
+
+    render(<SendBoxHarness active={false} initialValue='/' />);
+
+    expect(await screen.findByText('/officecli-docx')).toBeInTheDocument();
+    expect(screen.getByText('/aionui-config')).toBeInTheDocument();
   });
 });
 

--- a/tests/unit/renderer/hooks/guidPage.dom.test.tsx
+++ b/tests/unit/renderer/hooks/guidPage.dom.test.tsx
@@ -21,6 +21,7 @@ const {
   resolveGuidAssistantDefaultsMock,
   sendMock,
   navigateMock,
+  loadProductSkillCatalogMock,
 } = vi.hoisted(() => ({
   modelSelectionMock: {
     modelList: [],
@@ -123,6 +124,7 @@ const {
     isButtonDisabled: false,
   },
   navigateMock: vi.fn(),
+  loadProductSkillCatalogMock: vi.fn(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -143,6 +145,10 @@ vi.mock('@/common', () => ({
       listAvailableSkills: { invoke: vi.fn().mockResolvedValue([]) },
     },
   },
+}));
+
+vi.mock('@/renderer/services/runtime/kiBuddySkillCatalog', () => ({
+  loadProductSkillCatalog: loadProductSkillCatalogMock,
 }));
 
 vi.mock('@/renderer/hooks/mcp/catalog', () => ({
@@ -305,6 +311,8 @@ describe('GuidPage', () => {
     locationMock.state = null;
     locationMock.key = 'guid-location';
     navigateMock.mockReset();
+    loadProductSkillCatalogMock.mockReset();
+    loadProductSkillCatalogMock.mockResolvedValue({ entries: [], hiddenResources: [], visibleSkills: [] });
     swrMock.useSWRMock.mockReturnValue({ data: null });
     capturedGuidActionRowProps.length = 0;
     capturedAssistantSelectionAreaProps.length = 0;
@@ -346,6 +354,43 @@ describe('GuidPage', () => {
         deletable: false,
       },
     ];
+  });
+
+  it('uses the product-projected Skill catalog on the home page', async () => {
+    loadProductSkillCatalogMock.mockResolvedValue({
+      entries: [],
+      hiddenResources: [],
+      visibleSkills: [
+        {
+          name: 'officecli-docx',
+          description: 'Word documents',
+          location: '/skills/officecli-docx/SKILL.md',
+          relative_location: 'officecli-docx/SKILL.md',
+          is_auto_inject: false,
+          is_custom: false,
+          source: 'builtin',
+        },
+        {
+          name: 'cron',
+          description: 'Scheduled task management',
+          location: '/skills/auto-inject/cron/SKILL.md',
+          relative_location: 'auto-inject/cron/SKILL.md',
+          is_auto_inject: true,
+          is_custom: false,
+          source: 'builtin',
+        },
+      ],
+    });
+
+    render(<GuidPage />);
+
+    await waitFor(() => {
+      expect(capturedGuidActionRowProps.at(-1)?.allSkills).toEqual([
+        { name: 'officecli-docx', description: 'Word documents', isAuto: false },
+        { name: 'cron', description: 'Scheduled task management', isAuto: true },
+      ]);
+    });
+    expect(loadProductSkillCatalogMock).toHaveBeenCalledTimes(1);
   });
 
   it('keeps the existing replace contract for ordinary Guid prefills', () => {

--- a/tests/unit/renderer/services/runtime/kiBuddySkillCatalog.dom.test.ts
+++ b/tests/unit/renderer/services/runtime/kiBuddySkillCatalog.dom.test.ts
@@ -1,0 +1,243 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createAionUiProductExperience, createKiBuddyProductExperience } from '@/common/platform/ki-buddy';
+import {
+  filterProductVisibleSkillNames,
+  projectProductSkillCatalog,
+} from '@/renderer/services/runtime/kiBuddySkillCatalog';
+import productConfig from '../../../../../ki-buddy-product.json';
+
+describe('projectProductSkillCatalog', () => {
+  it('filters runtime-loaded names to the product-visible catalog', () => {
+    expect(
+      filterProductVisibleSkillNames(
+        ['officecli-docx', 'cron', 'aionui-config'],
+        [
+          {
+            name: 'officecli-docx',
+            description: 'Word documents',
+            location: '/builtin/officecli-docx/SKILL.md',
+            relative_location: 'officecli-docx/SKILL.md',
+            is_auto_inject: false,
+            is_custom: false,
+            source: 'builtin',
+          },
+          {
+            name: 'cron',
+            description: 'Scheduled task management',
+            location: '/builtin/auto-inject/cron/SKILL.md',
+            relative_location: 'auto-inject/cron/SKILL.md',
+            is_auto_inject: true,
+            is_custom: false,
+            source: 'builtin',
+          },
+        ]
+      )
+    ).toEqual(['officecli-docx', 'cron']);
+  });
+
+  it('preserves AionUi loaded Skill names while the catalog is unavailable', () => {
+    expect(
+      filterProductVisibleSkillNames(['officecli-docx', 'aionui-config'], undefined, createAionUiProductExperience())
+    ).toEqual(['officecli-docx', 'aionui-config']);
+  });
+
+  it('does not expose Ki-Buddy loaded Skill names before the projected catalog is available', () => {
+    expect(
+      filterProductVisibleSkillNames(
+        ['officecli-docx', 'aionui-config'],
+        undefined,
+        createKiBuddyProductExperience(productConfig.experience)
+      )
+    ).toEqual([]);
+  });
+
+  it('shows Office, Custom, and non-excluded auto-injected skills while recording hidden resources', () => {
+    const result = projectProductSkillCatalog(
+      [
+        {
+          name: 'officecli-docx',
+          description: 'Word documents',
+          location: '/builtin/officecli-docx/SKILL.md',
+          relative_location: 'officecli-docx/SKILL.md',
+          is_auto_inject: false,
+          is_custom: false,
+          source: 'builtin',
+        },
+        {
+          name: 'officecli-pptx',
+          description: 'PowerPoint presentations',
+          location: '/builtin/officecli-pptx/SKILL.md',
+          relative_location: 'officecli-pptx/SKILL.md',
+          is_auto_inject: false,
+          is_custom: false,
+          source: 'builtin',
+        },
+        {
+          name: 'officecli-xlsx',
+          description: 'Excel workbooks',
+          location: '/builtin/officecli-xlsx/SKILL.md',
+          relative_location: 'officecli-xlsx/SKILL.md',
+          is_auto_inject: false,
+          is_custom: false,
+          source: 'builtin',
+        },
+        {
+          name: 'team-workflow',
+          description: 'User skill',
+          location: '/user/team-workflow/SKILL.md',
+          is_auto_inject: false,
+          is_custom: true,
+          source: 'custom',
+        },
+        {
+          name: 'mermaid',
+          description: 'Upstream built-in',
+          location: '/builtin/mermaid/SKILL.md',
+          relative_location: 'mermaid/SKILL.md',
+          is_auto_inject: false,
+          is_custom: false,
+          source: 'builtin',
+        },
+        {
+          name: 'cron',
+          description: 'Auto-injected runtime skill',
+          location: '/builtin/cron/SKILL.md',
+          relative_location: 'auto-inject/cron/SKILL.md',
+          is_auto_inject: true,
+          is_custom: false,
+          source: 'builtin',
+        },
+        {
+          name: 'officecli',
+          description: 'Auto-injected Office CLI skill',
+          location: '/builtin/officecli/SKILL.md',
+          relative_location: 'auto-inject/officecli/SKILL.md',
+          is_auto_inject: true,
+          is_custom: false,
+          source: 'builtin',
+        },
+        {
+          name: 'skill-creator',
+          description: 'Auto-injected skill creator',
+          location: '/builtin/skill-creator/SKILL.md',
+          relative_location: 'auto-inject/skill-creator/SKILL.md',
+          is_auto_inject: true,
+          is_custom: false,
+          source: 'builtin',
+        },
+        {
+          name: 'aionui-config',
+          description: 'Excluded product configuration skill',
+          location: '/builtin/aionui-config/SKILL.md',
+          relative_location: 'auto-inject/aionui-config/SKILL.md',
+          is_auto_inject: true,
+          is_custom: false,
+          source: 'builtin',
+        },
+        {
+          name: 'extension-skill',
+          description: 'Extension skill',
+          location: '/extension/skill/SKILL.md',
+          is_auto_inject: false,
+          is_custom: false,
+          source: 'extension',
+        },
+        {
+          name: 'future-skill',
+          description: 'Future source',
+          location: '/future/skill/SKILL.md',
+          is_auto_inject: false,
+          is_custom: false,
+          source: 'future',
+        },
+      ],
+      createKiBuddyProductExperience(productConfig.experience)
+    );
+
+    expect(result.entries.map(({ skill, origin, access }) => ({ name: skill.name, origin, access }))).toEqual([
+      { name: 'officecli-docx', origin: 'productBuiltin', access: 'use' },
+      { name: 'officecli-pptx', origin: 'productBuiltin', access: 'use' },
+      { name: 'officecli-xlsx', origin: 'productBuiltin', access: 'use' },
+      { name: 'team-workflow', origin: 'custom', access: 'manage' },
+      { name: 'cron', origin: 'upstreamBuiltin', access: 'use' },
+      { name: 'officecli', origin: 'upstreamBuiltin', access: 'use' },
+      { name: 'skill-creator', origin: 'upstreamBuiltin', access: 'use' },
+    ]);
+    expect(result.hiddenResources).toEqual([
+      expect.objectContaining({ resourceId: 'builtin:mermaid/SKILL.md', origin: 'upstreamBuiltin' }),
+      expect.objectContaining({
+        resourceId: 'builtin:auto-inject/aionui-config/SKILL.md',
+        origin: 'upstreamBuiltin',
+      }),
+      expect.objectContaining({ resourceId: 'extension:extension-skill', origin: 'extension' }),
+      expect.objectContaining({ resourceId: 'unclassified:future-skill', origin: 'unclassified' }),
+    ]);
+    expect(result.hiddenResources[0]).not.toHaveProperty('location');
+    expect(result.hiddenResources[0]).not.toHaveProperty('description');
+  });
+
+  it('does not identify a renamed built-in as an Office product resource by display name alone', () => {
+    const result = projectProductSkillCatalog(
+      [
+        {
+          name: 'officecli-docx',
+          description: 'Name collision',
+          location: '/builtin/other/SKILL.md',
+          relative_location: 'other/SKILL.md',
+          is_auto_inject: false,
+          is_custom: false,
+          source: 'builtin',
+        },
+      ],
+      createKiBuddyProductExperience(productConfig.experience)
+    );
+
+    expect(result.entries).toEqual([]);
+    expect(result.hiddenResources).toEqual([
+      expect.objectContaining({ resourceId: 'builtin:other/SKILL.md', origin: 'upstreamBuiltin' }),
+    ]);
+  });
+
+  it('keeps the complete Skill catalog manageable when the Ki-Buddy capability is absent', () => {
+    const skills = [
+      {
+        name: 'mermaid',
+        description: 'Upstream built-in',
+        location: '/builtin/mermaid/SKILL.md',
+        relative_location: 'mermaid/SKILL.md',
+        is_auto_inject: false,
+        is_custom: false,
+        source: 'builtin',
+      },
+      {
+        name: 'cron',
+        description: 'Auto-injected runtime skill',
+        location: '/builtin/cron/SKILL.md',
+        relative_location: 'auto-inject/cron/SKILL.md',
+        is_auto_inject: true,
+        is_custom: false,
+        source: 'builtin',
+      },
+      {
+        name: 'extension-skill',
+        description: 'Extension skill',
+        location: '/extension/skill/SKILL.md',
+        is_auto_inject: false,
+        is_custom: false,
+        source: 'extension',
+      },
+    ];
+
+    const result = projectProductSkillCatalog(skills, createAionUiProductExperience());
+
+    expect(result.visibleSkills).toEqual(skills);
+    expect(result.entries.every(({ access }) => access === 'manage')).toBe(true);
+    expect(result.hiddenResources).toEqual([]);
+  });
+});

--- a/tests/unit/renderer/useGuidSend.dom.test.ts
+++ b/tests/unit/renderer/useGuidSend.dom.test.ts
@@ -11,6 +11,7 @@ import { useGuidSend, type GuidSendDeps } from '@/renderer/pages/guid/hooks/useG
 
 const createConversationInvokeMock = vi.fn();
 const swrMutateMock = vi.fn();
+const getProductExperienceMock = vi.fn();
 
 vi.mock('@/common', () => ({
   ipcBridge: {
@@ -34,6 +35,10 @@ vi.mock('swr', () => ({
 
 vi.mock('@/renderer/utils/workspace/workspaceHistory', () => ({
   updateWorkspaceTime: vi.fn(),
+}));
+
+vi.mock('@/renderer/services/runtime/kiBuddyRuntime', () => ({
+  getProductExperience: () => getProductExperienceMock(),
 }));
 
 vi.mock('@arco-design/web-react', () => ({
@@ -81,6 +86,42 @@ describe('useGuidSend', () => {
     createConversationInvokeMock.mockResolvedValue({ id: 'conv-1' });
     swrMutateMock.mockReset();
     swrMutateMock.mockResolvedValue(undefined);
+    getProductExperienceMock.mockReset();
+    getProductExperienceMock.mockReturnValue({
+      behaviorDefaults: () => ({ scheduledTaskExecutor: 'assistant-or-team', autoInjectedSkillExclusions: [] }),
+    });
+  });
+
+  it('sends only the Ki-Buddy product exclusion for AionCore auto-injected Skills', async () => {
+    getProductExperienceMock.mockReturnValue({
+      behaviorDefaults: () => ({
+        scheduledTaskExecutor: 'assistant',
+        autoInjectedSkillExclusions: ['aionui-config'],
+      }),
+    });
+    const { result } = renderHook(() => useGuidSend(createDeps()));
+
+    await act(async () => {
+      await result.current.handleSend();
+    });
+
+    const payload = createConversationInvokeMock.mock.calls[0][0];
+    expect(payload.assistant?.conversation_overrides?.disabled_builtin_skill_ids).toBeUndefined();
+    expect(payload.extra.exclude_auto_inject_skills).toEqual(['aionui-config']);
+    expect(payload.extra.exclude_auto_inject_skills).not.toContain('officecli');
+    expect(payload.extra.exclude_auto_inject_skills).not.toContain('skill-creator');
+    expect(payload.extra.exclude_auto_inject_skills).not.toContain('cron');
+  });
+
+  it('does not add product auto-inject exclusions to AionUi conversation requests', async () => {
+    const { result } = renderHook(() => useGuidSend(createDeps()));
+
+    await act(async () => {
+      await result.current.handleSend();
+    });
+
+    const payload = createConversationInvokeMock.mock.calls[0][0];
+    expect(payload.extra.exclude_auto_inject_skills).toBeUndefined();
   });
 
   it('passes selected mode into assistant conversation overrides when creating a preset ACP conversation', async () => {
@@ -170,8 +211,14 @@ describe('useGuidSend', () => {
   });
 
   it('forwards local skill overrides through assistant conversation overrides for ACP assistants', async () => {
+    getProductExperienceMock.mockReturnValue({
+      behaviorDefaults: () => ({
+        scheduledTaskExecutor: 'assistant',
+        autoInjectedSkillExclusions: ['aionui-config'],
+      }),
+    });
     const deps = createDeps();
-    deps.guidEnabledSkills = ['pdf-reader'];
+    deps.guidEnabledSkills = ['team-workflow'];
     deps.guidDisabledBuiltinSkills = ['todo-tracker'];
 
     const { result } = renderHook(() => useGuidSend(deps));
@@ -182,8 +229,9 @@ describe('useGuidSend', () => {
 
     const payload = createConversationInvokeMock.mock.calls[0][0];
     expect(payload.assistant?.id).toBe('assistant-1');
-    expect(payload.assistant?.conversation_overrides?.skill_ids).toEqual(['pdf-reader']);
+    expect(payload.assistant?.conversation_overrides?.skill_ids).toEqual(['team-workflow']);
     expect(payload.assistant?.conversation_overrides?.disabled_builtin_skill_ids).toEqual(['todo-tracker']);
+    expect(payload.extra.exclude_auto_inject_skills).toEqual(['aionui-config']);
   });
 
   it('forwards local skill overrides for generated Aion CLI assistants through assistant conversation overrides', async () => {

--- a/tests/unit/skills/SkillDetailPage.dom.test.tsx
+++ b/tests/unit/skills/SkillDetailPage.dom.test.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { KI_BUDDY_PRODUCT_CAPABILITY } from '@/common/platform/ki-buddy';
 
 const mocks = vi.hoisted(() => ({
   listAvailableSkills: vi.fn(),
@@ -137,6 +138,8 @@ describe('getAssistantsUsingSkill', () => {
 describe('SkillDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.__kiBuddyProductPresentation = null;
+    window.__kiBuddyProductBootstrapError = null;
     mocks.params.skillName = 'demo-skill';
     mocks.locationState.skillsTab = 'custom';
     mocks.listAvailableSkills.mockResolvedValue([
@@ -258,6 +261,7 @@ describe('SkillDetailPage', () => {
   });
 
   it('opens the skill editing flow in chat with the skill name prefilled', async () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
     render(<SkillDetailPage />);
 
     const button = await screen.findByTestId('btn-edit-skill-via-chat');
@@ -267,5 +271,28 @@ describe('SkillDetailPage', () => {
       prompt:
         "I'd like to improve this Skill: demo-skill\n\nPlease review its content and help me make improvements. My suggestions are:",
     });
+  });
+
+  it('keeps a Ki-Buddy Office Skill usable without exposing definition editing', async () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    mocks.params.skillName = 'officecli-docx';
+    mocks.locationState.skillsTab = 'official';
+    mocks.listAvailableSkills.mockResolvedValue([
+      {
+        name: 'officecli-docx',
+        description: 'Word documents.',
+        location: '/tmp/builtin-skills/officecli-docx/SKILL.md',
+        relative_location: 'officecli-docx/SKILL.md',
+        is_auto_inject: false,
+        is_custom: false,
+        source: 'builtin',
+      },
+    ]);
+
+    render(<SkillDetailPage />);
+
+    await waitFor(() => expect(screen.getByTestId('skill-detail-info')).toBeInTheDocument());
+    expect(screen.getByTestId('btn-add-assistant')).toBeInTheDocument();
+    expect(screen.queryByTestId('btn-edit-skill-via-chat')).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/skills/SkillsHubSettings.dom.test.tsx
+++ b/tests/unit/skills/SkillsHubSettings.dom.test.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { KI_BUDDY_PRODUCT_CAPABILITY } from '@/common/platform/ki-buddy';
 
 const mocks = vi.hoisted(() => ({
   listAvailableSkills: vi.fn(),
@@ -104,6 +105,8 @@ describe('SkillsHubSettings', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    window.__kiBuddyProductPresentation = null;
+    window.__kiBuddyProductBootstrapError = null;
     searchParamsMock.current = new URLSearchParams();
     searchParamsMock.pathname = '/settings/capabilities';
     searchParamsMock.state = undefined;
@@ -378,6 +381,78 @@ describe('SkillsHubSettings', () => {
     expect(screen.queryByText('job-generated')).not.toBeInTheDocument();
     // The custom skill is not in the Official tab.
     expect(screen.queryByTestId('my-skill-card-sample-single')).not.toBeInTheDocument();
+  });
+
+  it('uses the Ki-Buddy Skill catalog while keeping Custom Skill management available', async () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    mocks.listAvailableSkills.mockResolvedValue([
+      {
+        name: 'officecli-docx',
+        description: 'Word documents.',
+        location: '/tmp/builtin-skills/officecli-docx/SKILL.md',
+        relative_location: 'officecli-docx/SKILL.md',
+        is_auto_inject: false,
+        is_custom: false,
+        source: 'builtin',
+      },
+      {
+        name: 'mermaid',
+        description: 'Hidden upstream skill.',
+        location: '/tmp/builtin-skills/mermaid/SKILL.md',
+        relative_location: 'mermaid/SKILL.md',
+        is_auto_inject: false,
+        is_custom: false,
+        source: 'builtin',
+      },
+      {
+        name: 'cron',
+        description: 'Visible auto-injected skill.',
+        location: '/tmp/builtin-skills/auto-inject/cron/SKILL.md',
+        relative_location: 'auto-inject/cron/SKILL.md',
+        is_auto_inject: true,
+        is_custom: false,
+        source: 'builtin',
+      },
+      {
+        name: 'aionui-config',
+        description: 'Excluded auto-injected skill.',
+        location: '/tmp/builtin-skills/auto-inject/aionui-config/SKILL.md',
+        relative_location: 'auto-inject/aionui-config/SKILL.md',
+        is_auto_inject: true,
+        is_custom: false,
+        source: 'builtin',
+      },
+      {
+        name: 'extension-skill',
+        description: 'Hidden extension skill.',
+        location: '/tmp/extensions/extension-skill/SKILL.md',
+        is_auto_inject: false,
+        is_custom: false,
+        source: 'extension',
+      },
+      {
+        name: 'team-workflow',
+        description: 'Managed Custom Skill.',
+        location: '/tmp/user-skills/team-workflow/SKILL.md',
+        is_auto_inject: false,
+        is_custom: true,
+        source: 'custom',
+      },
+    ]);
+
+    render(<SkillsHubSettings withWrapper={false} />);
+
+    const customSkill = await screen.findByTestId('my-skill-card-team-workflow');
+    expect(customSkill).toBeInTheDocument();
+    expect(screen.getByTestId('btn-add-skill')).toBeInTheDocument();
+    expect(screen.getByTestId('btn-delete-team-workflow')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('settings-tab-official'));
+    expect(screen.getByTestId('official-skill-card-officecli-docx')).toBeInTheDocument();
+    expect(screen.queryByText('mermaid')).not.toBeInTheDocument();
+    expect(screen.getByTestId('auto-skills-section')).toHaveTextContent('cron');
+    expect(screen.queryByText('aionui-config')).not.toBeInTheDocument();
+    expect(screen.queryByText('extension-skill')).not.toBeInTheDocument();
   });
 
   it('restores the originating tab and preserves it when opening another skill', async () => {


### PR DESCRIPTION
# Pull Request

## Description

统一 Ki-Buddy 的 Skill 产品资源访问规则，并保持资源可见性、会话选择与 AionCore 自动注入语义相互独立。

主要变化：

- 通过稳定的 builtin 相对路径识别 Word、PPT、Excel 官方 Skill，Custom Skill 保持可管理和可使用。
- Ki-Buddy 隐藏普通上游 builtin、extension 与未知 Skill，并输出结构化诊断。
- 自动注入技能继续在 Skills 页独立显示，并在新会话中默认勾选；Ki-Buddy 显示 `cron`、`officecli`、`skill-creator`，不显示 `aionui-config`。
- Skills 设置、Guid、Assistant 编辑器、Slash 命令、附件菜单和会话指示器统一消费产品投影目录。
- Ki-Buddy 对话请求通过产品排除项移除 `aionui-config`；会话中手动取消勾选的自动注入技能仍会传给 AionCore。
- AionUi 保持原有 Skill 展示、选择和注入行为；catalog 请求失败时继续使用会话 Skill 快照。
- 增加资源分类、自动注入展示与默认选择、Custom Skill 管理、对话请求、异常路径和产品双分支测试。

## Related Issues

- Closes #45

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bun run test` — tests pass
- [x] `bun run test:coverage` — coverage report generated
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

未新增视觉设计。本次修正恢复既有的自动注入技能区域和会话默认勾选行为。

## Additional Context

- `just push --force-with-lease` 门禁通过：lint 0 errors、format、typecheck、i18n 和 4027 项测试通过，5 项跳过。
- `bun run test:coverage` 完成；改动核心 `kiBuddySkillCatalog.ts` 覆盖率为 100%，仓库全局 Statements 覆盖率为现有的 52.59%。
- i18n 检查存在仓库已有的缺失翻译与未知 key warning，但检查结果通过，本次未新增用户可见文案。
- 未勾选桌面端手工运行验证。此前生产打包尝试未完成：通用构建缺少 darwin-x64 bundled resources；arm64 DMG 阶段因 `hdiutil: 设备未配置` 中止。
