### PR TITLE
feat(ki-buddy): unify agent and model resource access

### DIFF
--- a/packages/desktop/src/common/adapter/httpBridge.ts
+++ b/packages/desktop/src/common/adapter/httpBridge.ts
@@ -261,7 +261,7 @@ type ProviderLike<Data, Params> = {
 
 export function withResponseMap<Raw, Mapped, Params>(
   inner: ProviderLike<Raw, Params>,
-  map: (data: Raw) => Mapped
+  map: (data: Raw) => Mapped | Promise<Mapped>
 ): ProviderLike<Mapped, Params> {
   return {
     provider: () => {},

--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -161,7 +161,7 @@ export const shell = {
 
 type AssistantPresentationMapper = {
   detail: (detail: AssistantDetail) => AssistantDetail;
-  list: (assistants: Assistant[]) => Assistant[];
+  list: (assistants: Assistant[]) => Assistant[] | Promise<Assistant[]>;
 };
 
 const IDENTITY_ASSISTANT_PRESENTATION_MAPPER: AssistantPresentationMapper = {

--- a/packages/desktop/src/renderer/hooks/agent/useManagedAgents.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useManagedAgents.ts
@@ -5,23 +5,26 @@
  */
 
 import { ipcBridge } from '@/common';
-import type { ManagedAgent } from '@/renderer/utils/model/agentTypes';
 import { MANAGED_AGENTS_SWR_KEY } from '@/renderer/utils/model/agentTypes';
 import { fetchProductManagedAgents } from '@/renderer/services/runtime/productBrandRuntime';
+import type { ProductManagedAgent } from '@/renderer/services/runtime/kiBuddyAgentCatalog';
 import useSWR, { mutate } from 'swr';
 
 export type UseManagedAgentsResult = {
-  agents: ManagedAgent[];
+  agents: ProductManagedAgent[];
   isLoading: boolean;
   isRefreshing: boolean;
   error: unknown;
-  revalidate: () => Promise<ManagedAgent[] | undefined>;
-  refreshCatalog: () => Promise<ManagedAgent[] | undefined>;
+  revalidate: () => Promise<ProductManagedAgent[] | undefined>;
+  refreshCatalog: () => Promise<ProductManagedAgent[] | undefined>;
   refreshCustomAgents: () => Promise<void>;
 };
 
-export async function refreshManagedAgentCatalogAndAssistants(): Promise<ManagedAgent[] | undefined> {
-  const [agents] = await Promise.all([mutate<ManagedAgent[]>(MANAGED_AGENTS_SWR_KEY), mutate('assistants.list')]);
+export async function refreshManagedAgentCatalogAndAssistants(): Promise<ProductManagedAgent[] | undefined> {
+  const [agents] = await Promise.all([
+    mutate<ProductManagedAgent[]>(MANAGED_AGENTS_SWR_KEY),
+    mutate('assistants.list'),
+  ]);
   return agents;
 }
 
@@ -42,12 +45,12 @@ export async function refreshManagedAgentCatalogAndAssistants(): Promise<Managed
  * Do not use this anywhere other than `AgentSettings`.
  */
 export const useManagedAgents = (): UseManagedAgentsResult => {
-  const { data, isLoading, isValidating, error } = useSWR<ManagedAgent[]>(
+  const { data, isLoading, isValidating, error } = useSWR<ProductManagedAgent[]>(
     MANAGED_AGENTS_SWR_KEY,
     fetchProductManagedAgents
   );
 
-  const revalidateManaged = () => mutate<ManagedAgent[]>(MANAGED_AGENTS_SWR_KEY);
+  const revalidateManaged = () => mutate<ProductManagedAgent[]>(MANAGED_AGENTS_SWR_KEY);
 
   return {
     agents: data ?? [],
@@ -68,8 +71,8 @@ export const useManagedAgents = (): UseManagedAgentsResult => {
  * Uses the same `/api/agents/management` payload because that endpoint is
  * backed by `agent_metadata`, where ACP catalog snapshots are persisted.
  */
-export const useManagedAgentRuntimeCatalog = (): ManagedAgent[] => {
-  const { data } = useSWR<ManagedAgent[]>(MANAGED_AGENTS_SWR_KEY, fetchProductManagedAgents);
+export const useManagedAgentRuntimeCatalog = (): ProductManagedAgent[] => {
+  const { data } = useSWR<ProductManagedAgent[]>(MANAGED_AGENTS_SWR_KEY, fetchProductManagedAgents);
   return data ?? [];
 };
 
@@ -80,7 +83,7 @@ export const useManagedAgentRuntimeCatalog = (): ManagedAgent[] => {
  * actually mutate the agent directory should invalidate the detected-agent
  * cache separately.
  */
-export async function getManagedAgents(): Promise<ManagedAgent[]> {
+export async function getManagedAgents(): Promise<ProductManagedAgent[]> {
   const data = await fetchProductManagedAgents();
   await mutate(MANAGED_AGENTS_SWR_KEY, data, { revalidate: false });
   return data;

--- a/packages/desktop/src/renderer/hooks/agent/useModelProviderList.ts
+++ b/packages/desktop/src/renderer/hooks/agent/useModelProviderList.ts
@@ -1,6 +1,6 @@
-import { ipcBridge } from '@/common';
 import { GOOGLE_AUTH_PROVIDER_ID } from '@/common/config/constants';
 import type { IProvider } from '@/common/config/storage';
+import { loadProductModelCatalog } from '@/renderer/services/runtime/kiBuddyModelCatalog';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import useSWR, { type SWRConfiguration } from 'swr';
 import { useGoogleAuthModels } from './useGoogleAuthModels';
@@ -23,7 +23,8 @@ export const PROVIDERS_SWR_OPTIONS: SWRConfiguration<IProvider[], Error> = {
 };
 
 export const fetchProviders = async (): Promise<IProvider[]> => {
-  return (await ipcBridge.mode.listProviders.invoke()) ?? [];
+  const catalog = await loadProductModelCatalog();
+  return [...catalog.visibleProviders];
 };
 
 export const useProvidersQuery = () => {

--- a/packages/desktop/src/renderer/hooks/mcp/catalog.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/catalog.ts
@@ -12,6 +12,7 @@ import {
   type ProductResourceOrigin,
 } from '@/common/platform/ki-buddy';
 import { getClientBusinessSetting } from '@/renderer/services/clientBusinessSettings';
+import { reportHiddenProductResources } from '@/renderer/services/runtime/kiBuddyProductResourceDiagnostics';
 import { getProductExperience } from '@/renderer/services/runtime/kiBuddyRuntime';
 
 type BackendMcpTransport = Exclude<IMcpServerTransport, { type: 'streamable_http' }>;
@@ -133,15 +134,6 @@ export const projectMcpCatalogCandidates = (
   };
 };
 
-/** Emits non-sensitive diagnostics for MCP resources hidden by the product policy. */
-export const reportHiddenMcpResources = (hiddenResources: readonly ProductResourceHiddenRecord[]): void => {
-  if (hiddenResources.length === 0) return;
-  console.info('[ProductExperience] MCP resources hidden by product policy', {
-    code: 'product_resource_projection',
-    resources: hiddenResources,
-  });
-};
-
 /** Evaluates registered product MCP requirements once the backend catalog can authoritatively answer. */
 export async function loadProductBuiltinMcpResourceState(
   experience: ProductExperience = getProductExperience(),
@@ -191,7 +183,7 @@ export const ensureBackendMcpCatalog = async (
     ]),
     experience
   );
-  reportHiddenMcpResources(projection.hiddenResources);
+  reportHiddenProductResources('mcp', projection.hiddenResources);
 
   const visibleServers = new Set(projection.entries.map(({ server }) => server));
   const userServers = allBackendServers.filter((server) => visibleServers.has(server));

--- a/packages/desktop/src/renderer/hooks/mcp/useMcpServers.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/useMcpServers.ts
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useMemo, useState, type SetStateAction } from '
 import { ipcBridge } from '@/common';
 import type { IMcpServer } from '@/common/config/storage';
 import type { ProductResourceHiddenRecord } from '@/common/platform/ki-buddy';
+import { reportHiddenProductResources } from '@/renderer/services/runtime/kiBuddyProductResourceDiagnostics';
 import { getProductExperience } from '@/renderer/services/runtime/kiBuddyRuntime';
 import {
   ensureBackendMcpCatalog,
   getMcpCatalogServerKey,
   projectMcpCatalogCandidates,
-  reportHiddenMcpResources,
   type McpCatalogEntry,
 } from './catalog';
 
@@ -60,7 +60,7 @@ export const useMcpServers = () => {
           converted.map((server) => ({ server, origin: 'extension' as const })),
           getProductExperience()
         );
-        reportHiddenMcpResources(projection.hiddenResources);
+        reportHiddenProductResources('mcp', projection.hiddenResources);
         setExtensionMcpCatalogEntries(projection.entries);
         setExtensionHiddenResources(projection.hiddenResources);
       })

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -108,7 +108,7 @@ import { bootstrapRendererConfig } from '@renderer/services/bootstrapRenderer';
 import BackendStartingView from './components/layout/BackendStartingView';
 import BackendStartupGate from './components/layout/BackendStartupGate';
 import KiBuddyProductIntegrityGate, {
-  KiBuddyMcpProductIntegrityGate,
+  KiBuddyProductResourceIntegrityGate,
 } from './pages/ki-buddy/KiBuddyProductIntegrityGate';
 import GpuAutoDisableNotice from './components/layout/GpuAutoDisableNotice';
 import Layout from './components/layout/Layout';
@@ -348,7 +348,7 @@ const Main = () => {
   }
 
   return (
-    <KiBuddyMcpProductIntegrityGate enabled={Boolean(kiBuddyRuntime) && status === 'authenticated'}>
+    <KiBuddyProductResourceIntegrityGate enabled={Boolean(kiBuddyRuntime) && status === 'authenticated'}>
       <Router
         layout={
           <ConversationHistoryProvider>
@@ -356,7 +356,7 @@ const Main = () => {
           </ConversationHistoryProvider>
         }
       />
-    </KiBuddyMcpProductIntegrityGate>
+    </KiBuddyProductResourceIntegrityGate>
   );
 };
 

--- a/packages/desktop/src/renderer/pages/ki-buddy/KiBuddyProductIntegrityGate.tsx
+++ b/packages/desktop/src/renderer/pages/ki-buddy/KiBuddyProductIntegrityGate.tsx
@@ -6,10 +6,13 @@ import {
 } from '@/renderer/components/layout/InstallationIntegrityDialog';
 import type { ProductBuiltinResourceState } from '@/common/platform/ki-buddy';
 import { loadProductBuiltinMcpResourceState } from '@/renderer/hooks/mcp/catalog';
+import { loadProductBuiltinAgentResourceState } from '@/renderer/services/runtime/kiBuddyAgentCatalog';
 
 type KiBuddyProductIntegrityGateProps = {
   failure: string;
 };
+
+const PRODUCT_RESOURCE_VALIDATION_RETRY_MS = 1_000;
 
 /** Blocks the business host when a recognized Ki-Buddy installation has an invalid packaged policy. */
 const KiBuddyProductIntegrityGate: React.FC<KiBuddyProductIntegrityGateProps> = ({ failure }) => {
@@ -35,8 +38,8 @@ const KiBuddyProductIntegrityGate: React.FC<KiBuddyProductIntegrityGateProps> = 
   );
 };
 
-/** Validates product-owned MCP requirements after Ki-Buddy authentication and catalog startup. */
-export const KiBuddyMcpProductIntegrityGate: React.FC<PropsWithChildren<{ enabled: boolean }>> = ({
+/** Validates product-owned resource requirements after Ki-Buddy authentication and catalog startup. */
+export const KiBuddyProductResourceIntegrityGate: React.FC<PropsWithChildren<{ enabled: boolean }>> = ({
   children,
   enabled,
 }) => {
@@ -46,15 +49,41 @@ export const KiBuddyMcpProductIntegrityGate: React.FC<PropsWithChildren<{ enable
   useEffect(() => {
     if (!enabled) return;
     let active = true;
-    void loadProductBuiltinMcpResourceState()
-      .then((state) => {
-        if (active) setResourceState(state);
-      })
-      .catch((error) => {
-        console.error('[Ki-Buddy] Failed to validate product MCP resources:', error);
+    let retryTimer: number | undefined;
+    const validateResources = async (): Promise<void> => {
+      const results = await Promise.allSettled([
+        loadProductBuiltinAgentResourceState(),
+        loadProductBuiltinMcpResourceState(),
+      ]);
+      if (!active) return;
+      const labels = ['Agent', 'MCP'] as const;
+      results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+          console.error(`[Ki-Buddy] Failed to validate product ${labels[index]} resources:`, result.reason);
+        }
       });
+      const states = results.flatMap((result) => (result.status === 'fulfilled' ? [result.value] : []));
+      const missing = states.flatMap((state) => (state.status === 'invalid' ? state.missing : []));
+      if (missing.length > 0) {
+        setResourceState({ status: 'invalid', missing });
+        return;
+      }
+      if (
+        results.some((result) => result.status === 'rejected') ||
+        states.some((state) => state.status === 'pending')
+      ) {
+        setResourceState({ status: 'pending', missing: [] });
+        retryTimer = window.setTimeout((): void => {
+          void validateResources();
+        }, PRODUCT_RESOURCE_VALIDATION_RETRY_MS);
+        return;
+      }
+      setResourceState({ status: 'ready', missing: [] });
+    };
+    void validateResources();
     return () => {
       active = false;
+      if (retryTimer !== undefined) window.clearTimeout(retryTimer);
     };
   }, [enabled]);
 
@@ -75,7 +104,7 @@ export const KiBuddyMcpProductIntegrityGate: React.FC<PropsWithChildren<{ enable
           runtime: {
             failureKind: missingResource.code,
             message: missingResource.code,
-            resource: 'product-builtin-mcp',
+            resource: `product-builtin-${missingResource.kind}`,
             resourceId: missingResource.resourceId,
             scopeKind: 'application',
           },

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
@@ -20,6 +20,7 @@ import { BoundAssistantStack } from './BoundAssistants';
 type AgentCardProps =
   | {
       type: 'official';
+      readOnly?: boolean;
       agent: ManagedAgent;
       boundAssistants: Assistant[];
       onTestConnection: () => void;
@@ -28,6 +29,7 @@ type AgentCardProps =
     }
   | {
       type: 'custom';
+      readOnly?: boolean;
       agent: ManagedAgent;
       boundAssistants: Assistant[];
       onTestConnection: () => void;
@@ -106,6 +108,7 @@ const AgentCard: React.FC<AgentCardProps> = (props) => {
   const { agent, boundAssistants, onTestConnection, onConfigure, isTesting } = props;
 
   const isCustom = props.type === 'custom';
+  const canManage = !props.readOnly;
   const isDisabled = isCustom && agent.enabled === false;
   const diagnostics = formatManagedAgentDiagnosticMessage(t, agent);
   const displayStatus = resolveDisplayStatus(agent.status, agent.last_check_error_code);
@@ -122,8 +125,8 @@ const AgentCard: React.FC<AgentCardProps> = (props) => {
   return (
     <div
       data-testid={`agent-row-${agent.id}`}
-      className='group flex cursor-pointer items-center justify-between gap-12px rounded-12px border border-solid border-transparent bg-base px-14px py-10px transition-all duration-180 hover:border-border-1 hover:bg-fill-1'
-      onClick={onConfigure}
+      className={`group flex items-center justify-between gap-12px rounded-12px border border-solid border-transparent bg-base px-14px py-10px transition-all duration-180 hover:border-border-1 hover:bg-fill-1 ${canManage ? 'cursor-pointer' : 'cursor-default'}`}
+      onClick={canManage ? onConfigure : undefined}
     >
       <div className={`flex min-w-0 flex-1 items-center gap-12px ${isDisabled ? 'opacity-50' : ''}`}>
         <Avatar
@@ -174,16 +177,18 @@ const AgentCard: React.FC<AgentCardProps> = (props) => {
         {/* Both agent kinds get an explicit Edit button that opens the same
             configuration page the whole row links to (status, path/env
             overrides, bound assistants). */}
-        <Button
-          data-testid={`agent-row-edit-${agent.id}`}
-          size='small'
-          type='outline'
-          onClick={onConfigure}
-          className='!h-30px !rounded-8px !border-border-2 !bg-base !px-10px !text-12px !font-500 !text-t-primary hover:!border-border-1 hover:!bg-fill-1'
-        >
-          {t('common.edit', { defaultValue: 'Edit' })}
-        </Button>
-        {props.type === 'custom' ? (
+        {canManage ? (
+          <Button
+            data-testid={`agent-row-edit-${agent.id}`}
+            size='small'
+            type='outline'
+            onClick={onConfigure}
+            className='!h-30px !rounded-8px !border-border-2 !bg-base !px-10px !text-12px !font-500 !text-t-primary hover:!border-border-1 hover:!bg-fill-1'
+          >
+            {t('common.edit', { defaultValue: 'Edit' })}
+          </Button>
+        ) : null}
+        {props.type === 'custom' && canManage ? (
           <>
             {/* Custom agents add the definition editor (command/args/env) plus
                 enable/delete — controls that have no meaning for built-ins. */}

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/LocalAgents.tsx
@@ -54,7 +54,7 @@ const LocalAgents: React.FC = () => {
     (a) => a.agent_source !== 'custom' && !isDeprecatedRuntimeAgentType(a.agent_type)
   );
 
-  const customAgents: ManagedAgent[] = allAgents.filter((a) => a.agent_source === 'custom');
+  const customAgents = allAgents.filter((a) => a.agent_source === 'custom');
 
   const [editorVisible, setEditorVisible] = useState(false);
   const [editingAgent, setEditingAgent] = useState<ManagedAgent | null>(null);
@@ -285,6 +285,7 @@ const LocalAgents: React.FC = () => {
             <AgentCard
               key={agent.id}
               type='official'
+              readOnly={agent.productAccess !== 'manage'}
               agent={agent}
               boundAssistants={getBoundAssistants(agent, assistants)}
               onTestConnection={() => void handleTestConnection(agent.id)}
@@ -357,6 +358,7 @@ const LocalAgents: React.FC = () => {
             <AgentCard
               key={agent.id}
               type='custom'
+              readOnly={agent.productAccess !== 'manage'}
               agent={agent}
               boundAssistants={getBoundAssistants(agent, assistants)}
               onTestConnection={() => void handleTestConnection(agent.id)}

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/agentFilters.ts
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/agentFilters.ts
@@ -10,7 +10,10 @@ export const getAgentAvailabilityFilterStats = (agents: ManagedAgent[]) => ({
   unavailable: agents.filter((agent) => !isAgentAvailable(agent)).length,
 });
 
-export const filterAgentsByAvailability = (agents: ManagedAgent[], filter: AgentAvailabilityFilter): ManagedAgent[] => {
+export const filterAgentsByAvailability = <T extends ManagedAgent>(
+  agents: T[],
+  filter: AgentAvailabilityFilter
+): T[] => {
   if (filter === 'available') {
     return agents.filter(isAgentAvailable);
   }

--- a/packages/desktop/src/renderer/services/runtime/kiBuddyAgentCatalog.ts
+++ b/packages/desktop/src/renderer/services/runtime/kiBuddyAgentCatalog.ts
@@ -1,0 +1,146 @@
+import {
+  evaluateProductBuiltinResourceState,
+  projectProductResources,
+  type ProductBuiltinResourceRequirement,
+  type ProductBuiltinResourceState,
+  type ProductExperience,
+  type ProductResourceAccess,
+  type ProductResourceHiddenRecord,
+  type ProductResourceOrigin,
+} from '@/common/platform/ki-buddy';
+import type { Assistant } from '@/common/types/agent/assistantTypes';
+import { requestManagedAgents, type ManagedAgent } from '@/renderer/utils/model/agentTypes';
+import { getKiBuddyProductRuntime, getProductExperience } from './kiBuddyRuntime';
+import { reportHiddenProductResources } from './kiBuddyProductResourceDiagnostics';
+
+export const KI_CLI_PRODUCT_RESOURCE_ID = '632f31d2';
+
+const getProductBuiltinAgentRequirements = (): readonly ProductBuiltinResourceRequirement[] => {
+  const resourceName = getKiBuddyProductRuntime()?.brand.cliName;
+  return [
+    {
+      featureId: 'agents',
+      resourceId: KI_CLI_PRODUCT_RESOURCE_ID,
+      ...(resourceName ? { resourceName } : {}),
+    },
+  ];
+};
+
+export type ProductAgentCatalogEntry = Readonly<{
+  access: Exclude<ProductResourceAccess, 'hidden'>;
+  agent: ProductManagedAgent;
+  origin: ProductResourceOrigin;
+  resourceId: string;
+}>;
+
+export type ProductManagedAgent = ManagedAgent &
+  Readonly<{
+    productAccess: Exclude<ProductResourceAccess, 'hidden'>;
+  }>;
+
+export type ProductAgentCatalog = Readonly<{
+  entries: readonly ProductAgentCatalogEntry[];
+  hiddenResources: readonly ProductResourceHiddenRecord[];
+  visibleAgents: readonly ProductManagedAgent[];
+}>;
+
+const resolveProductAgentOrigin = (agent: ManagedAgent): ProductResourceOrigin => {
+  if (agent.agent_source === 'custom') return 'custom';
+  if (agent.agent_source === 'extension' || agent.isExtension === true) return 'extension';
+  if (agent.id === KI_CLI_PRODUCT_RESOURCE_ID && agent.agent_source === 'internal' && agent.agent_type === 'aionrs') {
+    return 'productBuiltin';
+  }
+  if (agent.agent_source === 'builtin') return 'upstreamBuiltin';
+  return 'unclassified';
+};
+
+const toProductAgentResource = (agent: ManagedAgent) => ({
+  id: agent.id,
+  name: agent.name,
+  origin: resolveProductAgentOrigin(agent),
+  agent,
+});
+
+/** Applies product access to stable Agent IDs plus backend source/type identity. */
+export const projectProductAgentCatalog = (
+  agents: readonly ManagedAgent[],
+  experience: ProductExperience
+): ProductAgentCatalog => {
+  const projection = projectProductResources(experience, 'agent', agents.map(toProductAgentResource));
+  const entries = projection.visible.map(({ resource, access }) => ({
+    access,
+    agent: { ...resource.agent, productAccess: access },
+    origin: resource.origin,
+    resourceId: resource.id,
+  }));
+
+  return {
+    entries,
+    hiddenResources: projection.hidden,
+    visibleAgents: entries.map(({ agent }) => agent),
+  };
+};
+
+/** Keeps Assistant candidates only when their stable Agent ID exists in the authoritative projected directory. */
+export const projectProductAssistantCandidates = (
+  assistants: readonly Assistant[],
+  agentCatalog: ProductAgentCatalog
+): Assistant[] => {
+  const visibleAgentIds = new Set(agentCatalog.entries.map(({ resourceId }) => resourceId));
+  const hiddenAssistants = assistants.filter((assistant) => !visibleAgentIds.has(assistant.agent_id));
+  reportHiddenProductResources(
+    'assistant',
+    hiddenAssistants.map((assistant) => ({
+      access: 'hidden',
+      code: 'product_resource_hidden',
+      kind: 'assistant',
+      origin: 'unclassified',
+      resourceId: assistant.id,
+      resourceName: assistant.name,
+    }))
+  );
+  return assistants.filter((assistant) => visibleAgentIds.has(assistant.agent_id));
+};
+
+/** Loads and projects the authoritative Agent directory for every renderer consumer. */
+export const loadProductAgentCatalog = async (
+  experience: ProductExperience = getProductExperience()
+): Promise<ProductAgentCatalog> => {
+  const catalog = projectProductAgentCatalog(await requestManagedAgents(), experience);
+  reportHiddenProductResources('agent', catalog.hiddenResources);
+  return catalog;
+};
+
+/** Projects Assistant candidates against the same authoritative Agent directory used by settings. */
+export const loadProductAssistantCandidates = async (
+  assistants: readonly Assistant[],
+  experience: ProductExperience = getProductExperience()
+): Promise<Assistant[]> => projectProductAssistantCandidates(assistants, await loadProductAgentCatalog(experience));
+
+/** Evaluates the required KiCLI identity after the backend Agent directory is ready. */
+export const loadProductBuiltinAgentResourceState = async (
+  experience: ProductExperience = getProductExperience(),
+  requirements: readonly ProductBuiltinResourceRequirement[] = getProductBuiltinAgentRequirements()
+): Promise<ProductBuiltinResourceState> => {
+  const pendingState = evaluateProductBuiltinResourceState(experience, 'agent', {
+    availableResourceIds: [],
+    catalogReady: false,
+    requirements,
+  });
+  if (pendingState.status !== 'pending') return pendingState;
+
+  try {
+    const catalog = await loadProductAgentCatalog(experience);
+    const availableResourceIds = catalog.entries
+      .filter(({ origin }) => origin === 'productBuiltin')
+      .map(({ resourceId }) => resourceId);
+    return evaluateProductBuiltinResourceState(experience, 'agent', {
+      availableResourceIds,
+      catalogReady: true,
+      requirements,
+    });
+  } catch (error) {
+    console.error('[ProductExperience] Failed to load the Agent catalog for product integrity validation', error);
+    return pendingState;
+  }
+};

--- a/packages/desktop/src/renderer/services/runtime/kiBuddyModelCatalog.ts
+++ b/packages/desktop/src/renderer/services/runtime/kiBuddyModelCatalog.ts
@@ -1,0 +1,79 @@
+import { ipcBridge } from '@/common';
+import type { IProvider } from '@/common/config/storage';
+import {
+  projectProductResources,
+  type ProductExperience,
+  type ProductResourceAccess,
+  type ProductResourceHiddenRecord,
+  type ProductResourceOrigin,
+} from '@/common/platform/ki-buddy';
+import { getProductExperience } from './kiBuddyRuntime';
+import { reportHiddenProductResources } from './kiBuddyProductResourceDiagnostics';
+
+export type ProductModelCatalogEntry = Readonly<{
+  access: Exclude<ProductResourceAccess, 'hidden'>;
+  modelId: string;
+  origin: ProductResourceOrigin;
+  providerId: string;
+  resourceId: string;
+}>;
+
+export type ProductModelCatalog = Readonly<{
+  entries: readonly ProductModelCatalogEntry[];
+  hiddenResources: readonly ProductResourceHiddenRecord[];
+  visibleProviders: readonly IProvider[];
+}>;
+
+const getModelResourceId = (providerId: string, modelId: string) => `provider:${providerId}/model:${modelId}`;
+
+/** Projects user-managed provider models through the shared product resource policy. */
+export const projectProductModelCatalog = (
+  providers: readonly IProvider[],
+  experience: ProductExperience
+): ProductModelCatalog => {
+  const projection = projectProductResources(
+    experience,
+    'model',
+    providers.flatMap((provider) =>
+      provider.models.map((modelId) => ({
+        id: getModelResourceId(provider.id, modelId),
+        name: modelId,
+        origin: 'custom' as const,
+        modelId,
+        providerId: provider.id,
+      }))
+    )
+  );
+  const entries = projection.visible.map(({ resource, access }) => ({
+    access,
+    modelId: resource.modelId,
+    origin: resource.origin,
+    providerId: resource.providerId,
+    resourceId: resource.id,
+  }));
+  const visibleResourceIds = new Set(entries.map(({ resourceId }) => resourceId));
+  const customModelsVisible = experience.resourceAccess('model', 'custom') !== 'hidden';
+  const visibleProviders = providers.flatMap((provider): IProvider[] => {
+    if (provider.models.length === 0) return customModelsVisible ? [provider] : [];
+    const models = provider.models.filter((modelId) =>
+      visibleResourceIds.has(getModelResourceId(provider.id, modelId))
+    );
+    return models.length > 0 ? [{ ...provider, models }] : [];
+  });
+
+  return {
+    entries,
+    hiddenResources: projection.hidden,
+    visibleProviders,
+  };
+};
+
+/** Loads the provider directory and applies one Model projection for every renderer consumer. */
+export const loadProductModelCatalog = async (
+  experience: ProductExperience = getProductExperience()
+): Promise<ProductModelCatalog> => {
+  const providers = (await ipcBridge.mode.listProviders.invoke()) ?? [];
+  const catalog = projectProductModelCatalog(providers, experience);
+  reportHiddenProductResources('model', catalog.hiddenResources);
+  return catalog;
+};

--- a/packages/desktop/src/renderer/services/runtime/kiBuddyProductResourceDiagnostics.ts
+++ b/packages/desktop/src/renderer/services/runtime/kiBuddyProductResourceDiagnostics.ts
@@ -1,0 +1,21 @@
+import type { ProductResourceHiddenRecord, ProductResourceKind } from '@/common/platform/ki-buddy';
+
+const RESOURCE_KIND_LABELS: Record<ProductResourceKind, string> = {
+  agent: 'Agent',
+  assistant: 'Assistant',
+  mcp: 'MCP',
+  model: 'Model',
+  skill: 'Skill',
+};
+
+/** Emits non-sensitive diagnostics for resources hidden by the active product policy. */
+export function reportHiddenProductResources(
+  kind: ProductResourceKind,
+  hiddenResources: readonly ProductResourceHiddenRecord[]
+): void {
+  if (hiddenResources.length === 0) return;
+  console.info(`[ProductExperience] ${RESOURCE_KIND_LABELS[kind]} resources hidden by product policy`, {
+    code: 'product_resource_projection',
+    resources: hiddenResources,
+  });
+}

--- a/packages/desktop/src/renderer/services/runtime/kiBuddySkillCatalog.ts
+++ b/packages/desktop/src/renderer/services/runtime/kiBuddySkillCatalog.ts
@@ -6,6 +6,7 @@ import {
   type ProductResourceHiddenRecord,
   type ProductResourceOrigin,
 } from '@/common/platform/ki-buddy';
+import { reportHiddenProductResources } from './kiBuddyProductResourceDiagnostics';
 import { getProductExperience } from './kiBuddyRuntime';
 
 export type AvailableSkill = Awaited<ReturnType<typeof ipcBridge.fs.listAvailableSkills.invoke>>[number];
@@ -100,15 +101,6 @@ export const projectProductSkillCatalog = (
   };
 };
 
-/** Emits non-sensitive diagnostics for Skill resources hidden by the product policy. */
-export const reportHiddenProductSkills = (hiddenResources: readonly ProductResourceHiddenRecord[]): void => {
-  if (hiddenResources.length === 0) return;
-  console.info('[ProductExperience] Skill resources hidden by product policy', {
-    code: 'product_resource_projection',
-    resources: hiddenResources,
-  });
-};
-
 /** Keeps runtime-loaded Skill names that remain visible in the active product catalog. */
 export const filterProductVisibleSkillNames = (
   names: readonly string[] | undefined,
@@ -132,6 +124,6 @@ export const loadProductSkillCatalog = async (
 ): Promise<ProductSkillCatalog> => {
   const skills = await ipcBridge.fs.listAvailableSkills.invoke();
   const catalog = projectProductSkillCatalog(skills, experience);
-  reportHiddenProductSkills(catalog.hiddenResources);
+  reportHiddenProductResources('skill', catalog.hiddenResources);
   return catalog;
 };

--- a/packages/desktop/src/renderer/services/runtime/productBrandRuntime.ts
+++ b/packages/desktop/src/renderer/services/runtime/productBrandRuntime.ts
@@ -2,7 +2,11 @@ import aionUiLogoUrl from '@/renderer/assets/logos/brand/app.png';
 import { configureAssistantPresentationMapper } from '@/common/adapter/ipcBridge';
 import type { TConversationAssistantIdentity } from '@/common/config/storage';
 import type { Assistant, AssistantAgent, AssistantDetail } from '@/common/types/agent/assistantTypes';
-import { fetchManagedAgents, type ManagedAgent } from '@/renderer/utils/model/agentTypes';
+import {
+  loadProductAgentCatalog,
+  loadProductAssistantCandidates,
+  type ProductManagedAgent,
+} from './kiBuddyAgentCatalog';
 import { getKiBuddyProductRuntime } from './kiBuddyRuntime';
 import { createKiBuddyPresentationAdapter } from './kiBuddyPresentationAdapter';
 import type {
@@ -71,9 +75,9 @@ export function adaptProductAgentIdentity<T extends AgentIdentity>(agent: T): T 
 }
 
 /** Fetches the managed-agent catalog with product identity applied at one shared boundary. */
-export async function fetchProductManagedAgents(): Promise<ManagedAgent[]> {
-  const agents = await fetchManagedAgents();
-  return agents.map(adaptProductAgentIdentity);
+export async function fetchProductManagedAgents(): Promise<ProductManagedAgent[]> {
+  const catalog = await loadProductAgentCatalog();
+  return catalog.visibleAgents.map(adaptProductAgentIdentity);
 }
 
 /** Resolves the product logo for views that display the internal CLI as an assistant runtime. */
@@ -101,7 +105,8 @@ export function installProductAssistantCatalogAdapter(): void {
   if (!getKiBuddyProductRuntime()) return;
   configureAssistantPresentationMapper({
     detail: adaptProductAssistantDetailIdentity,
-    list: (assistants: Assistant[]) => assistants.map(adaptProductAssistantIdentity),
+    list: async (assistants: Assistant[]) =>
+      (await loadProductAssistantCandidates(assistants)).map(adaptProductAssistantIdentity),
   });
 }
 

--- a/packages/desktop/src/renderer/utils/model/agentTypes.ts
+++ b/packages/desktop/src/renderer/utils/model/agentTypes.ts
@@ -158,6 +158,12 @@ export type ManagedAgent = Omit<AgentMetadata, 'available' | 'handshake'> & {
   handshake?: AgentHandshake;
 };
 
+/** Requests the managed Agent directory while preserving transport failures for authoritative consumers. */
+export async function requestManagedAgents(): Promise<ManagedAgent[]> {
+  const agents = await ipcBridge.acpConversation.getManagedAgents.invoke();
+  return Array.isArray(agents) ? (agents as ManagedAgent[]) : [];
+}
+
 /**
  * Fetcher for MANAGED_AGENTS_SWR_KEY — the Agent settings management view.
  * Hits `/api/agents/management` so user-disabled and missing rows remain
@@ -167,14 +173,10 @@ export type ManagedAgent = Omit<AgentMetadata, 'available' | 'handshake'> & {
  */
 export async function fetchManagedAgents(): Promise<ManagedAgent[]> {
   try {
-    const agents = await ipcBridge.acpConversation.getManagedAgents.invoke();
-    if (Array.isArray(agents)) {
-      return agents as ManagedAgent[];
-    }
+    return await requestManagedAgents();
   } catch {
-    // fallback to empty
+    return [];
   }
-  return [];
 }
 
 const getAgentManagementErrorDetails = (details: unknown): AgentManagementErrorDetails => {

--- a/tests/unit/assets/agentLogo.test.ts
+++ b/tests/unit/assets/agentLogo.test.ts
@@ -149,7 +149,7 @@ describe('agentLogo', () => {
       vi.stubGlobal('window', { __kiBuddyProductPresentation: KI_BUDDY_PRODUCT_CAPABILITY });
       bridgeMocks.getManagedAgents.mockResolvedValue([
         {
-          id: 'aionrs',
+          id: '632f31d2',
           name: 'Aion CLI',
           agent_type: 'aionrs',
           agent_source: 'internal',

--- a/tests/unit/renderer/LocalAgents.dom.test.tsx
+++ b/tests/unit/renderer/LocalAgents.dom.test.tsx
@@ -102,7 +102,7 @@ import type { Assistant } from '@/common/types/agent/assistantTypes';
 
 const makeAgents = () => [
   {
-    id: 'aionrs',
+    id: '632f31d2',
     name: 'Aion CLI',
     agent_type: 'aionrs',
     agent_source: 'internal',
@@ -111,6 +111,7 @@ const makeAgents = () => [
     available: true,
     installed: true,
     status: 'online',
+    productAccess: 'use',
   },
   {
     id: 'acp-claude',
@@ -122,6 +123,7 @@ const makeAgents = () => [
     available: false,
     installed: false,
     status: 'missing',
+    productAccess: 'manage',
   },
   {
     id: 'openclaw-gateway',
@@ -133,6 +135,7 @@ const makeAgents = () => [
     available: false,
     installed: false,
     status: 'missing',
+    productAccess: 'manage',
   },
   {
     id: 'custom-1',
@@ -144,6 +147,7 @@ const makeAgents = () => [
     available: true,
     installed: true,
     status: 'offline',
+    productAccess: 'manage',
   },
 ];
 
@@ -161,7 +165,7 @@ describe('LocalAgents', () => {
     fireEvent.click(screen.getAllByText('settings.agentManagement.testConnection')[0]);
 
     await waitFor(() => {
-      expect(ipcBridge.acpConversation.checkManagedAgentHealthById.invoke).toHaveBeenCalledWith({ id: 'aionrs' });
+      expect(ipcBridge.acpConversation.checkManagedAgentHealthById.invoke).toHaveBeenCalledWith({ id: '632f31d2' });
     });
     await waitFor(() => {
       expect(refreshCatalog).toHaveBeenCalled();
@@ -202,6 +206,20 @@ describe('LocalAgents', () => {
     expect(screen.getByText('Aion CLI')).toBeTruthy();
     expect(screen.getByText('Claude Code')).toBeTruthy();
     expect(screen.getByText('My Agent')).toBeTruthy();
+  });
+
+  it('keeps a use-only product Agent testable without management actions', () => {
+    useManagedAgents.mockReturnValue({
+      agents: makeAgents(),
+      revalidate: vi.fn(),
+      refreshCatalog: vi.fn(),
+    });
+
+    render(<LocalAgents />);
+
+    expect(screen.getByTestId('agent-row-test-632f31d2')).toBeInTheDocument();
+    expect(screen.queryByTestId('agent-row-edit-632f31d2')).toBeNull();
+    expect(screen.getByTestId('agent-row-edit-custom-1')).toBeInTheDocument();
   });
 
   it('shows the empty state when no detected agents are present', () => {
@@ -360,6 +378,7 @@ describe('LocalAgents', () => {
           available: false,
           installed: false,
           status: 'missing',
+          productAccess: 'manage',
         },
       ],
       revalidate: vi.fn(),

--- a/tests/unit/renderer/agentTypes.test.ts
+++ b/tests/unit/renderer/agentTypes.test.ts
@@ -1,7 +1,17 @@
 import type { TFunction } from 'i18next';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { ManagedAgent } from '@/renderer/utils/model/agentTypes';
-import { formatManagedAgentDiagnosticMessage } from '@/renderer/utils/model/agentTypes';
+import { formatManagedAgentDiagnosticMessage, requestManagedAgents } from '@/renderer/utils/model/agentTypes';
+
+const { getManagedAgentsMock } = vi.hoisted(() => ({ getManagedAgentsMock: vi.fn() }));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      getManagedAgents: { invoke: getManagedAgentsMock },
+    },
+  },
+}));
 
 const t = ((key: string, options?: Record<string, unknown>) => {
   switch (key) {
@@ -56,5 +66,14 @@ describe('formatManagedAgentDiagnosticMessage', () => {
     );
 
     expect(message).toBe('raw backend message');
+  });
+});
+
+describe('requestManagedAgents', () => {
+  it('preserves a transport failure for authoritative catalog consumers', async () => {
+    const error = new Error('backend unavailable');
+    getManagedAgentsMock.mockRejectedValue(error);
+
+    await expect(requestManagedAgents()).rejects.toBe(error);
   });
 });

--- a/tests/unit/renderer/components/settings/SettingsModal/contents/AgentModalContent.dom.test.tsx
+++ b/tests/unit/renderer/components/settings/SettingsModal/contents/AgentModalContent.dom.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { expect, it, vi } from 'vitest';
+
+vi.mock('@/renderer/pages/settings/AgentSettings/LocalAgents', () => ({
+  default: () => <div>Projected Agent directory</div>,
+}));
+
+vi.mock('@/renderer/components/base/AionScrollArea', () => ({
+  default: ({ children, disableOverflow }: { children: React.ReactNode; disableOverflow?: boolean }) => (
+    <div data-disable-overflow={String(disableOverflow)}>{children}</div>
+  ),
+}));
+
+vi.mock('@/renderer/components/settings/SettingsModal/settingsViewContext', () => ({
+  useSettingsViewMode: () => 'page',
+}));
+
+import AgentModalContent from '@/renderer/components/settings/SettingsModal/contents/AgentModalContent';
+
+it('mounts the shared Agent settings directory in page mode', () => {
+  render(<AgentModalContent />);
+
+  expect(screen.getByText('Projected Agent directory')).toBeInTheDocument();
+  expect(screen.getByText('Projected Agent directory').parentElement).toHaveAttribute('data-disable-overflow', 'true');
+});

--- a/tests/unit/renderer/components/settings/SettingsModal/contents/ModelModalContent.dom.test.tsx
+++ b/tests/unit/renderer/components/settings/SettingsModal/contents/ModelModalContent.dom.test.tsx
@@ -1,0 +1,161 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, expect, it, vi } from 'vitest';
+import type { IProvider } from '@/common/config/storage';
+
+const { mocks, provider } = vi.hoisted(() => ({
+  mocks: {
+    addModelOpen: vi.fn(),
+    addPlatformOpen: vi.fn(),
+    deleteProvider: vi.fn(),
+    editProviderOpen: vi.fn(),
+    mutate: vi.fn(),
+    updateProvider: vi.fn(),
+  },
+  provider: {
+    id: 'provider-1',
+    platform: 'openai',
+    name: 'Primary Provider',
+    base_url: 'https://example.invalid',
+    api_key: 'secret',
+    models: ['model-one'],
+  } satisfies IProvider,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@arco-design/web-react', async () => {
+  const actual = await vi.importActual<typeof import('@arco-design/web-react')>('@arco-design/web-react');
+  return {
+    ...actual,
+    Popconfirm: ({ children, onOk }: { children: React.ReactNode; onOk?: () => void }) => (
+      <span onClick={() => onOk?.()}>{children}</span>
+    ),
+  };
+});
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      checkProviderHealth: { invoke: vi.fn() },
+    },
+    mode: {
+      createProvider: { invoke: vi.fn() },
+      deleteProvider: { invoke: mocks.deleteProvider },
+      listProviders: { invoke: vi.fn().mockResolvedValue([provider]) },
+      updateProvider: { invoke: mocks.updateProvider },
+    },
+  },
+}));
+
+vi.mock('@/renderer/hooks/agent/useModelProviderList', () => ({
+  useProvidersQuery: () => ({ data: [provider], mutate: mocks.mutate }),
+}));
+
+vi.mock('@/renderer/pages/settings/components/AddPlatformModal', () => ({
+  default: {
+    useModal: () => [{ open: mocks.addPlatformOpen, close: vi.fn() }, <div key='add-platform-modal' />],
+  },
+}));
+
+vi.mock('@/renderer/pages/settings/components/AddModelModal', () => ({
+  default: {
+    useModal: () => [{ open: mocks.addModelOpen, close: vi.fn() }, <div key='add-model-modal' />],
+  },
+}));
+
+vi.mock('@/renderer/pages/settings/components/EditModeModal', () => ({
+  default: {
+    useModal: () => [{ open: mocks.editProviderOpen, close: vi.fn() }, <div key='edit-provider-modal' />],
+  },
+}));
+
+vi.mock('@/renderer/components/base/TalkToButlerButton', () => ({
+  default: ({ onManual }: { onManual: () => void }) => (
+    <button data-testid='add-provider' onClick={onManual}>
+      add provider
+    </button>
+  ),
+}));
+
+vi.mock('@/renderer/components/settings/SettingsModal/settingsViewContext', () => ({
+  useSettingsViewMode: () => 'page',
+}));
+
+vi.mock('@/renderer/hooks/system/useDeepLink', () => ({
+  consumePendingDeepLink: () => null,
+}));
+
+vi.mock('@/renderer/services/runtime/productBrandRuntime', () => ({
+  getProductDocumentationUrl: (url: string) => url,
+}));
+
+import ModelModalContent from '@/renderer/components/settings/SettingsModal/contents/ModelModalContent';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.deleteProvider.mockResolvedValue(undefined);
+  mocks.mutate.mockResolvedValue(undefined);
+  mocks.updateProvider.mockResolvedValue(undefined);
+});
+
+const renderContent = () => render(<ModelModalContent />);
+
+it('shows providers from the projected Model directory', () => {
+  renderContent();
+
+  expect(screen.getByText('Primary Provider')).toBeInTheDocument();
+});
+
+it('keeps provider creation available from the projected Model directory', () => {
+  renderContent();
+
+  fireEvent.click(screen.getByTestId('add-provider'));
+  expect(mocks.addPlatformOpen).toHaveBeenCalledOnce();
+});
+
+it('keeps model creation available from the projected Model directory', () => {
+  const { container } = render(<ModelModalContent />);
+
+  const providerActions = container.querySelectorAll<HTMLButtonElement>('.model-provider-action-btn');
+  expect(providerActions).toHaveLength(3);
+
+  fireEvent.click(providerActions[0]);
+  expect(mocks.addModelOpen).toHaveBeenCalledWith({ data: provider });
+});
+
+it('keeps provider editing available from the projected Model directory', () => {
+  const { container } = renderContent();
+  const providerActions = container.querySelectorAll<HTMLButtonElement>('.model-provider-action-btn');
+
+  fireEvent.click(providerActions[2]);
+  expect(mocks.editProviderOpen).toHaveBeenCalledWith({ data: provider });
+});
+
+it('keeps provider deletion available from the projected Model directory', async () => {
+  const { container } = renderContent();
+  const providerActions = container.querySelectorAll<HTMLButtonElement>('.model-provider-action-btn');
+
+  fireEvent.click(providerActions[1]);
+  await waitFor(() => expect(mocks.deleteProvider).toHaveBeenCalledWith({ id: provider.id }));
+});
+
+it('keeps model selection available from the projected Model directory', async () => {
+  renderContent();
+
+  const switches = screen.getAllByRole('switch');
+  fireEvent.click(switches[0]);
+  await waitFor(() =>
+    expect(mocks.updateProvider).toHaveBeenCalledWith({
+      id: provider.id,
+      model_enabled: { 'model-one': false },
+      platform: provider.platform,
+      name: provider.name,
+      base_url: provider.base_url,
+      api_key: provider.api_key,
+      models: provider.models,
+    })
+  );
+});

--- a/tests/unit/renderer/hooks/agent/useManagedAgents.dom.test.ts
+++ b/tests/unit/renderer/hooks/agent/useManagedAgents.dom.test.ts
@@ -15,9 +15,15 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
+const { fetchProductManagedAgentsMock, mutateMock, useSWRMock } = vi.hoisted(() => ({
+  fetchProductManagedAgentsMock: vi.fn(),
+  mutateMock: vi.fn().mockResolvedValue(undefined),
+  useSWRMock: vi.fn(() => ({ data: [], error: null, isLoading: false })),
+}));
+
 vi.mock('swr', () => ({
-  default: vi.fn(() => ({ data: [], error: null, isLoading: false })),
-  mutate: vi.fn().mockResolvedValue(undefined),
+  default: useSWRMock,
+  mutate: mutateMock,
 }));
 
 vi.mock('@/common', () => ({
@@ -33,13 +39,15 @@ vi.mock('@/renderer/utils/model/agentTypes', () => ({
 }));
 
 vi.mock('@/renderer/services/runtime/productBrandRuntime', () => ({
-  fetchProductManagedAgents: vi.fn(),
+  fetchProductManagedAgents: fetchProductManagedAgentsMock,
 }));
 
-import { getManagedAgents, useManagedAgents } from '@/renderer/hooks/agent/useManagedAgents';
+import {
+  getManagedAgents,
+  useManagedAgentRuntimeCatalog,
+  useManagedAgents,
+} from '@/renderer/hooks/agent/useManagedAgents';
 import { ipcBridge } from '@/common';
-import useSWR, { mutate } from 'swr';
-import { fetchProductManagedAgents } from '@/renderer/services/runtime/productBrandRuntime';
 
 describe('useManagedAgents', () => {
   beforeEach(() => {
@@ -47,18 +55,31 @@ describe('useManagedAgents', () => {
   });
 
   it('subscribes to the management SWR key with the managed fetcher', () => {
-    (useSWR as any).mockReturnValue({ data: [], error: null, isLoading: false });
+    useSWRMock.mockReturnValue({ data: [], error: null, isLoading: false });
 
     renderHook(() => useManagedAgents());
 
-    expect(useSWR).toHaveBeenCalledWith('agents.managed', fetchProductManagedAgents);
+    expect(useSWRMock).toHaveBeenCalledWith('agents.managed', fetchProductManagedAgentsMock);
+  });
+
+  it('shares one projected Agent directory between settings and runtime consumers', () => {
+    const agents = [{ id: '632f31d2', name: 'Ki CLI', agent_type: 'aionrs', agent_source: 'internal', enabled: true }];
+    useSWRMock.mockReturnValue({ data: agents, error: null, isLoading: false });
+
+    const settings = renderHook(() => useManagedAgents());
+    const runtime = renderHook(() => useManagedAgentRuntimeCatalog());
+
+    expect(settings.result.current.agents).toEqual(agents);
+    expect(runtime.result.current).toEqual(agents);
+    expect(useSWRMock).toHaveBeenNthCalledWith(1, 'agents.managed', fetchProductManagedAgentsMock);
+    expect(useSWRMock).toHaveBeenNthCalledWith(2, 'agents.managed', fetchProductManagedAgentsMock);
   });
 
   it('exposes the agents returned by SWR', () => {
     const agents = [
       { id: 'x', name: 'X', agent_type: 'acp', agent_source: 'custom', enabled: false, available: false },
     ];
-    (useSWR as any).mockReturnValue({ data: agents, error: null, isLoading: false });
+    useSWRMock.mockReturnValue({ data: agents, error: null, isLoading: false });
 
     const { result } = renderHook(() => useManagedAgents());
 
@@ -66,7 +87,7 @@ describe('useManagedAgents', () => {
   });
 
   it('falls back to an empty list when SWR has no data yet', () => {
-    (useSWR as any).mockReturnValue({ data: undefined, error: null, isLoading: true });
+    useSWRMock.mockReturnValue({ data: undefined, error: null, isLoading: true });
 
     const { result } = renderHook(() => useManagedAgents());
 
@@ -74,7 +95,7 @@ describe('useManagedAgents', () => {
   });
 
   it('revalidate refreshes only the management key', async () => {
-    (useSWR as any).mockReturnValue({ data: [], error: null, isLoading: false });
+    useSWRMock.mockReturnValue({ data: [], error: null, isLoading: false });
 
     const { result } = renderHook(() => useManagedAgents());
 
@@ -82,12 +103,12 @@ describe('useManagedAgents', () => {
       await result.current.revalidate();
     });
 
-    expect(mutate).toHaveBeenCalledWith('agents.managed');
-    expect(mutate).not.toHaveBeenCalledWith('agents.detected');
+    expect(mutateMock).toHaveBeenCalledWith('agents.managed');
+    expect(mutateMock).not.toHaveBeenCalledWith('agents.detected');
   });
 
   it('refreshCatalog refreshes the management key and assistant list caches', async () => {
-    (useSWR as any).mockReturnValue({ data: [], error: null, isLoading: false });
+    useSWRMock.mockReturnValue({ data: [], error: null, isLoading: false });
 
     const { result } = renderHook(() => useManagedAgents());
 
@@ -95,12 +116,12 @@ describe('useManagedAgents', () => {
       await result.current.refreshCatalog();
     });
 
-    expect(mutate).toHaveBeenCalledWith('agents.managed');
-    expect(mutate).toHaveBeenCalledWith('assistants.list');
+    expect(mutateMock).toHaveBeenCalledWith('agents.managed');
+    expect(mutateMock).toHaveBeenCalledWith('assistants.list');
   });
 
   it('refreshCustomAgents triggers a backend rescan then refreshes management and assistant caches', async () => {
-    (useSWR as any).mockReturnValue({ data: [], error: null, isLoading: false });
+    useSWRMock.mockReturnValue({ data: [], error: null, isLoading: false });
 
     const { result } = renderHook(() => useManagedAgents());
 
@@ -109,21 +130,21 @@ describe('useManagedAgents', () => {
     });
 
     expect(ipcBridge.acpConversation.refreshCustomAgents.invoke).toHaveBeenCalled();
-    expect(mutate).toHaveBeenCalledWith('agents.managed');
-    expect(mutate).toHaveBeenCalledWith('assistants.list');
+    expect(mutateMock).toHaveBeenCalledWith('agents.managed');
+    expect(mutateMock).toHaveBeenCalledWith('assistants.list');
   });
 
   it('getManagedAgents fetches the management catalog without invalidating the detected cache', async () => {
     const managedAgents = [
       { id: 'managed-1', name: 'Managed Agent', agent_type: 'acp', agent_source: 'builtin', enabled: true },
     ];
-    (fetchProductManagedAgents as any).mockResolvedValue(managedAgents);
+    fetchProductManagedAgentsMock.mockResolvedValue(managedAgents);
 
     const result = await getManagedAgents();
 
-    expect(fetchProductManagedAgents).toHaveBeenCalledTimes(1);
-    expect(mutate).toHaveBeenCalledWith('agents.managed', managedAgents, { revalidate: false });
-    expect(mutate).not.toHaveBeenCalledWith('agents.detected');
+    expect(fetchProductManagedAgentsMock).toHaveBeenCalledTimes(1);
+    expect(mutateMock).toHaveBeenCalledWith('agents.managed', managedAgents, { revalidate: false });
+    expect(mutateMock).not.toHaveBeenCalledWith('agents.detected');
     expect(result).toEqual(managedAgents);
   });
 });

--- a/tests/unit/renderer/hooks/agent/useModelProviderList.dom.test.ts
+++ b/tests/unit/renderer/hooks/agent/useModelProviderList.dom.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import type { IProvider } from '@/common/config/storage';
+
+const { loadProductModelCatalogMock, listProvidersMock } = vi.hoisted(() => ({
+  loadProductModelCatalogMock: vi.fn(),
+  listProvidersMock: vi.fn(),
+}));
+
+vi.mock('@/renderer/services/runtime/kiBuddyModelCatalog', () => ({
+  loadProductModelCatalog: loadProductModelCatalogMock,
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    mode: {
+      listProviders: { invoke: listProvidersMock },
+    },
+  },
+}));
+
+import { fetchProviders } from '@/renderer/hooks/agent/useModelProviderList';
+
+const provider: IProvider = {
+  id: 'provider-1',
+  platform: 'openai',
+  name: 'Provider',
+  base_url: '',
+  api_key: '',
+  models: ['model-1'],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+it('fetches every Model consumer from the shared product-projected provider directory', async () => {
+  loadProductModelCatalogMock.mockResolvedValue({
+    entries: [],
+    hiddenResources: [],
+    visibleProviders: [provider],
+  });
+  listProvidersMock.mockResolvedValue([]);
+
+  await expect(fetchProviders()).resolves.toEqual([provider]);
+  expect(loadProductModelCatalogMock).toHaveBeenCalledOnce();
+  expect(listProvidersMock).not.toHaveBeenCalled();
+});

--- a/tests/unit/renderer/hooks/mcpCatalog.dom.test.ts
+++ b/tests/unit/renderer/hooks/mcpCatalog.dom.test.ts
@@ -174,6 +174,38 @@ describe('ensureBackendMcpCatalog', () => {
       expect.objectContaining({ resourceId: 'upstream-1', origin: 'upstreamBuiltin' }),
     ]);
   });
+
+  it('emits structured diagnostics for MCP resources hidden by the active product policy', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    getClientBusinessSettingMock.mockResolvedValue([
+      {
+        id: 'upstream-1',
+        name: 'upstream one',
+        enabled: true,
+        transport: { type: 'stdio', command: 'upstream', args: [] },
+        created_at: 1,
+        updated_at: 1,
+        original_json: '{}',
+        builtin: true,
+      },
+    ]);
+    mcpServiceMock.listServers.invoke.mockResolvedValue([]);
+
+    const catalog = await ensureBackendMcpCatalog(createKiBuddyProductExperience(productConfig.experience));
+
+    expect(info).toHaveBeenCalledWith(
+      '[ProductExperience] MCP resources hidden by product policy',
+      expect.objectContaining({ code: 'product_resource_projection', resources: catalog.hiddenResources })
+    );
+    info.mockRestore();
+  });
+
+  it('preserves the backend rejection when the MCP catalog cannot be loaded', async () => {
+    const error = new Error('catalog unavailable');
+    mcpServiceMock.listServers.invoke.mockRejectedValue(error);
+
+    await expect(ensureBackendMcpCatalog()).rejects.toBe(error);
+  });
 });
 
 describe('loadProductBuiltinMcpResourceState', () => {

--- a/tests/unit/renderer/ki-buddy/KiBuddyProductIntegrityGate.dom.test.tsx
+++ b/tests/unit/renderer/ki-buddy/KiBuddyProductIntegrityGate.dom.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { beforeEach, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 
-const { loadProductBuiltinMcpResourceStateMock } = vi.hoisted(() => ({
+const { loadProductBuiltinAgentResourceStateMock, loadProductBuiltinMcpResourceStateMock } = vi.hoisted(() => ({
+  loadProductBuiltinAgentResourceStateMock: vi.fn(),
   loadProductBuiltinMcpResourceStateMock: vi.fn(),
 }));
 
@@ -33,14 +34,22 @@ vi.mock('@/renderer/components/layout/InstallationIntegrityDialog', () => ({
 vi.mock('@/renderer/hooks/mcp/catalog', () => ({
   loadProductBuiltinMcpResourceState: loadProductBuiltinMcpResourceStateMock,
 }));
+vi.mock('@/renderer/services/runtime/kiBuddyAgentCatalog', () => ({
+  loadProductBuiltinAgentResourceState: loadProductBuiltinAgentResourceStateMock,
+}));
 
 import KiBuddyProductIntegrityGate, {
-  KiBuddyMcpProductIntegrityGate,
+  KiBuddyProductResourceIntegrityGate,
 } from '@/renderer/pages/ki-buddy/KiBuddyProductIntegrityGate';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  loadProductBuiltinAgentResourceStateMock.mockResolvedValue({ status: 'ready', missing: [] });
   loadProductBuiltinMcpResourceStateMock.mockResolvedValue({ status: 'ready', missing: [] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 it('shows an installation-integrity error instead of AionUi business content for an invalid Ki-Buddy policy', () => {
@@ -52,24 +61,55 @@ it('shows an installation-integrity error instead of AionUi business content for
 
 it('does not load the MCP catalog outside the authenticated Ki-Buddy product path', () => {
   render(
-    <KiBuddyMcpProductIntegrityGate enabled={false}>
+    <KiBuddyProductResourceIntegrityGate enabled={false}>
       <div>AionUi business content</div>
-    </KiBuddyMcpProductIntegrityGate>
+    </KiBuddyProductResourceIntegrityGate>
   );
 
   expect(screen.getByText('AionUi business content')).toBeInTheDocument();
+  expect(loadProductBuiltinAgentResourceStateMock).not.toHaveBeenCalled();
   expect(loadProductBuiltinMcpResourceStateMock).not.toHaveBeenCalled();
 });
 
-it('keeps business content available when registered product MCP resources are present', async () => {
+it('keeps business content available when registered product resources are present', async () => {
   render(
-    <KiBuddyMcpProductIntegrityGate enabled>
+    <KiBuddyProductResourceIntegrityGate enabled>
       <div>Ki-Buddy business content</div>
-    </KiBuddyMcpProductIntegrityGate>
+    </KiBuddyProductResourceIntegrityGate>
   );
 
+  await waitFor(() => expect(loadProductBuiltinAgentResourceStateMock).toHaveBeenCalledOnce());
   await waitFor(() => expect(loadProductBuiltinMcpResourceStateMock).toHaveBeenCalledOnce());
   expect(screen.getByText('Ki-Buddy business content')).toBeInTheDocument();
+});
+
+it('shows installation integrity diagnostics for a missing KiCLI while keeping Account content available', async () => {
+  loadProductBuiltinAgentResourceStateMock.mockResolvedValue({
+    status: 'invalid',
+    missing: [
+      {
+        code: 'required_product_resource_missing',
+        featureId: 'agents',
+        kind: 'agent',
+        origin: 'productBuiltin',
+        resourceId: '632f31d2',
+        resourceName: 'Ki CLI',
+      },
+    ],
+  });
+
+  render(
+    <KiBuddyProductResourceIntegrityGate enabled>
+      <div>Account and diagnostics content</div>
+    </KiBuddyProductResourceIntegrityGate>
+  );
+
+  expect(
+    await screen.findByText('common.backendStartup.incompleteInstallation.runtimeComponentDescription:Ki CLI')
+  ).toBeInTheDocument();
+  expect(screen.getByText('632f31d2')).toBeInTheDocument();
+  expect(screen.getByText('closable integrity notice')).toBeInTheDocument();
+  expect(screen.getByText('Account and diagnostics content')).toBeInTheDocument();
 });
 
 it('shows installation integrity diagnostics when a required product MCP is missing', async () => {
@@ -88,9 +128,9 @@ it('shows installation integrity diagnostics when a required product MCP is miss
   });
 
   render(
-    <KiBuddyMcpProductIntegrityGate enabled>
+    <KiBuddyProductResourceIntegrityGate enabled>
       <div>Ki-Buddy business content</div>
-    </KiBuddyMcpProductIntegrityGate>
+    </KiBuddyProductResourceIntegrityGate>
   );
 
   expect(
@@ -106,12 +146,47 @@ it('does not misreport an installation failure when catalog loading throws', asy
   loadProductBuiltinMcpResourceStateMock.mockRejectedValue(new Error('catalog unavailable'));
 
   render(
-    <KiBuddyMcpProductIntegrityGate enabled>
+    <KiBuddyProductResourceIntegrityGate enabled>
       <div>Ki-Buddy business content</div>
-    </KiBuddyMcpProductIntegrityGate>
+    </KiBuddyProductResourceIntegrityGate>
   );
 
   await waitFor(() => expect(consoleError).toHaveBeenCalled());
   expect(screen.getByText('Ki-Buddy business content')).toBeInTheDocument();
   consoleError.mockRestore();
+});
+
+it('retries a pending Agent directory and reports a missing KiCLI after it becomes authoritative', async () => {
+  vi.useFakeTimers();
+  loadProductBuiltinAgentResourceStateMock
+    .mockResolvedValueOnce({ status: 'pending', missing: [] })
+    .mockResolvedValueOnce({
+      status: 'invalid',
+      missing: [
+        {
+          code: 'required_product_resource_missing',
+          featureId: 'agents',
+          kind: 'agent',
+          origin: 'productBuiltin',
+          resourceId: '632f31d2',
+          resourceName: 'Ki CLI',
+        },
+      ],
+    });
+
+  render(
+    <KiBuddyProductResourceIntegrityGate enabled>
+      <div>Account and diagnostics content</div>
+    </KiBuddyProductResourceIntegrityGate>
+  );
+
+  await act(async () => Promise.resolve());
+  expect(loadProductBuiltinAgentResourceStateMock).toHaveBeenCalledOnce();
+
+  await act(async () => vi.advanceTimersByTimeAsync(1_000));
+
+  expect(loadProductBuiltinAgentResourceStateMock).toHaveBeenCalledTimes(2);
+  expect(
+    screen.getByText('common.backendStartup.incompleteInstallation.runtimeComponentDescription:Ki CLI')
+  ).toBeInTheDocument();
 });

--- a/tests/unit/renderer/services/runtime/kiBuddyAgentCatalog.dom.test.ts
+++ b/tests/unit/renderer/services/runtime/kiBuddyAgentCatalog.dom.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  KI_BUDDY_PRODUCT_CAPABILITY,
+  createAionUiProductExperience,
+  createKiBuddyProductExperience,
+} from '@/common/platform/ki-buddy';
+import type { ManagedAgent } from '@/renderer/utils/model/agentTypes';
+import type { Assistant } from '@/common/types/agent/assistantTypes';
+import {
+  KI_CLI_PRODUCT_RESOURCE_ID,
+  loadProductAgentCatalog,
+  loadProductBuiltinAgentResourceState,
+  projectProductAssistantCandidates,
+  projectProductAgentCatalog,
+} from '@/renderer/services/runtime/kiBuddyAgentCatalog';
+import productConfig from '../../../../../ki-buddy-product.json';
+
+const { requestManagedAgentsMock } = vi.hoisted(() => ({ requestManagedAgentsMock: vi.fn() }));
+
+vi.mock('@/renderer/utils/model/agentTypes', async () => {
+  const actual = await vi.importActual<typeof import('@/renderer/utils/model/agentTypes')>(
+    '@/renderer/utils/model/agentTypes'
+  );
+  return {
+    ...actual,
+    requestManagedAgents: requestManagedAgentsMock,
+  };
+});
+
+const agent = (overrides: Partial<ManagedAgent> & Pick<ManagedAgent, 'id' | 'name'>): ManagedAgent => ({
+  agent_type: 'acp',
+  agent_source: 'builtin',
+  enabled: true,
+  installed: true,
+  status: 'online',
+  ...overrides,
+});
+
+const candidates = [
+  agent({
+    id: KI_CLI_PRODUCT_RESOURCE_ID,
+    name: 'Renamed internal runtime',
+    agent_type: 'aionrs',
+    agent_source: 'internal',
+  }),
+  agent({ id: 'builtin-claude', name: 'Claude Code' }),
+  agent({ id: 'custom-1', name: 'My Agent', agent_source: 'custom' }),
+  agent({ id: 'extension-1', name: 'Extension Agent', agent_source: 'extension', isExtension: true }),
+  agent({
+    id: 'future-1',
+    name: 'Future Agent',
+    agent_source: 'future' as ManagedAgent['agent_source'],
+  }),
+];
+
+const assistant = (id: string, agentId: string, source: 'internal' | 'builtin' | 'custom'): Assistant => ({
+  id,
+  source: 'generated',
+  name: id,
+  name_i18n: {},
+  description_i18n: {},
+  enabled: true,
+  sort_order: 1,
+  agent_id: agentId,
+  agent: { type: source === 'internal' ? 'aionrs' : 'acp', source },
+  enabled_skills: [],
+  custom_skill_names: [],
+  disabled_builtin_skills: [],
+  context_i18n: {},
+  prompts: [],
+  prompts_i18n: {},
+  models: [],
+  agent_status: 'online',
+  team_selectable: true,
+  deletable: true,
+});
+
+describe('projectProductAgentCatalog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the stable KiCLI resource with use access and Custom Agents with manage access', () => {
+    const catalog = projectProductAgentCatalog(candidates, createKiBuddyProductExperience(productConfig.experience));
+
+    expect(catalog.entries.map(({ agent: entry, origin, access }) => ({ id: entry.id, origin, access }))).toEqual([
+      { id: KI_CLI_PRODUCT_RESOURCE_ID, origin: 'productBuiltin', access: 'use' },
+      { id: 'custom-1', origin: 'custom', access: 'manage' },
+    ]);
+    expect(catalog.visibleAgents).toEqual([
+      { ...candidates[0], productAccess: 'use' },
+      { ...candidates[2], productAccess: 'manage' },
+    ]);
+  });
+
+  it('hides upstream, Extension, and unclassified Agents with non-sensitive structured diagnostics', () => {
+    const catalog = projectProductAgentCatalog(candidates, createKiBuddyProductExperience(productConfig.experience));
+
+    expect(catalog.hiddenResources).toEqual([
+      expect.objectContaining({ resourceId: 'builtin-claude', origin: 'upstreamBuiltin' }),
+      expect.objectContaining({ resourceId: 'extension-1', origin: 'extension' }),
+      expect.objectContaining({ resourceId: 'future-1', origin: 'unclassified' }),
+    ]);
+    expect(catalog.hiddenResources.every((record) => record.code === 'product_resource_hidden')).toBe(true);
+    expect(catalog.hiddenResources[0]).not.toHaveProperty('command');
+    expect(catalog.hiddenResources[0]).not.toHaveProperty('env');
+  });
+
+  it('does not identify a similarly named or similarly typed Agent as KiCLI without the stable product ID', () => {
+    const catalog = projectProductAgentCatalog(
+      [
+        agent({
+          id: 'wrong-id',
+          name: 'Ki CLI',
+          agent_type: 'aionrs',
+          agent_source: 'internal',
+        }),
+        agent({
+          id: KI_CLI_PRODUCT_RESOURCE_ID,
+          name: 'Ki CLI',
+          agent_type: 'acp',
+          agent_source: 'builtin',
+        }),
+      ],
+      createKiBuddyProductExperience(productConfig.experience)
+    );
+
+    expect(catalog.entries).toEqual([]);
+    expect(catalog.hiddenResources.map(({ resourceId, origin }) => ({ resourceId, origin }))).toEqual([
+      { resourceId: 'wrong-id', origin: 'unclassified' },
+      { resourceId: KI_CLI_PRODUCT_RESOURCE_ID, origin: 'upstreamBuiltin' },
+    ]);
+  });
+
+  it('keeps every Agent visible and manageable in AionUi', () => {
+    const catalog = projectProductAgentCatalog(candidates, createAionUiProductExperience());
+
+    expect(catalog.visibleAgents).toEqual(candidates.map((candidate) => ({ ...candidate, productAccess: 'manage' })));
+    expect(catalog.entries.every(({ access }) => access === 'manage')).toBe(true);
+    expect(catalog.hiddenResources).toEqual([]);
+  });
+
+  it('loads one projected catalog and emits structured records for hidden Agents', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    requestManagedAgentsMock.mockResolvedValue(candidates);
+
+    const catalog = await loadProductAgentCatalog(createKiBuddyProductExperience(productConfig.experience));
+
+    expect(catalog.visibleAgents.map(({ id }) => id)).toEqual([KI_CLI_PRODUCT_RESOURCE_ID, 'custom-1']);
+    expect(info).toHaveBeenCalledWith(
+      '[ProductExperience] Agent resources hidden by product policy',
+      expect.objectContaining({ code: 'product_resource_projection', resources: catalog.hiddenResources })
+    );
+    info.mockRestore();
+  });
+});
+
+describe('loadProductBuiltinAgentResourceState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.__kiBuddyProductPresentation = null;
+  });
+
+  it('accepts the required KiCLI only when the backend directory contains its stable identity', async () => {
+    requestManagedAgentsMock.mockResolvedValue([candidates[0]]);
+
+    await expect(
+      loadProductBuiltinAgentResourceState(createKiBuddyProductExperience(productConfig.experience))
+    ).resolves.toEqual({ status: 'ready', missing: [] });
+  });
+
+  it('reports installation integrity when a similarly named Agent replaces the required KiCLI identity', async () => {
+    window.__kiBuddyProductPresentation = {
+      ...KI_BUDDY_PRODUCT_CAPABILITY,
+      brand: { ...KI_BUDDY_PRODUCT_CAPABILITY.brand, cliName: 'Configured CLI' },
+    };
+    requestManagedAgentsMock.mockResolvedValue([
+      agent({ id: 'wrong-id', name: 'Ki CLI', agent_type: 'aionrs', agent_source: 'internal' }),
+    ]);
+
+    await expect(
+      loadProductBuiltinAgentResourceState(createKiBuddyProductExperience(productConfig.experience))
+    ).resolves.toEqual({
+      status: 'invalid',
+      missing: [
+        {
+          code: 'required_product_resource_missing',
+          featureId: 'agents',
+          kind: 'agent',
+          origin: 'productBuiltin',
+          resourceId: KI_CLI_PRODUCT_RESOURCE_ID,
+          resourceName: 'Configured CLI',
+        },
+      ],
+    });
+  });
+
+  it('keeps integrity pending when the backend directory is unavailable', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    requestManagedAgentsMock.mockRejectedValue(new Error('catalog unavailable'));
+
+    await expect(
+      loadProductBuiltinAgentResourceState(createKiBuddyProductExperience(productConfig.experience))
+    ).resolves.toEqual({ status: 'pending', missing: [] });
+    expect(error).toHaveBeenCalled();
+    error.mockRestore();
+  });
+});
+
+describe('projectProductAssistantCandidates', () => {
+  it('uses the authoritative projected Agent directory for Guid and conversation Assistant candidates', () => {
+    const assistants = [
+      assistant('ki-cli-assistant', KI_CLI_PRODUCT_RESOURCE_ID, 'internal'),
+      assistant('upstream-assistant', 'builtin-claude', 'builtin'),
+      assistant('custom-assistant', 'custom-1', 'custom'),
+      assistant('stale-custom-assistant', 'custom-removed', 'custom'),
+    ];
+    const catalog = projectProductAgentCatalog(candidates, createKiBuddyProductExperience(productConfig.experience));
+
+    const visible = projectProductAssistantCandidates(assistants, catalog);
+
+    expect(visible.map(({ id }) => id)).toEqual(['ki-cli-assistant', 'custom-assistant']);
+  });
+});

--- a/tests/unit/renderer/services/runtime/kiBuddyModelCatalog.dom.test.ts
+++ b/tests/unit/renderer/services/runtime/kiBuddyModelCatalog.dom.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IProvider } from '@/common/config/storage';
+import { createAionUiProductExperience, createKiBuddyProductExperience } from '@/common/platform/ki-buddy';
+import { loadProductModelCatalog, projectProductModelCatalog } from '@/renderer/services/runtime/kiBuddyModelCatalog';
+import productConfig from '../../../../../ki-buddy-product.json';
+
+const { listProvidersMock } = vi.hoisted(() => ({
+  listProvidersMock: vi.fn(),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    mode: {
+      listProviders: { invoke: listProvidersMock },
+    },
+  },
+}));
+
+const providers: IProvider[] = [
+  {
+    id: 'provider-1',
+    platform: 'openai',
+    name: 'Primary',
+    base_url: 'https://example.invalid',
+    api_key: 'secret',
+    models: ['gpt-one', 'gpt-two'],
+  },
+  {
+    id: 'provider-empty',
+    platform: 'custom',
+    name: 'Empty provider',
+    base_url: '',
+    api_key: '',
+    models: [],
+  },
+];
+
+describe('projectProductModelCatalog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps current provider models visible with manage access in Ki-Buddy', () => {
+    const catalog = projectProductModelCatalog(providers, createKiBuddyProductExperience(productConfig.experience));
+
+    expect(catalog.visibleProviders).toEqual(providers);
+    expect(
+      catalog.entries.map(({ providerId, modelId, origin, access }) => ({
+        providerId,
+        modelId,
+        origin,
+        access,
+      }))
+    ).toEqual([
+      { providerId: 'provider-1', modelId: 'gpt-one', origin: 'custom', access: 'manage' },
+      { providerId: 'provider-1', modelId: 'gpt-two', origin: 'custom', access: 'manage' },
+    ]);
+    expect(catalog.hiddenResources).toEqual([]);
+  });
+
+  it('keeps the complete provider catalog manageable in AionUi', () => {
+    const catalog = projectProductModelCatalog(providers, createAionUiProductExperience());
+
+    expect(catalog.visibleProviders).toEqual(providers);
+    expect(catalog.entries.every(({ access }) => access === 'manage')).toBe(true);
+    expect(catalog.hiddenResources).toEqual([]);
+  });
+
+  it('records hidden models without exposing provider credentials or endpoints', () => {
+    const hiddenModelPolicy = {
+      ...productConfig.experience,
+      resources: {
+        ...productConfig.experience.resources,
+        model: {
+          ...productConfig.experience.resources.model,
+          custom: 'hidden',
+        },
+      },
+    } as const;
+    const catalog = projectProductModelCatalog(providers, createKiBuddyProductExperience(hiddenModelPolicy));
+
+    expect(catalog.visibleProviders).toEqual([]);
+    expect(catalog.hiddenResources).toEqual([
+      expect.objectContaining({ resourceId: 'provider:provider-1/model:gpt-one', origin: 'custom' }),
+      expect.objectContaining({ resourceId: 'provider:provider-1/model:gpt-two', origin: 'custom' }),
+    ]);
+    expect(catalog.hiddenResources[0]).not.toHaveProperty('api_key');
+    expect(catalog.hiddenResources[0]).not.toHaveProperty('base_url');
+  });
+
+  it('loads the shared provider directory through one product projection', async () => {
+    listProvidersMock.mockResolvedValue(providers);
+
+    const catalog = await loadProductModelCatalog(createKiBuddyProductExperience(productConfig.experience));
+
+    expect(listProvidersMock).toHaveBeenCalledOnce();
+    expect(catalog.visibleProviders).toEqual(providers);
+  });
+
+  it('emits structured diagnostics when the active model policy hides resources', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const hiddenModelPolicy = {
+      ...productConfig.experience,
+      resources: {
+        ...productConfig.experience.resources,
+        model: {
+          ...productConfig.experience.resources.model,
+          custom: 'hidden',
+        },
+      },
+    } as const;
+    listProvidersMock.mockResolvedValue(providers);
+
+    const catalog = await loadProductModelCatalog(createKiBuddyProductExperience(hiddenModelPolicy));
+
+    expect(info).toHaveBeenCalledWith(
+      '[ProductExperience] Model resources hidden by product policy',
+      expect.objectContaining({ code: 'product_resource_projection', resources: catalog.hiddenResources })
+    );
+    info.mockRestore();
+  });
+});

--- a/tests/unit/renderer/services/runtime/kiBuddySkillCatalog.dom.test.ts
+++ b/tests/unit/renderer/services/runtime/kiBuddySkillCatalog.dom.test.ts
@@ -4,15 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAionUiProductExperience, createKiBuddyProductExperience } from '@/common/platform/ki-buddy';
 import {
   filterProductVisibleSkillNames,
+  loadProductSkillCatalog,
   projectProductSkillCatalog,
 } from '@/renderer/services/runtime/kiBuddySkillCatalog';
 import productConfig from '../../../../../ki-buddy-product.json';
 
+const { listAvailableSkillsMock } = vi.hoisted(() => ({ listAvailableSkillsMock: vi.fn() }));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    fs: {
+      listAvailableSkills: { invoke: listAvailableSkillsMock },
+    },
+  },
+}));
+
 describe('projectProductSkillCatalog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('filters runtime-loaded names to the product-visible catalog', () => {
     expect(
       filterProductVisibleSkillNames(
@@ -239,5 +254,41 @@ describe('projectProductSkillCatalog', () => {
     expect(result.visibleSkills).toEqual(skills);
     expect(result.entries.every(({ access }) => access === 'manage')).toBe(true);
     expect(result.hiddenResources).toEqual([]);
+  });
+});
+
+describe('loadProductSkillCatalog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('emits structured diagnostics for Skills hidden by the active product policy', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    listAvailableSkillsMock.mockResolvedValue([
+      {
+        name: 'mermaid',
+        description: 'Upstream built-in',
+        location: '/builtin/mermaid/SKILL.md',
+        relative_location: 'mermaid/SKILL.md',
+        is_auto_inject: false,
+        is_custom: false,
+        source: 'builtin',
+      },
+    ]);
+
+    const catalog = await loadProductSkillCatalog(createKiBuddyProductExperience(productConfig.experience));
+
+    expect(info).toHaveBeenCalledWith(
+      '[ProductExperience] Skill resources hidden by product policy',
+      expect.objectContaining({ code: 'product_resource_projection', resources: catalog.hiddenResources })
+    );
+    info.mockRestore();
+  });
+
+  it('preserves the bridge rejection when the Skill catalog cannot be loaded', async () => {
+    const error = new Error('catalog unavailable');
+    listAvailableSkillsMock.mockRejectedValue(error);
+
+    await expect(loadProductSkillCatalog(createKiBuddyProductExperience(productConfig.experience))).rejects.toBe(error);
   });
 });

--- a/tests/unit/renderer/services/runtime/productBrandRuntime.dom.test.tsx
+++ b/tests/unit/renderer/services/runtime/productBrandRuntime.dom.test.tsx
@@ -32,6 +32,27 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+const jsonResponse = (data: unknown) =>
+  new Response(JSON.stringify({ data }), {
+    headers: { 'Content-Type': 'application/json' },
+    status: 200,
+  });
+
+const stubAssistantAndAgentCatalogs = (
+  assistants: readonly Record<string, unknown>[],
+  agents: readonly Record<string, unknown>[]
+) => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/api/assistants')) return Promise.resolve(jsonResponse(assistants));
+      if (url.endsWith('/api/agents/management')) return Promise.resolve(jsonResponse(agents));
+      return Promise.reject(new Error(`Unexpected request: ${url}`));
+    })
+  );
+};
+
 describe('renderer product brand adapter', () => {
   beforeEach(() => {
     vi.stubGlobal('__APP_VERSION__', '2.1.47');
@@ -105,25 +126,19 @@ describe('renderer product brand adapter', () => {
 
   it('adapts direct assistant bridge responses after one catalog registration', async () => {
     window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            data: [
-              {
-                id: 'bare-aionrs',
-                source: 'generated',
-                name: 'Aion CLI',
-                name_i18n: { 'en-US': 'Aion CLI' },
-                avatar: '/api/assets/logos/aionui.svg',
-                agent: { type: 'aionrs', source: 'internal' },
-              },
-            ],
-          }),
-          { headers: { 'Content-Type': 'application/json' }, status: 200 }
-        )
-      )
+    stubAssistantAndAgentCatalogs(
+      [
+        {
+          id: 'bare-aionrs',
+          source: 'generated',
+          name: 'Aion CLI',
+          name_i18n: { 'en-US': 'Aion CLI' },
+          avatar: '/api/assets/logos/aionui.svg',
+          agent_id: '632f31d2',
+          agent: { type: 'aionrs', source: 'internal' },
+        },
+      ],
+      [{ id: '632f31d2', name: 'Aion CLI', agent_source: 'internal', agent_type: 'aionrs' }]
     );
     installProductAssistantCatalogAdapter();
 
@@ -131,6 +146,110 @@ describe('renderer product brand adapter', () => {
 
     expect(assistants[0]).toMatchObject({ name: 'Ki CLI', name_i18n: { 'en-US': 'Ki CLI' } });
     expect(assistants[0]?.avatar).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it('hides assistant candidates whose Agent is hidden by the product directory', async () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    stubAssistantAndAgentCatalogs(
+      [
+        {
+          id: 'ki-cli-assistant',
+          source: 'generated',
+          name: 'Aion CLI',
+          agent_id: '632f31d2',
+          agent: { type: 'aionrs', source: 'internal' },
+        },
+        {
+          id: 'upstream-assistant',
+          source: 'generated',
+          name: 'Claude Code',
+          agent_id: 'builtin-claude',
+          agent: { type: 'acp', source: 'builtin' },
+        },
+      ],
+      [
+        { id: '632f31d2', name: 'Aion CLI', agent_source: 'internal', agent_type: 'aionrs' },
+        { id: 'builtin-claude', name: 'Claude Code', agent_source: 'builtin', agent_type: 'acp' },
+      ]
+    );
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    installProductAssistantCatalogAdapter();
+
+    const assistants = await ipcBridge.assistants.list.invoke();
+
+    expect(assistants.map(({ id }) => id)).toEqual(['ki-cli-assistant']);
+    expect(info).toHaveBeenCalledWith(
+      '[ProductExperience] Agent resources hidden by product policy',
+      expect.objectContaining({ code: 'product_resource_projection' })
+    );
+    info.mockRestore();
+  });
+
+  it('hides a stale Assistant snapshot when its custom Agent is absent from the authoritative directory', async () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    stubAssistantAndAgentCatalogs(
+      [
+        {
+          id: 'stale-custom-assistant',
+          source: 'generated',
+          name: 'Removed custom Agent',
+          agent_id: 'custom-removed',
+          agent: { type: 'acp', source: 'custom' },
+        },
+      ],
+      []
+    );
+    installProductAssistantCatalogAdapter();
+
+    await expect(ipcBridge.assistants.list.invoke()).resolves.toEqual([]);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not expose Assistant candidates when the authoritative Agent directory is unavailable', async () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: string | URL | Request) => {
+        const url = String(input);
+        if (url.endsWith('/api/assistants')) return Promise.resolve(jsonResponse([]));
+        if (url.endsWith('/api/agents/management')) return Promise.reject(new Error('Agent directory unavailable'));
+        return Promise.reject(new Error(`Unexpected request: ${url}`));
+      })
+    );
+    installProductAssistantCatalogAdapter();
+
+    await expect(ipcBridge.assistants.list.invoke()).rejects.toThrow('Agent directory unavailable');
+  });
+
+  it('recovers Assistant candidates after the authoritative Agent directory becomes available', async () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    let agentDirectoryRequests = 0;
+    const customAssistant = {
+      id: 'custom-assistant',
+      source: 'generated',
+      name: 'Custom Assistant',
+      agent_id: 'custom-1',
+      agent: { type: 'acp', source: 'custom' },
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: string | URL | Request) => {
+        const url = String(input);
+        if (url.endsWith('/api/assistants')) return Promise.resolve(jsonResponse([customAssistant]));
+        if (url.endsWith('/api/agents/management')) {
+          agentDirectoryRequests += 1;
+          if (agentDirectoryRequests === 1) return Promise.reject(new Error('Agent directory unavailable'));
+          return Promise.resolve(
+            jsonResponse([{ id: 'custom-1', name: 'Custom Agent', agent_source: 'custom', agent_type: 'acp' }])
+          );
+        }
+        return Promise.reject(new Error(`Unexpected request: ${url}`));
+      })
+    );
+    installProductAssistantCatalogAdapter();
+
+    await expect(ipcBridge.assistants.list.invoke()).rejects.toThrow('Agent directory unavailable');
+    await expect(ipcBridge.assistants.list.invoke()).resolves.toEqual([customAssistant]);
   });
 
   it('keeps direct assistant bridge responses unchanged without the product capability', async () => {


### PR DESCRIPTION
# Pull Request

## Description

本 PR 统一 Ki-Buddy 中 Agent 与 Model 的产品资源访问策略：

- 使用稳定资源身份识别 KiCLI，并区分 `use`、`manage` 与 `hidden` 权限。
- 让 Agent 设置、Guid、对话创建及 Assistant 候选共用同一投影目录。
- 保持 Custom Agent 的管理能力以及 Model provider 的新增、编辑、删除和选择能力。
- 在后端目录就绪后检查必需内置 Agent；缺失时显示产品安装完整性错误。
- 将 Agent、Assistant、Model、MCP、Skill 的隐藏资源诊断统一到结构化、非敏感的报告入口。
- 保持 AionUi capability 缺失时的原有全量可见与可管理行为。

这样可以避免各消费者独立判断资源来源或显示名称，降低产品策略不一致和陈旧 Assistant 快照误入候选列表的风险。

## Related Issues

- Closes #46

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (868 existing warnings)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 4062 passed, 5 skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

未执行桌面应用手工运行验证；本 PR 已通过两轮独立 Standards/Spec 审查，最终均无发现。

## Screenshots

不适用。本 PR 调整资源目录、权限和完整性检查逻辑，没有新增独立视觉页面。

## Additional Context

- 全量测试仍会输出仓库已有的 `MaxListenersExceededWarning`，不影响测试结果。
- 分支基于 `product/main`，包含单个功能提交。
