### PR TITLE
feat(ki-buddy): project settings experience

### DIFF
--- a/docs/adr/0011-control-aionui-with-product-experience-policy.md
+++ b/docs/adr/0011-control-aionui-with-product-experience-policy.md
@@ -22,6 +22,9 @@ AionUi 与 Ki-Buddy 分别提供 adapter。产品 capability 完全缺失时使�
 | `packages/desktop/src/preload/main.ts`、`packages/desktop/src/common/types/platform/electron.ts`                                                                                                                                          | 通过单一 getter 转发不可变 bootstrap snapshot；完整性启动不读取业务 IPC                                        | AionUi preload 继续暴露原有 backend 与 renderer bridge                                           |
 | `packages/desktop/src/renderer/index.html`、`packages/desktop/src/renderer/main.tsx`、`packages/desktop/src/renderer/services/i18n/index.ts`                                                                                              | 在首个业务画面前应用产品 capability；配置损坏时停止业务初始化；登录后目录缺少已注册产品资源时显示完整性错误    | capability 缺失时继续使用 AionUi 标题、主题、i18n 与应用 host                                    |
 | `packages/desktop/src/renderer/components/layout/Layout.tsx`、`Router.tsx`、`Sider/index.tsx`、`Titlebar/index.tsx`                                                                                                                       | 从同一 feature ID 投影 Team 入口、直接路由、订阅和 workspace 控件                                              | `ProductExperience` 的 AionUi adapter 保持 Team 入口、路由与生命周期可用                         |
+| `packages/desktop/src/renderer/components/layout/Router.tsx`、`Sider/index.tsx`、`packages/desktop/src/renderer/pages/settings/components/SettingsSider.tsx`、`SettingsPageWrapper.tsx`                                                   | 从统一设置 registry 生成菜单、默认页、直接路由和 Extension settings 挂载条件；停用页面不执行 hooks 或请求      | AionUi adapter 注册原有设置页和 Extension settings，旧设置地址继续按原有重定向规则工作           |
+| `packages/desktop/src/renderer/components/settings/SettingsModal/contents/AppearanceModalContent.tsx`、`packages/desktop/src/renderer/pages/settings/AppearanceSettings/CssThemeSettings.tsx`                                             | 分别控制主题预设、主题市场和自定义主题的挂载与数据读取；字体和 UI scale 不受主题能力影响                       | AionUi adapter 保持内置主题、Extension 主题、自定义主题、字体与 UI scale 全部可用                |
+| `packages/desktop/src/renderer/pages/guid/components/QuickActionButtons.tsx`                                                                                                                                                              | 只在 Guid WebUI 与 WebUI 页面同时启用时挂载状态请求、事件订阅和快捷入口                                        | AionUi adapter 保持 WebUI 快捷入口、状态显示和跳转                                               |
 | `packages/desktop/src/renderer/hooks/mcp/catalog.ts`、`useMcpServers.ts`、`packages/desktop/src/renderer/pages/settings/ToolsSettings/`、`packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx` | 按可信 catalog 通道和后端 `product_origin` 投影 MCP 的 `hidden`、`use`、`manage`；隐藏记录只保留非敏感诊断字段 | AionUi adapter 保持全部 MCP 来源可见；extension 原有只读交互和上游 image-generation 配置保持不变 |
 | `packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx`                                                                                                                                                        | 从 behavior defaults 决定 Scheduled Tasks 是否允许 Team 执行者                                                 | AionUi adapter 继续使用 `assistant-or-team`                                                      |
 | `packages/desktop/src/process/bridge/updateBridge.ts`、`notificationBridge.ts`                                                                                                                                                            | 注入产品更新源和通知资源；完整性失败时禁用对应业务服务                                                         | capability 缺失时继续使用 AionUi 更新源、User-Agent 和通知图标                                   |
@@ -36,11 +39,12 @@ AionUi 原行为由以下测试保护：
 - `tests/unit/renderer/ki-buddy/KiBuddyProductIntegrityGate.dom.test.tsx`：只在登录后的 Ki-Buddy 产品路径验证 MCP requirement；目录已就绪但缺少已注册资源时显示结构化安装完整性错误。
 - `tests/unit/feedback/McpServerHeaderFeedback.dom.test.tsx`、`tests/unit/settings/ToolsModalContentImageGuide.dom.test.tsx`：`use` 允许连接检测但不提供管理操作；AionUi 的 `manage` 操作和 image-generation 配置保持可用。
 - `tests/unit/renderer/services/runtime/productBootstrap.dom.test.ts` 与 `kiBuddyRuntime.dom.test.ts`：capability 存在、缺失和损坏时使用对应启动路径。
+- `tests/integration/ProductExperienceSettingsHost.dom.test.tsx`：Ki-Buddy 设置 registry、默认页、停用路由、移动端 Extension hooks、Appearance 数据读取和 Guid WebUI 订阅均受策略约束；AionUi 原设置、主题和 WebUI 快捷行为保持可用。
 
 每次同步 AionUi 基线时必须复查：
 
 1. main、preload、renderer 启动顺序是否改变，bootstrap 是否仍在首个业务画面前只读取一次。
-2. Router、Sider、Layout、Titlebar 或 Scheduled Tasks 是否新增了绕过 `ProductExperience` 的入口、直接访问或生命周期。
+2. Router、Sider、Settings registry、Appearance、Guid quick actions、Layout、Titlebar 或 Scheduled Tasks 是否新增了绕过 `ProductExperience` 的入口、直接访问、数据读取或生命周期。
 3. AionUi 新增的完整产品能力是否已经加入稳定 feature ID，并在 Ki-Buddy 策略中明确声明启用或停用。
 4. 更新、通知、Tray、菜单、backend 和后台订阅是否仍在 invalid 路径之外启动。
 5. capability 存在与缺失两组回归、AionUi 原行为保护测试以及完整测试是否通过。
@@ -49,7 +53,7 @@ MCP 来源由 catalog 边界决定：extension bridge 固定产生 `extension`�
 
 MCP requirement 使用独立注册表和稳定后端资源 ID。#41 接入前注册表为空，不读取目录也不要求 Agents Adapter MCP 存在；#41 启用对应能力时登记真实资源 ID。登录后的 Ki-Buddy 在后端目录可用后执行验证：读取失败保持 `pending`，明确缺失才进入安装完整性错误。`manage` 只保留上游 AionUi 当前已经提供的管理操作，不据此增加上游尚未具备的启停入口。
 
-当 AionUi 提供正式的产品策略注册、单一 preload bootstrap、首帧 capability 注入和按 capability 管理生命周期的公开扩展点后，应将对应职责迁移到上游接口，并删除本 ADR 列出的本地上游接缝。迁移只有在 Ki-Buddy invalid/ready 与 AionUi absent 三种状态的等价测试全部通过后才能完成。
+当 AionUi 提供正式的产品策略注册、单一 preload bootstrap、首帧 capability 注入、统一设置 registry、主题子能力控制和按 capability 管理页面生命周期的公开扩展点后，应将对应职责迁移到上游接口，并删除本 ADR 列出的本地上游接缝。迁移只有在 Ki-Buddy invalid/ready 与 AionUi absent 三种状态的等价测试全部通过后才能完成。
 
 ## Considered Options
 

--- a/packages/desktop/src/renderer/components/layout/Router.tsx
+++ b/packages/desktop/src/renderer/components/layout/Router.tsx
@@ -3,6 +3,7 @@ import { HashRouter, Navigate, Route, Routes, useLocation } from 'react-router-d
 import AppLoader from '@renderer/components/layout/AppLoader';
 import { useAuth } from '@renderer/hooks/context/AuthContext';
 import { getKiBuddyRouteComponents, isProductFeatureEnabled } from '@/renderer/services/runtime/kiBuddyRuntime';
+import { getSettingsExperienceProjection } from '@renderer/pages/settings/components/SettingsSider';
 const Conversation = React.lazy(() => import('@renderer/pages/conversation'));
 const Guid = React.lazy(() => import('@renderer/pages/guid'));
 const AgentSettings = React.lazy(() => import('@renderer/pages/settings/AgentSettings'));
@@ -33,10 +34,16 @@ const withRouteFallback = (Component: React.LazyExoticComponent<React.ComponentT
  * Legacy `/settings/capabilities?tab=tools` deep links now map to the standalone
  * Tools page; everything else (skills tab or no tab) lands on the Skills page.
  */
-const CapabilitiesRedirect: React.FC = () => {
+const CapabilitiesRedirect: React.FC<{
+  defaultSettingsPath: string;
+  skillsEnabled: boolean;
+  toolsEnabled: boolean;
+}> = ({ defaultSettingsPath, skillsEnabled, toolsEnabled }) => {
   const { search } = useLocation();
   const tab = new URLSearchParams(search).get('tab');
-  return <Navigate to={tab === 'tools' ? '/settings/tools' : '/settings/skills'} replace />;
+  const target =
+    tab === 'tools' && toolsEnabled ? '/settings/tools' : skillsEnabled ? '/settings/skills' : defaultSettingsPath;
+  return <Navigate to={target} replace />;
 };
 
 const ProtectedLayout: React.FC<{ layout: React.ReactElement }> = ({ layout }) => {
@@ -57,6 +64,12 @@ const PanelRoute: React.FC<{ layout: React.ReactElement }> = ({ layout }) => {
   const { status } = useAuth();
   const kiBuddyRoutes = getKiBuddyRouteComponents();
   const teamEnabled = isProductFeatureEnabled('team');
+  const settingsProjection = getSettingsExperienceProjection({
+    includeProductEntries: Boolean(kiBuddyRoutes),
+    isDesktop: true,
+  });
+  const enabledSettings = new Set(settingsProjection.entries.map(({ id }) => id));
+  const { defaultPath: defaultSettingsPath, extensionSettingsEnabled } = settingsProjection;
   const LoginPage = kiBuddyRoutes?.LoginPage ?? AionUiLoginPage;
 
   const routes = (
@@ -79,43 +92,66 @@ const PanelRoute: React.FC<{ layout: React.ReactElement }> = ({ layout }) => {
           <Route path='/guid' element={withRouteFallback(Guid)} />
           <Route path='/conversation/:id' element={withRouteFallback(Conversation)} />
           {teamEnabled && <Route path='/team/:id' element={withRouteFallback(TeamIndex)} />}
-          <Route path='/settings/model' element={withRouteFallback(ModeSettings)} />
+          {enabledSettings.has('model') && <Route path='/settings/model' element={withRouteFallback(ModeSettings)} />}
           <Route path='/assistants' element={withRouteFallback(AssistantSettings)} />
           {/* Assistants moved out of Settings to a top-level entry; keep a redirect
               so old deep links / back-nav still land on the new page. */}
           <Route path='/settings/assistants' element={<Navigate to='/assistants' replace />} />
-          <Route path='/settings/agent' element={withRouteFallback(AgentSettings)} />
-          <Route path='/settings/agent/:id/repair' element={withRouteFallback(AgentRepairPage)} />
+          {enabledSettings.has('agent') && (
+            <>
+              <Route path='/settings/agent' element={withRouteFallback(AgentSettings)} />
+              <Route path='/settings/agent/:id/repair' element={withRouteFallback(AgentRepairPage)} />
+            </>
+          )}
           {/* Skills and Tools are top-level settings entries. */}
-          <Route path='/settings/skills' element={withRouteFallback(SkillsSettings)} />
-          <Route path='/settings/skills/import-history' element={withRouteFallback(SkillsSettings)} />
-          <Route path='/settings/skills/detail/:skillName' element={withRouteFallback(SkillDetailPage)} />
-          <Route path='/settings/tools' element={withRouteFallback(ToolsSettings)} />
+          {enabledSettings.has('skills') && (
+            <>
+              <Route path='/settings/skills' element={withRouteFallback(SkillsSettings)} />
+              <Route path='/settings/skills/import-history' element={withRouteFallback(SkillsSettings)} />
+              <Route path='/settings/skills/detail/:skillName' element={withRouteFallback(SkillDetailPage)} />
+            </>
+          )}
+          {enabledSettings.has('tools') && <Route path='/settings/tools' element={withRouteFallback(ToolsSettings)} />}
           {/* Legacy routes — the previous combined "Capabilities" page is now two pages. */}
-          <Route path='/settings/capabilities' element={<CapabilitiesRedirect />} />
           <Route
-            path='/settings/capabilities/skills/import-history'
-            element={<Navigate to='/settings/skills/import-history' replace />}
-          />
-          <Route path='/settings/skills-hub' element={<Navigate to='/settings/skills' replace />} />
-          <Route path='/settings/appearance' element={withRouteFallback(AppearanceSettings)} />
-          <Route path='/settings/display' element={<Navigate to='/settings/appearance' replace />} />
-          <Route path='/settings/webui' element={withRouteFallback(WebuiSettings)} />
-          <Route path='/settings/pet' element={withRouteFallback(PetSettings)} />
-          <Route path='/settings/system' element={withRouteFallback(SystemSettings)} />
-          <Route path='/settings/about' element={withRouteFallback(SystemSettings)} />
-          <Route
-            path='/settings/account'
+            path='/settings/capabilities'
             element={
-              kiBuddyRoutes ? (
-                withRouteFallback(kiBuddyRoutes.AccountSettings)
-              ) : (
-                <Navigate to='/settings/agent' replace />
-              )
+              <CapabilitiesRedirect
+                defaultSettingsPath={defaultSettingsPath}
+                skillsEnabled={enabledSettings.has('skills')}
+                toolsEnabled={enabledSettings.has('tools')}
+              />
             }
           />
-          <Route path='/settings/ext/:tabId' element={withRouteFallback(ExtensionSettingsPage)} />
-          <Route path='/settings' element={<Navigate to='/settings/agent' replace />} />
+          {enabledSettings.has('skills') && (
+            <>
+              <Route
+                path='/settings/capabilities/skills/import-history'
+                element={<Navigate to='/settings/skills/import-history' replace />}
+              />
+              <Route path='/settings/skills-hub' element={<Navigate to='/settings/skills' replace />} />
+            </>
+          )}
+          {enabledSettings.has('appearance') && (
+            <>
+              <Route path='/settings/appearance' element={withRouteFallback(AppearanceSettings)} />
+              <Route path='/settings/display' element={<Navigate to='/settings/appearance' replace />} />
+            </>
+          )}
+          {enabledSettings.has('webui') && <Route path='/settings/webui' element={withRouteFallback(WebuiSettings)} />}
+          {enabledSettings.has('pet') && <Route path='/settings/pet' element={withRouteFallback(PetSettings)} />}
+          {enabledSettings.has('system') && (
+            <Route path='/settings/system' element={withRouteFallback(SystemSettings)} />
+          )}
+          {enabledSettings.has('about') && <Route path='/settings/about' element={withRouteFallback(SystemSettings)} />}
+          {enabledSettings.has('account') && kiBuddyRoutes && (
+            <Route path='/settings/account' element={withRouteFallback(kiBuddyRoutes.AccountSettings)} />
+          )}
+          {extensionSettingsEnabled && (
+            <Route path='/settings/ext/:tabId' element={withRouteFallback(ExtensionSettingsPage)} />
+          )}
+          <Route path='/settings' element={<Navigate to={defaultSettingsPath} replace />} />
+          <Route path='/settings/*' element={<Navigate to={defaultSettingsPath} replace />} />
           <Route path='/test/components' element={withRouteFallback(ComponentsShowcase)} />
           <Route path='/scheduled' element={withRouteFallback(ScheduledTasksPage)} />
           <Route path='/scheduled/:job_id' element={withRouteFallback(TaskDetailPage)} />

--- a/packages/desktop/src/renderer/components/layout/Sider/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/index.tsx
@@ -68,7 +68,7 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
         console.error('Navigation failed:', error);
       });
     } else {
-      Promise.resolve(navigate('/settings/agent')).catch((error) => {
+      Promise.resolve(navigate('/settings')).catch((error) => {
         console.error('Navigation failed:', error);
       });
     }

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/AppearanceModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/AppearanceModalContent.tsx
@@ -12,6 +12,7 @@ import CssThemeSettings from '@renderer/pages/settings/AppearanceSettings/CssThe
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
 import { FONT_SIZE_KEYS, FONT_SIZE_SPECS, FONT_SIZE_STEP, type FontSizeKey } from '@/common/config/fontSizes';
 import { useThemeContext } from '@renderer/hooks/context/ThemeContext';
+import { isProductFeatureEnabled } from '@/renderer/services/runtime/kiBuddyRuntime';
 import { useSettingsViewMode } from '../settingsViewContext';
 
 /** Map each configurable font-size region to its row label i18n key. */
@@ -52,6 +53,12 @@ const AppearanceModalContent: React.FC = () => {
   const viewMode = useSettingsViewMode();
   const isPageMode = viewMode === 'page';
   const { fontSizes, setFontSize } = useThemeContext();
+  const themeCapabilities = {
+    customThemes: isProductFeatureEnabled('themeCustomEditor'),
+    marketplace: isProductFeatureEnabled('themeMarketplace'),
+    presets: isProductFeatureEnabled('themePresets'),
+  };
+  const showThemeSettings = Object.values(themeCapabilities).some(Boolean);
 
   return (
     <div className='flex flex-col h-full w-full'>
@@ -59,10 +66,12 @@ const AppearanceModalContent: React.FC = () => {
       <AionScrollArea className='flex-1 min-h-0 pb-16px' disableOverflow={isPageMode}>
         <div className='space-y-16px'>
           {/* 主题画廊 / Theme Gallery */}
-          <div className='px-16px md:px-24px lg:px-28px py-14px md:py-16px bg-2 rd-16px'>
-            <div className='text-14px text-t-primary leading-22px mb-12px'>{t('settings.theme')}</div>
-            <CssThemeSettings />
-          </div>
+          {showThemeSettings && (
+            <div className='px-16px md:px-24px lg:px-28px py-14px md:py-16px bg-2 rd-16px'>
+              <div className='text-14px text-t-primary leading-22px mb-12px'>{t('settings.theme')}</div>
+              <CssThemeSettings capabilities={themeCapabilities} />
+            </div>
+          )}
 
           {/* 字体大小 / Font sizes */}
           <div className='px-16px md:px-24px lg:px-28px py-14px md:py-16px bg-2 rd-16px'>

--- a/packages/desktop/src/renderer/pages/guid/components/QuickActionButtons.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/QuickActionButtons.tsx
@@ -10,6 +10,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { getRendererBrand } from '@/renderer/services/runtime/productBrandRuntime';
+import { isProductFeatureEnabled } from '@/renderer/services/runtime/kiBuddyRuntime';
 import styles from '../index.module.css';
 
 type QuickActionButtonsProps = {
@@ -27,16 +28,14 @@ let webuiStatusCache: {
   at: number;
 } | null = null;
 
-const QuickActionButtons: React.FC<QuickActionButtonsProps> = ({
-  onOpenLink,
-  onOpenBugReport,
-  inactiveBorderColor,
-  activeShadow,
-}) => {
+type WebuiQuickActionProps = Readonly<{
+  onHoverChange: (hovered: boolean) => void;
+  style: React.CSSProperties;
+}>;
+
+const WebuiQuickAction: React.FC<WebuiQuickActionProps> = ({ onHoverChange, style }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const repositoryUrl = getRendererBrand().links.repository;
-  const [hoveredQuickAction, setHoveredQuickAction] = useState<'bugReport' | 'repo' | 'webui' | null>(null);
   const [webuiQuickStatus, setWebuiQuickStatus] = useState<WebuiQuickStatus>('checking');
 
   useEffect(() => {
@@ -80,20 +79,6 @@ const QuickActionButtons: React.FC<QuickActionButtonsProps> = ({
     };
   }, []);
 
-  const quickActionStyle = useCallback(
-    (isActive: boolean) => ({
-      borderWidth: '1px',
-      borderStyle: 'solid',
-      borderColor: inactiveBorderColor,
-      boxShadow: isActive ? activeShadow : 'none',
-    }),
-    [activeShadow, inactiveBorderColor]
-  );
-
-  const handleOpenWebUI = useCallback(() => {
-    void navigate('/settings/webui');
-  }, [navigate]);
-
   const webuiStatusLabel =
     webuiQuickStatus === 'running'
       ? t('settings.webui.running', { defaultValue: 'Running' })
@@ -110,6 +95,53 @@ const QuickActionButtons: React.FC<QuickActionButtonsProps> = ({
         : webuiQuickStatus === 'error'
           ? 'var(--color-text-3)'
           : 'var(--color-text-4)';
+
+  return (
+    <div
+      className='group inline-flex items-center justify-center h-36px min-w-36px max-w-36px px-0 rd-999px bg-fill-0 cursor-pointer overflow-hidden whitespace-nowrap hover:max-w-200px hover:px-14px hover:justify-start hover:gap-8px transition-[max-width,padding,border-radius,box-shadow] duration-420 ease-in-out'
+      style={style}
+      onMouseEnter={() => onHoverChange(true)}
+      onMouseLeave={() => onHoverChange(false)}
+      onClick={() => void navigate('/settings/webui')}
+    >
+      <div className='relative w-20px h-20px flex-shrink-0 leading-none'>
+        <div className='absolute inset-0 flex items-center justify-center'>
+          <Earth
+            theme='outline'
+            size={20}
+            fill='currentColor'
+            className='block transition-colors duration-360'
+            style={{ color: webuiIconColor }}
+          />
+        </div>
+      </div>
+      <span className='opacity-0 max-w-0 overflow-hidden text-14px text-[var(--color-text-2)] group-hover:opacity-100 group-hover:max-w-160px transition-all duration-360 ease-in-out'>
+        {t('settings.webui', { defaultValue: 'WebUI' })} · {webuiStatusLabel}
+      </span>
+    </div>
+  );
+};
+
+const QuickActionButtons: React.FC<QuickActionButtonsProps> = ({
+  onOpenLink,
+  onOpenBugReport,
+  inactiveBorderColor,
+  activeShadow,
+}) => {
+  const { t } = useTranslation();
+  const repositoryUrl = getRendererBrand().links.repository;
+  const [hoveredQuickAction, setHoveredQuickAction] = useState<'bugReport' | 'repo' | 'webui' | null>(null);
+  const webUiEnabled = isProductFeatureEnabled('guidWebUi') && isProductFeatureEnabled('webUi');
+
+  const quickActionStyle = useCallback(
+    (isActive: boolean) => ({
+      borderWidth: '1px',
+      borderStyle: 'solid',
+      borderColor: inactiveBorderColor,
+      boxShadow: isActive ? activeShadow : 'none',
+    }),
+    [activeShadow, inactiveBorderColor]
+  );
 
   return (
     <div
@@ -170,28 +202,12 @@ const QuickActionButtons: React.FC<QuickActionButtonsProps> = ({
             {t('conversation.welcome.quickActionStar')}
           </span>
         </div>
-        <div
-          className='group inline-flex items-center justify-center h-36px min-w-36px max-w-36px px-0 rd-999px bg-fill-0 cursor-pointer overflow-hidden whitespace-nowrap hover:max-w-200px hover:px-14px hover:justify-start hover:gap-8px transition-[max-width,padding,border-radius,box-shadow] duration-420 ease-in-out'
-          style={quickActionStyle(hoveredQuickAction === 'webui')}
-          onMouseEnter={() => setHoveredQuickAction('webui')}
-          onMouseLeave={() => setHoveredQuickAction(null)}
-          onClick={handleOpenWebUI}
-        >
-          <div className='relative w-20px h-20px flex-shrink-0 leading-none'>
-            <div className='absolute inset-0 flex items-center justify-center'>
-              <Earth
-                theme='outline'
-                size={20}
-                fill='currentColor'
-                className='block transition-colors duration-360'
-                style={{ color: webuiIconColor }}
-              />
-            </div>
-          </div>
-          <span className='opacity-0 max-w-0 overflow-hidden text-14px text-[var(--color-text-2)] group-hover:opacity-100 group-hover:max-w-160px transition-all duration-360 ease-in-out'>
-            {t('settings.webui', { defaultValue: 'WebUI' })} · {webuiStatusLabel}
-          </span>
-        </div>
+        {webUiEnabled && (
+          <WebuiQuickAction
+            onHoverChange={(hovered) => setHoveredQuickAction(hovered ? 'webui' : null)}
+            style={quickActionStyle(hoveredQuickAction === 'webui')}
+          />
+        )}
       </div>
     </div>
   );

--- a/packages/desktop/src/renderer/pages/settings/AppearanceSettings/CssThemeSettings.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AppearanceSettings/CssThemeSettings.tsx
@@ -238,7 +238,21 @@ const ensureBackgroundCss = <T extends { id?: string; cover?: string; css?: stri
  * CSS 主题设置组件 / CSS Theme Settings Component
  * 用于管理和切换 CSS 皮肤主题 / For managing and switching CSS skin themes
  */
-const CssThemeSettings: React.FC = () => {
+export type CssThemeCapabilities = Readonly<{
+  customThemes: boolean;
+  marketplace: boolean;
+  presets: boolean;
+}>;
+
+const ALL_THEME_CAPABILITIES: CssThemeCapabilities = {
+  customThemes: true,
+  marketplace: true,
+  presets: true,
+};
+
+const CssThemeSettings: React.FC<{ capabilities?: CssThemeCapabilities }> = ({
+  capabilities = ALL_THEME_CAPABILITIES,
+}) => {
   const { t } = useTranslation();
   const { theme: currentTheme, activeTheme, activeId, selectTheme } = useThemeContext();
   const [themes, setThemes] = useState<Theme[]>([]);
@@ -259,7 +273,7 @@ const CssThemeSettings: React.FC = () => {
   // Virtual "Follow System" card, third in the gallery (after Light and Dark).
   // Not part of BUILTIN_THEMES — it must never enter resolution/dedup/persistence.
   const displayThemes = useMemo(() => {
-    if (themes.length === 0) return themes;
+    if (themes.length === 0 || !capabilities.presets) return themes;
     const systemCard: Theme = {
       id: SYSTEM_THEME_ID,
       name: t('settings.cssTheme.followSystem'),
@@ -271,41 +285,44 @@ const CssThemeSettings: React.FC = () => {
     const arr = [...themes];
     arr.splice(Math.min(2, arr.length), 0, systemCard);
     return arr;
-  }, [themes, t]);
+  }, [capabilities.presets, themes, t]);
 
   // 加载主题列表 / Load theme list
   useEffect(() => {
     const loadThemes = async () => {
       try {
-        const userThemes = (configService.get('theme.userThemes') as Theme[]) ?? [];
+        const userThemes = capabilities.customThemes ? ((configService.get('theme.userThemes') as Theme[]) ?? []) : [];
 
         // Apply background CSS to user themes that have cover images
         const normalizedUserThemes = userThemes.map((theme) => ensureBackgroundCss(theme));
 
         // 加载扩展主题 / Load extension-contributed themes
         let extensionThemes: Theme[] = [];
-        try {
-          const loadedExtensionThemes = await ipcBridge.extensions.getThemes.invoke();
-          // Map extension themes to Theme shape (css-only, builtin: true, appearance inferred as 'light')
-          extensionThemes = loadedExtensionThemes.map((theme) => ({
-            id: theme.id,
-            name: theme.name,
-            cover: resolveExtensionAssetUrl(theme.cover),
-            css: theme.css,
-            appearance: 'light' as const,
-            builtin: true,
-            created_at: theme.created_at ?? 0,
-            updated_at: theme.updated_at ?? 0,
-          }));
-        } catch {
-          // Extensions not available (e.g., WebUI mode or not initialized yet)
+        if (capabilities.marketplace) {
+          try {
+            const loadedExtensionThemes = await ipcBridge.extensions.getThemes.invoke();
+            // Map extension themes to Theme shape (css-only, builtin: true, appearance inferred as 'light')
+            extensionThemes = loadedExtensionThemes.map((theme) => ({
+              id: theme.id,
+              name: theme.name,
+              cover: resolveExtensionAssetUrl(theme.cover),
+              css: theme.css,
+              appearance: 'light' as const,
+              builtin: true,
+              created_at: theme.created_at ?? 0,
+              updated_at: theme.updated_at ?? 0,
+            }));
+          } catch {
+            // Extensions not available (e.g., WebUI mode or not initialized yet)
+          }
         }
 
         // 合并主题，按 ID 去重（先出现的优先）
         // Merge builtin, extension, and user themes; deduplicate by ID (first occurrence wins)
         const seenIds = new Set<string>();
         const allThemes: Theme[] = [];
-        for (const theme of [...BUILTIN_THEMES, ...extensionThemes, ...normalizedUserThemes]) {
+        const builtinThemes = capabilities.presets ? BUILTIN_THEMES : [];
+        for (const theme of [...builtinThemes, ...extensionThemes, ...normalizedUserThemes]) {
           if (!theme?.id || seenIds.has(theme.id)) continue;
           seenIds.add(theme.id);
           allThemes.push(theme);
@@ -317,7 +334,7 @@ const CssThemeSettings: React.FC = () => {
       }
     };
     void loadThemes();
-  }, []);
+  }, [capabilities.customThemes, capabilities.marketplace, capabilities.presets]);
 
   /**
    * 选择主题 / Select theme
@@ -440,9 +457,11 @@ const CssThemeSettings: React.FC = () => {
       {/* 标题栏 / Header */}
       <div className='flex items-start md:items-center justify-between gap-8px flex-wrap'>
         <span className='text-14px text-t-secondary leading-22px'>{t('settings.cssTheme.selectOrCustomize')}</span>
-        <Button type='primary' size='small' className='!h-32px !rounded-8px !px-14px !m-0' onClick={handleAddTheme}>
-          {t('settings.cssTheme.addManually')}
-        </Button>
+        {capabilities.customThemes && (
+          <Button type='primary' size='small' className='!h-32px !rounded-8px !px-14px !m-0' onClick={handleAddTheme}>
+            {t('settings.cssTheme.addManually')}
+          </Button>
+        )}
       </div>
 
       {/* 主题卡片列表 / Theme card list */}
@@ -484,7 +503,7 @@ const CssThemeSettings: React.FC = () => {
               <div className='absolute bottom-0 left-0 right-0 h-1/3 bg-gradient-to-t from-black/60 to-transparent flex items-end justify-between p-8px'>
                 <span className='text-13px text-white truncate flex-1'>{theme.name}</span>
                 {/* 编辑按钮（仅用户主题） / Edit button (user themes only) */}
-                {hoveredThemeId === theme.id && !theme.builtin && (
+                {capabilities.customThemes && hoveredThemeId === theme.id && !theme.builtin && (
                   <div
                     className='p-4px rounded-6px bg-white/20 cursor-pointer hover:bg-white/40 transition-colors ml-8px'
                     onClick={(e) => handleEditTheme(theme, e)}
@@ -506,16 +525,18 @@ const CssThemeSettings: React.FC = () => {
       </div>
 
       {/* 主题编辑弹窗 / Theme edit modal */}
-      <CssThemeModal
-        visible={modalVisible}
-        theme={editingTheme}
-        onClose={() => {
-          setModalVisible(false);
-          setEditingTheme(null);
-        }}
-        onSave={handleSaveTheme}
-        onDelete={editingTheme && !editingTheme.builtin ? () => handleDeleteTheme(editingTheme.id) : undefined}
-      />
+      {capabilities.customThemes && (
+        <CssThemeModal
+          visible={modalVisible}
+          theme={editingTheme}
+          onClose={() => {
+            setModalVisible(false);
+            setEditingTheme(null);
+          }}
+          onSave={handleSaveTheme}
+          onDelete={editingTheme && !editingTheme.builtin ? () => handleDeleteTheme(editingTheme.id) : undefined}
+        />
+      )}
     </div>
   );
 };

--- a/packages/desktop/src/renderer/pages/settings/components/SettingsPageWrapper.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/SettingsPageWrapper.tsx
@@ -8,85 +8,70 @@ import {
 import { isElectronDesktop, resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 import { type IExtensionSettingsTab } from '@/common/adapter/ipcBridge';
 import { useExtensionSettingsTabs } from '@/renderer/hooks/system/useExtensionSettingsTabs';
-import {
-  Cat,
-  Communication,
-  Computer,
-  Earth,
-  Info,
-  Lightning,
-  LinkCloud,
-  Puzzle,
-  Robot,
-  System,
-  Toolkit,
-} from '@icon-park/react';
+import { Puzzle } from '@icon-park/react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useExtI18n } from '@/renderer/hooks/system/useExtI18n';
-import { BUILTIN_TAB_IDS, LEGACY_ANCHOR_REMAP } from './SettingsSider';
+import { getSettingsNavigationProjection, mergeExtensionSettingsItems, type SettingsNavItem } from './SettingsSider';
+import { Button } from '@arco-design/web-react';
 import './settings.css';
-import { withKiBuddySettingsItem } from '@/renderer/services/runtime/kiBuddyRuntime';
 
-interface SettingsPageWrapperProps {
+type SettingsPageWrapperProps = {
   children: React.ReactNode;
   className?: string;
   contentClassName?: string;
-}
+};
 
-type NavItem = { label: string; icon: React.ReactElement; path: string; id: string };
+type MobileSettingsNavProps = Readonly<{
+  items: readonly SettingsNavItem[];
+  navigateToPath: (path: string) => void;
+  pathname: string;
+}>;
 
-type TranslateFn = (key: string, options?: { defaultValue?: string }) => string;
+const MobileSettingsNav: React.FC<MobileSettingsNavProps> = ({ items, navigateToPath, pathname }) => (
+  <div className='settings-mobile-top-nav'>
+    {items.map((item) => {
+      const active = pathname.includes(`/settings/${item.path}`);
+      return (
+        <Button
+          key={item.path}
+          type='text'
+          className={classNames('settings-mobile-top-nav__item', {
+            'settings-mobile-top-nav__item--active': active,
+          })}
+          onClick={() => navigateToPath(item.path)}
+        >
+          <span className='settings-mobile-top-nav__icon'>{item.icon}</span>
+          <span className='settings-mobile-top-nav__label'>{item.label}</span>
+        </Button>
+      );
+    })}
+  </div>
+);
 
-export function getBuiltinSettingsNavItems(isDesktop: boolean, t: TranslateFn): NavItem[] {
-  const builtinMap: Record<string, NavItem> = {
-    model: { id: 'model', label: t('settings.model'), icon: <LinkCloud theme='outline' size='16' />, path: 'model' },
-    assistants: {
-      id: 'assistants',
-      label: t('settings.assistants', { defaultValue: 'Assistants' }),
-      icon: <Robot theme='outline' size='16' />,
-      path: 'assistants',
-    },
-    agent: {
-      id: 'agent',
-      label: t('settings.agents', { defaultValue: 'Agents' }),
-      icon: <Robot theme='outline' size='16' />,
-      path: 'agent',
-    },
-    skills: {
-      id: 'skills',
-      label: t('settings.skills', { defaultValue: 'Skills' }),
-      icon: <Lightning theme='outline' size='16' />,
-      path: 'skills',
-    },
-    tools: {
-      id: 'tools',
-      label: t('settings.tools', { defaultValue: 'Tools' }),
-      icon: <Toolkit theme='outline' size='16' />,
-      path: 'tools',
-    },
-    appearance: {
-      id: 'appearance',
-      label: t('settings.appearancePanel'),
-      icon: <Computer theme='outline' size='16' />,
-      path: 'appearance',
-    },
-    webui: {
-      id: 'webui',
-      label: t('settings.webui'),
-      icon: isDesktop ? <Earth theme='outline' size='16' /> : <Communication theme='outline' size='16' />,
-      path: 'webui',
-    },
-    pet: { id: 'pet', label: t('pet.desktopPet'), icon: <Cat theme='outline' size='16' />, path: 'pet' },
-    system: { id: 'system', label: t('settings.system'), icon: <System theme='outline' size='16' />, path: 'system' },
-    about: { id: 'about', label: t('settings.about'), icon: <Info theme='outline' size='16' />, path: 'about' },
-  };
-
-  return withKiBuddySettingsItem(
-    BUILTIN_TAB_IDS.map((id) => builtinMap[id]),
-    t
+const ExtensionAwareMobileSettingsNav: React.FC<MobileSettingsNavProps> = ({ items, navigateToPath, pathname }) => {
+  const extensionTabs = useExtensionSettingsTabs();
+  const { resolveExtTabName } = useExtI18n();
+  const menuItems = React.useMemo(
+    () =>
+      mergeExtensionSettingsItems(items, extensionTabs, (tab: IExtensionSettingsTab) => {
+        const resolvedIcon = resolveExtensionAssetUrl(tab.icon) || tab.icon;
+        return {
+          id: tab.id,
+          label: resolveExtTabName(tab),
+          icon: resolvedIcon ? (
+            <img src={resolvedIcon} alt='' className='w-16px h-16px object-contain' />
+          ) : (
+            <Puzzle theme='outline' size='16' />
+          ),
+          path: `ext/${tab.id}`,
+        };
+      }),
+    [extensionTabs, items, resolveExtTabName]
   );
-}
+
+  return <MobileSettingsNav items={menuItems} navigateToPath={navigateToPath} pathname={pathname} />;
+};
 
 const SettingsPageWrapper: React.FC<SettingsPageWrapperProps> = ({ children, className, contentClassName }) => {
   const layout = useLayoutContext();
@@ -95,119 +80,49 @@ const SettingsPageWrapper: React.FC<SettingsPageWrapperProps> = ({ children, cla
   const { pathname } = useLocation();
   const { t } = useTranslation();
   const isDesktop = isElectronDesktop();
+  const { extensionSettingsEnabled, items: builtinItems } = React.useMemo(
+    () => getSettingsNavigationProjection(isDesktop, t),
+    [isDesktop, t]
+  );
 
-  const extensionTabs = useExtensionSettingsTabs();
-
-  const { resolveExtTabName } = useExtI18n();
-
-  const menuItems = React.useMemo(() => {
-    const builtins = getBuiltinSettingsNavItems(isDesktop, t);
-
-    // Insert extension tabs before system (unanchored default) or at anchor position
-    const result = [...builtins];
-    const unanchored: IExtensionSettingsTab[] = [];
-    const beforeMap = new Map<string, IExtensionSettingsTab[]>();
-    const afterMap = new Map<string, IExtensionSettingsTab[]>();
-
-    for (const tab of extensionTabs) {
-      if (!tab.position) {
-        unanchored.push(tab);
-        continue;
-      }
-      const { relativeTo: rawAnchor, placement } = tab.position;
-      const anchor = LEGACY_ANCHOR_REMAP[rawAnchor] ?? rawAnchor;
-      if (!result.some((item) => item.id === anchor)) {
-        unanchored.push(tab);
-        continue;
-      }
-      const map = placement === 'before' ? beforeMap : afterMap;
-      let list = map.get(anchor);
-      if (!list) {
-        list = [];
-        map.set(anchor, list);
-      }
-      list.push(tab);
-    }
-
-    const toNavItem = (tab: IExtensionSettingsTab): NavItem => {
-      const resolvedIcon = resolveExtensionAssetUrl(tab.icon) || tab.icon;
-      return {
-        id: tab.id,
-        label: resolveExtTabName(tab),
-        icon: resolvedIcon ? (
-          <img src={resolvedIcon} alt='' className='w-16px h-16px object-contain' />
-        ) : (
-          <Puzzle theme='outline' size='16' />
-        ),
-        path: `ext/${tab.id}`,
-      };
-    };
-
-    for (let i = result.length - 1; i >= 0; i--) {
-      const id = result[i].id;
-      const afters = afterMap.get(id);
-      if (afters) result.splice(i + 1, 0, ...afters.map(toNavItem));
-      const befores = beforeMap.get(id);
-      if (befores) result.splice(i, 0, ...befores.map(toNavItem));
-    }
-
-    if (unanchored.length > 0) {
-      const sysIdx = result.findIndex((item) => item.id === 'system');
-      const idx = sysIdx >= 0 ? sysIdx : result.length;
-      result.splice(idx, 0, ...unanchored.map(toNavItem));
-    }
-
-    return result;
-  }, [isDesktop, t, extensionTabs, resolveExtTabName]);
-
-  // Keep only horizontal padding on the scroll container — vertical padding is
-  // moved to the content layer below. A sticky header inside a scroll container
-  // with top padding would otherwise stick 32px down, letting content peek
-  // through the gap above it.
   const containerClass = classNames(
     'settings-page-wrapper w-full min-h-full box-border overflow-y-auto',
     isMobile ? 'px-16px' : 'px-12px md:px-40px',
     className
   );
-
   const contentClass = classNames(
     'settings-page-content mx-auto w-full md:max-w-1024px py-14px md:py-32px',
     contentClassName
   );
 
-  const navigateToTab = React.useCallback(
-    (tabId: string) => {
-      void navigate(`/settings/${tabId}`, { replace: true });
+  const navigateToPath = React.useCallback(
+    (path: string) => {
+      void navigate(`/settings/${path}`, { replace: true });
     },
     [navigate]
+  );
+
+  const navigateToTab = React.useCallback(
+    (tabId: string) => {
+      navigateToPath(tabId);
+    },
+    [navigateToPath]
   );
 
   return (
     <SettingsViewModeProvider value='page'>
       <SettingsTabNavigateProvider value={navigateToTab}>
         <div className={containerClass}>
-          {isMobile && (
-            <div className='settings-mobile-top-nav'>
-              {menuItems.map((item) => {
-                const active = pathname.includes(`/settings/${item.path}`);
-                return (
-                  <button
-                    key={item.path}
-                    type='button'
-                    className={classNames('settings-mobile-top-nav__item', {
-                      'settings-mobile-top-nav__item--active': active,
-                    })}
-                    onClick={() => {
-                      void navigate(`/settings/${item.path}`, { replace: true });
-                    }}
-                  >
-                    <span className='settings-mobile-top-nav__icon'>{item.icon}</span>
-                    <span className='settings-mobile-top-nav__label'>{item.label}</span>
-                  </button>
-                );
-              })}
-            </div>
-          )}
+          {isMobile &&
+            (extensionSettingsEnabled ? (
+              <ExtensionAwareMobileSettingsNav
+                items={builtinItems}
+                navigateToPath={navigateToPath}
+                pathname={pathname}
+              />
+            ) : (
+              <MobileSettingsNav items={builtinItems} navigateToPath={navigateToPath} pathname={pathname} />
+            ))}
           <div className={contentClass}>{children}</div>
         </div>
       </SettingsTabNavigateProvider>

--- a/packages/desktop/src/renderer/pages/settings/components/SettingsSider.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/SettingsSider.tsx
@@ -1,6 +1,7 @@
 import FlexFullContainer from '@/renderer/components/layout/FlexFullContainer';
 import { isElectronDesktop, resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 import { type IExtensionSettingsTab } from '@/common/adapter/ipcBridge';
+import type { ProductFeatureId } from '@/common/platform/ki-buddy';
 import { useExtI18n } from '@/renderer/hooks/system/useExtI18n';
 import { useExtensionSettingsTabs } from '@/renderer/hooks/system/useExtensionSettingsTabs';
 import {
@@ -22,20 +23,36 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Tooltip } from '@arco-design/web-react';
 import { getSiderTooltipProps } from '@/renderer/utils/ui/siderTooltip';
-import { withKiBuddySettingsItem } from '@/renderer/services/runtime/kiBuddyRuntime';
+import { getKiBuddyAccountSettingsItem, isProductFeatureEnabled } from '@/renderer/services/runtime/kiBuddyRuntime';
+
+type TranslateFn = (key: string, options?: { defaultValue?: string }) => string;
+
+export type SettingsRegistryEntry = Readonly<{
+  desktopOnly?: boolean;
+  featureId: ProductFeatureId;
+  id: string;
+  path: string;
+  productOnly?: boolean;
+}>;
+
+/** Stable settings order shared by navigation and route registration. */
+export const SETTINGS_REGISTRY = [
+  { id: 'account', path: 'account', featureId: 'account', productOnly: true, desktopOnly: false },
+  { id: 'agent', path: 'agent', featureId: 'agents', productOnly: false, desktopOnly: false },
+  { id: 'model', path: 'model', featureId: 'models', productOnly: false, desktopOnly: false },
+  { id: 'skills', path: 'skills', featureId: 'skills', productOnly: false, desktopOnly: false },
+  { id: 'tools', path: 'tools', featureId: 'tools', productOnly: false, desktopOnly: false },
+  { id: 'appearance', path: 'appearance', featureId: 'appearance', productOnly: false, desktopOnly: false },
+  { id: 'webui', path: 'webui', featureId: 'webUi', productOnly: false, desktopOnly: false },
+  { id: 'pet', path: 'pet', featureId: 'desktopPet', productOnly: false, desktopOnly: true },
+  { id: 'system', path: 'system', featureId: 'system', productOnly: false, desktopOnly: false },
+  { id: 'about', path: 'about', featureId: 'system', productOnly: false, desktopOnly: false },
+] as const satisfies readonly SettingsRegistryEntry[];
+
+export type BuiltinSettingsId = (typeof SETTINGS_REGISTRY)[number]['id'];
 
 /** Builtin settings tab IDs in display order (must match router paths). */
-export const BUILTIN_TAB_IDS = [
-  'agent',
-  'model',
-  'skills',
-  'tools',
-  'appearance',
-  'webui',
-  'pet',
-  'system',
-  'about',
-] as const;
+export const BUILTIN_TAB_IDS = SETTINGS_REGISTRY.map(({ id }) => id);
 
 /**
  * Legacy anchor IDs that have been merged into other tabs.
@@ -59,7 +76,7 @@ const GROUP_HEADER_BEFORE: Record<string, string> = {
   about: 'settings.groupAbout',
 };
 
-type SiderItem = {
+export type SettingsNavItem = {
   id: string;
   label: string;
   icon: React.ReactElement;
@@ -68,133 +85,166 @@ type SiderItem = {
   path: string;
 };
 
-const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }> = ({
-  collapsed = false,
-  tooltipEnabled = false,
-}) => {
+type EnabledSettingsOptions = Readonly<{
+  includeProductEntries: boolean;
+  isDesktop: boolean;
+}>;
+
+export type SettingsExperienceProjection = Readonly<{
+  defaultPath: string;
+  entries: ReadonlyArray<(typeof SETTINGS_REGISTRY)[number]>;
+  extensionSettingsEnabled: boolean;
+}>;
+
+/** Projects settings registration and Extension settings through the active ProductExperience. */
+export function getSettingsExperienceProjection({
+  includeProductEntries,
+  isDesktop,
+}: EnabledSettingsOptions): SettingsExperienceProjection {
+  const entries = SETTINGS_REGISTRY.filter((entry) => {
+    if (entry.productOnly && !includeProductEntries) return false;
+    if (entry.desktopOnly && !isDesktop) return false;
+    return isProductFeatureEnabled(entry.featureId);
+  });
+  const first = entries[0];
+  return {
+    defaultPath: first ? `/settings/${first.path}` : '/guid',
+    entries,
+    extensionSettingsEnabled: isProductFeatureEnabled('extensionSettings'),
+  };
+}
+
+export type SettingsNavigationProjection = Readonly<{
+  extensionSettingsEnabled: boolean;
+  items: readonly SettingsNavItem[];
+}>;
+
+/** Builds translated navigation items from the shared settings projection. */
+export function getSettingsNavigationProjection(isDesktop: boolean, t: TranslateFn): SettingsNavigationProjection {
+  const accountItem = getKiBuddyAccountSettingsItem(t);
+  const builtinMap: Record<Exclude<BuiltinSettingsId, 'account'>, SettingsNavItem> = {
+    agent: {
+      id: 'agent',
+      label: t('settings.agents', { defaultValue: 'Agents' }),
+      icon: <Speed />,
+      path: 'agent',
+    },
+    model: { id: 'model', label: t('settings.model'), icon: <LinkCloud />, path: 'model' },
+    skills: {
+      id: 'skills',
+      label: t('settings.skills', { defaultValue: 'Skills' }),
+      icon: <Lightning />,
+      path: 'skills',
+    },
+    tools: {
+      id: 'tools',
+      label: t('settings.tools', { defaultValue: 'Tools' }),
+      icon: <Toolkit />,
+      path: 'tools',
+    },
+    appearance: {
+      id: 'appearance',
+      label: t('settings.appearancePanel'),
+      icon: <Computer />,
+      path: 'appearance',
+    },
+    webui: {
+      id: 'webui',
+      label: t('settings.webui'),
+      icon: isDesktop ? <Earth /> : <Communication />,
+      path: 'webui',
+    },
+    pet: { id: 'pet', label: t('pet.desktopPet'), icon: <Cat />, path: 'pet' },
+    system: { id: 'system', label: t('settings.system'), icon: <System />, path: 'system' },
+    about: { id: 'about', label: t('settings.about'), icon: <Info />, path: 'about' },
+  };
+  const { entries, extensionSettingsEnabled } = getSettingsExperienceProjection({
+    includeProductEntries: Boolean(accountItem),
+    isDesktop,
+  });
+
+  const items = entries.flatMap((entry) => {
+    if (entry.id === 'account') return accountItem ? [accountItem] : [];
+    return [builtinMap[entry.id]];
+  });
+  return { extensionSettingsEnabled, items };
+}
+
+/** Inserts Extension settings contributions around the projected builtin registry. */
+export function mergeExtensionSettingsItems(
+  builtins: readonly SettingsNavItem[],
+  extensionTabs: readonly IExtensionSettingsTab[],
+  toItem: (tab: IExtensionSettingsTab) => SettingsNavItem
+): SettingsNavItem[] {
+  const result = [...builtins];
+  const beforeMap = new Map<string, IExtensionSettingsTab[]>();
+  const afterMap = new Map<string, IExtensionSettingsTab[]>();
+  const unanchored: IExtensionSettingsTab[] = [];
+
+  for (const tab of extensionTabs) {
+    if (!tab.position) {
+      unanchored.push(tab);
+      continue;
+    }
+    const { relativeTo: rawAnchor, placement } = tab.position;
+    const anchor = LEGACY_ANCHOR_REMAP[rawAnchor] ?? rawAnchor;
+    if (!result.some((item) => item.id === anchor)) {
+      unanchored.push(tab);
+      continue;
+    }
+    const map = placement === 'before' ? beforeMap : afterMap;
+    const list = map.get(anchor) ?? [];
+    list.push(tab);
+    map.set(anchor, list);
+  }
+
+  for (let index = result.length - 1; index >= 0; index--) {
+    const builtinId = result[index].id;
+    const afters = afterMap.get(builtinId);
+    if (afters) result.splice(index + 1, 0, ...afters.map(toItem));
+    const befores = beforeMap.get(builtinId);
+    if (befores) result.splice(index, 0, ...befores.map(toItem));
+  }
+
+  if (unanchored.length > 0) {
+    const systemIndex = result.findIndex((item) => item.id === 'system');
+    result.splice(systemIndex >= 0 ? systemIndex : result.length, 0, ...unanchored.map(toItem));
+  }
+
+  return result;
+}
+
+function getGroupHeaderPositions(
+  menus: readonly SettingsNavItem[],
+  extensionTabs: readonly IExtensionSettingsTab[]
+): Map<number, string> {
+  const headerAt = new Map<number, string>();
+  for (const [builtinId, headerKey] of Object.entries(GROUP_HEADER_BEFORE)) {
+    const builtinIndex = menus.findIndex((item) => item.id === builtinId);
+    if (builtinIndex < 0) continue;
+    const beforeCount = extensionTabs.filter((tab) => {
+      if (!tab.position || tab.position.placement !== 'before') return false;
+      return (LEGACY_ANCHOR_REMAP[tab.position.relativeTo] ?? tab.position.relativeTo) === builtinId;
+    }).length;
+    headerAt.set(builtinIndex - beforeCount, headerKey);
+  }
+  return headerAt;
+}
+
+type SettingsSiderViewProps = Readonly<{
+  collapsed: boolean;
+  extensionTabs: readonly IExtensionSettingsTab[];
+  menus: readonly SettingsNavItem[];
+  tooltipEnabled: boolean;
+}>;
+
+const SettingsSiderView: React.FC<SettingsSiderViewProps> = ({ collapsed, extensionTabs, menus, tooltipEnabled }) => {
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { pathname } = useLocation();
-  const isDesktop = isElectronDesktop();
-
-  const extensionTabs = useExtensionSettingsTabs();
-  const { resolveExtTabName } = useExtI18n();
-
-  const { menus, groupHeaderAt } = useMemo(() => {
-    // Build builtin items
-    const builtinMap: Record<string, SiderItem> = {
-      model: { id: 'model', label: t('settings.model'), icon: <LinkCloud />, path: 'model' },
-      agent: {
-        id: 'agent',
-        label: t('settings.agents', { defaultValue: 'Agents' }),
-        icon: <Speed />,
-        path: 'agent',
-      },
-      skills: {
-        id: 'skills',
-        label: t('settings.skills', { defaultValue: 'Skills' }),
-        icon: <Lightning />,
-        path: 'skills',
-      },
-      tools: {
-        id: 'tools',
-        label: t('settings.tools', { defaultValue: 'Tools' }),
-        icon: <Toolkit />,
-        path: 'tools',
-      },
-      appearance: { id: 'appearance', label: t('settings.appearancePanel'), icon: <Computer />, path: 'appearance' },
-      webui: {
-        id: 'webui',
-        label: t('settings.webui'),
-        icon: isDesktop ? <Earth /> : <Communication />,
-        path: 'webui',
-      },
-      pet: { id: 'pet', label: t('pet.desktopPet'), icon: <Cat />, path: 'pet' },
-      system: { id: 'system', label: t('settings.system'), icon: <System />, path: 'system' },
-      about: { id: 'about', label: t('settings.about'), icon: <Info />, path: 'about' },
-    };
-
-    // Start with ordered builtin IDs, hiding desktop-only tabs in browser mode
-    const result = withKiBuddySettingsItem(
-      BUILTIN_TAB_IDS.filter((id) => isDesktop || id !== 'pet').map((id) => builtinMap[id]),
-      t
-    );
-
-    // Extension tabs with position anchoring
-    const beforeMap = new Map<string, IExtensionSettingsTab[]>();
-    const afterMap = new Map<string, IExtensionSettingsTab[]>();
-    const unanchored: IExtensionSettingsTab[] = [];
-
-    for (const tab of extensionTabs) {
-      if (!tab.position) {
-        unanchored.push(tab);
-        continue;
-      }
-      const { relativeTo: rawAnchor, placement } = tab.position;
-      const anchor = LEGACY_ANCHOR_REMAP[rawAnchor] ?? rawAnchor;
-      if (!result.some((item) => item.id === anchor)) {
-        unanchored.push(tab);
-        continue;
-      }
-      const map = placement === 'before' ? beforeMap : afterMap;
-      let list = map.get(anchor);
-      if (!list) {
-        list = [];
-        map.set(anchor, list);
-      }
-      list.push(tab);
-    }
-
-    // Helper to create SiderItem from extension tab
-    const toSiderItem = (tab: IExtensionSettingsTab): SiderItem => {
-      const resolvedIcon = resolveExtensionAssetUrl(tab.icon) || tab.icon;
-      return {
-        id: tab.id,
-        label: resolveExtTabName(tab),
-        icon: resolvedIcon ? <img src={resolvedIcon} alt='' className='w-full h-full object-contain' /> : <Puzzle />,
-        isImageIcon: Boolean(resolvedIcon),
-        path: `ext/${tab.id}`,
-      };
-    };
-
-    // Insert anchored tabs (reverse iteration to preserve indices)
-    for (let i = result.length - 1; i >= 0; i--) {
-      const builtinId = result[i].id;
-      const afters = afterMap.get(builtinId);
-      if (afters) {
-        result.splice(i + 1, 0, ...afters.map(toSiderItem));
-      }
-      const befores = beforeMap.get(builtinId);
-      if (befores) {
-        result.splice(i, 0, ...befores.map(toSiderItem));
-      }
-    }
-
-    // Append unanchored before "system"
-    if (unanchored.length > 0) {
-      const systemIdx = result.findIndex((item) => item.id === 'system');
-      const insertIdx = systemIdx >= 0 ? systemIdx : result.length;
-      result.splice(insertIdx, 0, ...unanchored.map(toSiderItem));
-    }
-
-    // Compute group header render positions.
-    //
-    // A header must appear before the first *visible* item of its group, which may
-    // be an extension tab anchored with placement='before' to the group's first
-    // builtin — not the builtin itself. Otherwise such an extension would render
-    // above the header and visually belong to the previous group.
-    const headerAt = new Map<number, string>();
-    for (const [builtinId, headerKey] of Object.entries(GROUP_HEADER_BEFORE)) {
-      const builtinIdx = result.findIndex((item) => item.id === builtinId);
-      if (builtinIdx < 0) continue;
-      const beforeCount = beforeMap.get(builtinId)?.length ?? 0;
-      headerAt.set(builtinIdx - beforeCount, headerKey);
-    }
-
-    return { menus: result, groupHeaderAt: headerAt };
-  }, [t, isDesktop, extensionTabs, resolveExtTabName]);
-
+  const groupHeaderAt = useMemo(() => getGroupHeaderPositions(menus, extensionTabs), [extensionTabs, menus]);
   const siderTooltipProps = getSiderTooltipProps(tooltipEnabled);
+
   return (
     <div
       className={classNames('h-full settings-sider flex flex-col gap-2px overflow-y-auto overflow-x-hidden', {
@@ -232,7 +282,6 @@ const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }>
                   });
                 }}
               >
-                {/* Leading icon — 22px slot to align with main sider rows */}
                 <span className='settings-sider__item-icon size-22px flex items-center justify-center shrink-0 line-height-0'>
                   {item.isImageIcon ? (
                     <span className='w-16px h-16px flex items-center justify-center'>{item.icon}</span>
@@ -265,6 +314,64 @@ const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }>
       })}
     </div>
   );
+};
+
+type ExtensionAwareSettingsSiderProps = Readonly<{
+  builtins: readonly SettingsNavItem[];
+  collapsed: boolean;
+  tooltipEnabled: boolean;
+}>;
+
+const ExtensionAwareSettingsSider: React.FC<ExtensionAwareSettingsSiderProps> = ({
+  builtins,
+  collapsed,
+  tooltipEnabled,
+}) => {
+  const extensionTabs = useExtensionSettingsTabs();
+  const { resolveExtTabName } = useExtI18n();
+  const menus = useMemo(
+    () =>
+      mergeExtensionSettingsItems(builtins, extensionTabs, (tab) => {
+        const resolvedIcon = resolveExtensionAssetUrl(tab.icon) || tab.icon;
+        return {
+          id: tab.id,
+          label: resolveExtTabName(tab),
+          icon: resolvedIcon ? <img src={resolvedIcon} alt='' className='w-full h-full object-contain' /> : <Puzzle />,
+          isImageIcon: Boolean(resolvedIcon),
+          path: `ext/${tab.id}`,
+        };
+      }),
+    [builtins, extensionTabs, resolveExtTabName]
+  );
+
+  return (
+    <SettingsSiderView
+      collapsed={collapsed}
+      extensionTabs={extensionTabs}
+      menus={menus}
+      tooltipEnabled={tooltipEnabled}
+    />
+  );
+};
+
+const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }> = ({
+  collapsed = false,
+  tooltipEnabled = false,
+}) => {
+  const { t } = useTranslation();
+  const isDesktop = isElectronDesktop();
+  const { extensionSettingsEnabled, items: builtins } = useMemo(
+    () => getSettingsNavigationProjection(isDesktop, t),
+    [isDesktop, t]
+  );
+
+  if (!extensionSettingsEnabled) {
+    return (
+      <SettingsSiderView collapsed={collapsed} extensionTabs={[]} menus={builtins} tooltipEnabled={tooltipEnabled} />
+    );
+  }
+
+  return <ExtensionAwareSettingsSider builtins={builtins} collapsed={collapsed} tooltipEnabled={tooltipEnabled} />;
 };
 
 export default SettingsSider;

--- a/packages/desktop/src/renderer/services/runtime/kiBuddyRuntime.ts
+++ b/packages/desktop/src/renderer/services/runtime/kiBuddyRuntime.ts
@@ -115,8 +115,7 @@ export function getKiBuddyRouteComponents(): typeof KI_BUDDY_ROUTE_COMPONENTS | 
   return getKiBuddyRendererRuntime() ? KI_BUDDY_ROUTE_COMPONENTS : null;
 }
 
-/** Adds the product account entry to a settings item list when Ki-Buddy is active. */
-export function withKiBuddySettingsItem(items: SettingsItem[], t: TranslateFn): SettingsItem[] {
-  const item = getKiBuddyRendererRuntime() ? createKiBuddyAccountSettingsItem(t) : null;
-  return item ? [item, ...items] : items;
+/** Returns the product-owned account registration when the Ki-Buddy runtime is active. */
+export function getKiBuddyAccountSettingsItem(t: TranslateFn): SettingsItem | null {
+  return getKiBuddyRendererRuntime() ? createKiBuddyAccountSettingsItem(t) : null;
 }

--- a/tests/integration/ProductExperienceSettingsHost.dom.test.tsx
+++ b/tests/integration/ProductExperienceSettingsHost.dom.test.tsx
@@ -1,0 +1,386 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Outlet } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { KI_BUDDY_PRODUCT_CAPABILITY } from '@/common/platform/ki-buddy';
+
+const mocks = vi.hoisted(() => ({
+  configGet: vi.fn(() => []),
+  extensionPageRender: vi.fn(),
+  extensionThemes: vi.fn(async () => []),
+  extensionTabs: vi.fn(() => []),
+  extensionTranslations: vi.fn(() => ({ resolveExtTabName: (tab: { label: string }) => tab.label })),
+  isMobile: false,
+  petPageRender: vi.fn(),
+  themeSettingsRender: vi.fn(),
+  webuiGetStatus: vi.fn(async () => ({ running: false })),
+  webuiPageRender: vi.fn(),
+  webuiStatusChanged: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en-US' } }),
+}));
+vi.mock('@/renderer/hooks/context/AuthContext', () => ({
+  useAuth: () => ({ status: 'authenticated' }),
+}));
+vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({ isMobile: mocks.isMobile }),
+}));
+vi.mock('@/renderer/hooks/context/ThemeContext', () => ({
+  useThemeContext: () => ({
+    activeId: 'light',
+    activeTheme: null,
+    fontSizes: { chat: 14, markdown: 14, code: 13 },
+    selectTheme: vi.fn(),
+    setFontSize: vi.fn(),
+    setTheme: vi.fn(),
+    theme: 'light',
+  }),
+}));
+vi.mock('@/renderer/hooks/system/useExtensionSettingsTabs', () => ({
+  useExtensionSettingsTabs: mocks.extensionTabs,
+}));
+vi.mock('@/renderer/hooks/system/useExtI18n', () => ({
+  useExtI18n: mocks.extensionTranslations,
+}));
+vi.mock('@/common/config/configService', () => ({
+  configService: { get: mocks.configGet, set: vi.fn() },
+}));
+vi.mock('@/common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common')>();
+  return {
+    ...actual,
+    ipcBridge: {
+      ...actual.ipcBridge,
+      extensions: {
+        ...actual.ipcBridge.extensions,
+        getThemes: { ...actual.ipcBridge.extensions.getThemes, invoke: mocks.extensionThemes },
+      },
+    },
+  };
+});
+vi.mock('@/common/adapter/ipcBridge', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common/adapter/ipcBridge')>();
+  return {
+    ...actual,
+    webui: {
+      ...actual.webui,
+      getStatus: { ...actual.webui.getStatus, invoke: mocks.webuiGetStatus },
+      statusChanged: { ...actual.webui.statusChanged, on: mocks.webuiStatusChanged },
+    },
+  };
+});
+vi.mock('@/renderer/pages/ki-buddy', () => ({
+  loadKiBuddyAccountSettings: async () => ({ default: () => <div>account-settings-page</div> }),
+  loadKiBuddyLoginPage: async () => ({ default: () => <div>login-page</div> }),
+  loadKiBuddyStartupGate: async () => ({
+    default: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  }),
+}));
+vi.mock('@renderer/pages/guid', () => ({ default: () => <div>guid-page</div> }));
+vi.mock('@renderer/pages/conversation', () => ({ default: () => <div>conversation-page</div> }));
+vi.mock('@renderer/pages/team', () => ({ default: () => <div>team-page</div> }));
+vi.mock('@renderer/pages/settings/AgentSettings', () => ({ default: () => <div>agent-settings-page</div> }));
+vi.mock('@renderer/pages/settings/AgentSettings/AgentRepairPage', () => ({
+  default: () => <div>agent-repair-page</div>,
+}));
+vi.mock('@renderer/pages/settings/AssistantSettings', () => ({ default: () => <div>assistant-settings-page</div> }));
+vi.mock('@renderer/pages/settings/SkillsSettings/SkillsHubSettings', () => ({
+  default: () => <div>skills-settings-page</div>,
+}));
+vi.mock('@renderer/pages/settings/SkillsSettings/SkillDetailPage', () => ({
+  default: () => <div>skill-detail-page</div>,
+}));
+vi.mock('@renderer/pages/settings/ToolsSettings', () => ({ default: () => <div>tools-settings-page</div> }));
+vi.mock('@renderer/pages/settings/AppearanceSettings', () => ({
+  default: () => <div>appearance-settings-page</div>,
+}));
+vi.mock('@renderer/pages/settings/ModeSettings', () => ({ default: () => <div>model-settings-page</div> }));
+vi.mock('@renderer/pages/settings/SystemSettings', () => ({ default: () => <div>system-settings-page</div> }));
+vi.mock('@renderer/pages/settings/WebuiSettings', () => ({
+  default: () => {
+    mocks.webuiPageRender();
+    return <div>webui-settings-page</div>;
+  },
+}));
+vi.mock('@renderer/pages/settings/PetSettings', () => ({
+  default: () => {
+    mocks.petPageRender();
+    return <div>pet-settings-page</div>;
+  },
+}));
+vi.mock('@renderer/pages/settings/ExtensionSettingsPage', () => ({
+  default: () => {
+    mocks.extensionPageRender();
+    return <div>extension-settings-page</div>;
+  },
+}));
+vi.mock('@renderer/pages/TestShowcase', () => ({ default: () => <div>showcase-page</div> }));
+vi.mock('@renderer/pages/cron/ScheduledTasksPage', () => ({ default: () => <div>scheduled-page</div> }));
+vi.mock('@renderer/pages/cron/ScheduledTasksPage/TaskDetailPage', () => ({
+  default: () => <div>scheduled-detail-page</div>,
+}));
+vi.mock('@renderer/pages/settings/AppearanceSettings/CssThemeSettings', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/pages/settings/AppearanceSettings/CssThemeSettings')>();
+  return {
+    ...actual,
+    default: (props: React.ComponentProps<typeof actual.default>) => {
+      mocks.themeSettingsRender();
+      const CssThemeSettings = actual.default;
+      return (
+        <>
+          <div>theme-settings</div>
+          <CssThemeSettings {...props} />
+        </>
+      );
+    },
+  };
+});
+vi.mock('@/renderer/components/settings/FontSizeStepper', () => ({
+  default: () => <div data-testid='font-size-setting' />,
+}));
+vi.mock('@/renderer/components/settings/ScaleControl', () => ({
+  default: () => <div data-testid='scale-setting' />,
+}));
+
+import PanelRoute from '@/renderer/components/layout/Router';
+import SiderFooter from '@/renderer/components/layout/Sider/SiderFooter';
+import AppearanceModalContent from '@/renderer/components/settings/SettingsModal/contents/AppearanceModalContent';
+import CssThemeSettings from '@/renderer/pages/settings/AppearanceSettings/CssThemeSettings';
+import SettingsPageWrapper from '@/renderer/pages/settings/components/SettingsPageWrapper';
+import SettingsSider from '@/renderer/pages/settings/components/SettingsSider';
+import QuickActionButtons from '@/renderer/pages/guid/components/QuickActionButtons';
+
+const TestLayout = () => (
+  <div>
+    app-layout
+    <Outlet />
+  </div>
+);
+
+function activateKiBuddy(): void {
+  window.electronAPI = {
+    ...window.electronAPI,
+    kiBuddyAuth: {
+      getSession: vi.fn(),
+      login: vi.fn(),
+      logout: vi.fn(),
+    },
+  };
+  window.__kiBuddyProductBootstrapError = null;
+  window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+}
+
+describe('Product experience settings navigation', () => {
+  beforeEach(() => {
+    mocks.isMobile = false;
+    mocks.extensionTabs.mockClear();
+    mocks.extensionTranslations.mockClear();
+    window.__kiBuddyProductBootstrapError = null;
+    window.__kiBuddyProductPresentation = null;
+  });
+
+  it('does not start Extension settings hooks from the Ki-Buddy mobile navigation', () => {
+    activateKiBuddy();
+    mocks.isMobile = true;
+
+    render(
+      <MemoryRouter initialEntries={['/settings/account']}>
+        <SettingsPageWrapper>account-content</SettingsPageWrapper>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('account-content')).toBeInTheDocument();
+    expect(mocks.extensionTabs).not.toHaveBeenCalled();
+    expect(mocks.extensionTranslations).not.toHaveBeenCalled();
+  });
+
+  it('shows the Ki-Buddy settings in registry order without starting Extension settings subscriptions', () => {
+    activateKiBuddy();
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/settings/account']}>
+        <SettingsSider />
+      </MemoryRouter>
+    );
+
+    const ids = Array.from(container.querySelectorAll('[data-settings-id]')).map((item) =>
+      item.getAttribute('data-settings-id')
+    );
+    expect(ids).toEqual(['account', 'agent', 'model', 'skills', 'tools', 'appearance', 'system', 'about']);
+    expect(mocks.extensionTabs).not.toHaveBeenCalled();
+    expect(mocks.extensionTranslations).not.toHaveBeenCalled();
+  });
+
+  it('keeps the complete AionUi settings registry available', () => {
+    window.electronAPI = { ...window.electronAPI, kiBuddyAuth: undefined };
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/settings/agent']}>
+        <SettingsSider />
+      </MemoryRouter>
+    );
+
+    const ids = Array.from(container.querySelectorAll('[data-settings-id]')).map((item) =>
+      item.getAttribute('data-settings-id')
+    );
+    expect(ids).toEqual(['agent', 'model', 'skills', 'tools', 'appearance', 'webui', 'pet', 'system', 'about']);
+    expect(mocks.extensionTabs).toHaveBeenCalledOnce();
+  });
+});
+
+describe('Product experience settings routes', () => {
+  beforeEach(() => {
+    mocks.extensionPageRender.mockClear();
+    mocks.petPageRender.mockClear();
+    mocks.webuiPageRender.mockClear();
+    window.location.hash = '#/guid';
+    window.__kiBuddyProductBootstrapError = null;
+    window.__kiBuddyProductPresentation = null;
+  });
+
+  it('opens the first enabled registry page from the Ki-Buddy settings root', async () => {
+    activateKiBuddy();
+    window.location.hash = '#/settings';
+
+    render(<PanelRoute layout={<TestLayout />} />);
+
+    expect(await screen.findByText('account-settings-page')).toBeInTheDocument();
+    await waitFor(() => expect(window.location.hash).toBe('#/settings/account'));
+  });
+
+  it.each(['/settings/webui', '/settings/pet', '/settings/ext/marketplace'])(
+    'replaces disabled address %s without mounting its page',
+    async (path) => {
+      activateKiBuddy();
+      window.location.hash = `#${path}`;
+
+      render(<PanelRoute layout={<TestLayout />} />);
+
+      expect(await screen.findByText('account-settings-page')).toBeInTheDocument();
+      await waitFor(() => expect(window.location.hash).toBe('#/settings/account'));
+      expect(mocks.webuiPageRender).not.toHaveBeenCalled();
+      expect(mocks.petPageRender).not.toHaveBeenCalled();
+      expect(mocks.extensionPageRender).not.toHaveBeenCalled();
+    }
+  );
+
+  it('keeps AionUi settings routes registered', async () => {
+    window.electronAPI = { ...window.electronAPI, kiBuddyAuth: undefined };
+    window.location.hash = '#/settings/webui';
+
+    render(<PanelRoute layout={<TestLayout />} />);
+
+    expect(await screen.findByText('webui-settings-page')).toBeInTheDocument();
+    expect(mocks.webuiPageRender).toHaveBeenCalled();
+  });
+});
+
+describe('Product experience Appearance projection', () => {
+  beforeEach(() => {
+    mocks.configGet.mockClear();
+    mocks.extensionThemes.mockClear();
+    mocks.themeSettingsRender.mockClear();
+    window.__kiBuddyProductBootstrapError = null;
+    window.__kiBuddyProductPresentation = null;
+  });
+
+  it('keeps font and UI scale without mounting disabled theme capabilities in Ki-Buddy', () => {
+    activateKiBuddy();
+
+    render(<AppearanceModalContent />);
+
+    expect(screen.getAllByTestId('font-size-setting')).toHaveLength(3);
+    expect(screen.getByTestId('scale-setting')).toBeInTheDocument();
+    expect(screen.queryByText('theme-settings')).not.toBeInTheDocument();
+    expect(mocks.themeSettingsRender).not.toHaveBeenCalled();
+  });
+
+  it('keeps the AionUi theme settings available', () => {
+    render(<AppearanceModalContent />);
+
+    expect(screen.getByText('theme-settings')).toBeInTheDocument();
+    expect(mocks.themeSettingsRender).toHaveBeenCalledOnce();
+  });
+
+  it('does not read user or Extension themes when every theme capability is disabled', () => {
+    render(<CssThemeSettings capabilities={{ customThemes: false, marketplace: false, presets: false }} />);
+
+    expect(mocks.configGet).not.toHaveBeenCalled();
+    expect(mocks.extensionThemes).not.toHaveBeenCalled();
+    expect(screen.queryByText('settings.cssTheme.addManually')).not.toBeInTheDocument();
+  });
+
+  it('keeps AionUi user themes, Extension themes, and presets enabled', async () => {
+    render(<CssThemeSettings capabilities={{ customThemes: true, marketplace: true, presets: true }} />);
+
+    await waitFor(() => expect(mocks.extensionThemes).toHaveBeenCalledOnce());
+    expect(mocks.configGet).toHaveBeenCalledWith('theme.userThemes');
+    expect(screen.getByText('settings.cssTheme.addManually')).toBeInTheDocument();
+  });
+
+  it('keeps the quick light and dark mode control available in Ki-Buddy', () => {
+    activateKiBuddy();
+    const onThemeToggle = vi.fn();
+
+    render(
+      <SiderFooter
+        isMobile={false}
+        isSettings
+        theme='light'
+        siderTooltipProps={{}}
+        onSettingsClick={vi.fn()}
+        onThemeToggle={onThemeToggle}
+      />
+    );
+    fireEvent.click(screen.getByLabelText('settings.darkMode'));
+
+    expect(onThemeToggle).toHaveBeenCalledOnce();
+  });
+});
+
+describe('Product experience Guid WebUI projection', () => {
+  beforeEach(() => {
+    mocks.webuiGetStatus.mockClear();
+    mocks.webuiStatusChanged.mockClear();
+    window.__kiBuddyProductBootstrapError = null;
+    window.__kiBuddyProductPresentation = null;
+  });
+
+  it('does not mount WebUI status behavior in Ki-Buddy', () => {
+    activateKiBuddy();
+
+    render(
+      <MemoryRouter>
+        <QuickActionButtons
+          activeShadow='none'
+          inactiveBorderColor='transparent'
+          onOpenBugReport={vi.fn()}
+          onOpenLink={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText(/settings\.webui ·/)).not.toBeInTheDocument();
+    expect(mocks.webuiGetStatus).not.toHaveBeenCalled();
+    expect(mocks.webuiStatusChanged).not.toHaveBeenCalled();
+  });
+
+  it('keeps the AionUi WebUI quick action and status behavior', async () => {
+    render(
+      <MemoryRouter>
+        <QuickActionButtons
+          activeShadow='none'
+          inactiveBorderColor='transparent'
+          onOpenBugReport={vi.fn()}
+          onOpenLink={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/settings\.webui ·/)).toBeInTheDocument();
+    await waitFor(() => expect(mocks.webuiGetStatus).toHaveBeenCalledOnce());
+    expect(mocks.webuiStatusChanged).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/renderer/ki-buddy/settingsNavigation.dom.test.tsx
+++ b/tests/unit/renderer/ki-buddy/settingsNavigation.dom.test.tsx
@@ -4,8 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { KI_BUDDY_PRODUCT_CAPABILITY } from '@/common/platform/ki-buddy';
 import { createKiBuddyAccountSettingsItem } from '@/renderer/pages/ki-buddy/settingsNavigation';
-import SettingsSider from '@/renderer/pages/settings/components/SettingsSider';
-import { getBuiltinSettingsNavItems } from '@/renderer/pages/settings/components/SettingsPageWrapper';
+import SettingsSider, { getSettingsNavigationProjection } from '@/renderer/pages/settings/components/SettingsSider';
 
 const translateKey = (key: string) => key;
 
@@ -32,7 +31,7 @@ describe('Ki-Buddy settings navigation', () => {
   });
 
   it('adds the product entry only when the Ki-Buddy capability is present', () => {
-    expect(getBuiltinSettingsNavItems(true, translateKey).some(({ id }) => id === 'account')).toBe(false);
+    expect(getSettingsNavigationProjection(true, translateKey).items.some(({ id }) => id === 'account')).toBe(false);
     window.electronAPI = {
       ...window.electronAPI,
       kiBuddyAuth: {
@@ -43,7 +42,7 @@ describe('Ki-Buddy settings navigation', () => {
     };
     window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
 
-    expect(getBuiltinSettingsNavItems(true, translateKey)[0]?.id).toBe('account');
+    expect(getSettingsNavigationProjection(true, translateKey).items[0]?.id).toBe('account');
   });
 
   it.each(['account', 'agent'])('uses the shared selected navigation contract for %s', (settingsId) => {

--- a/tests/unit/renderer/services/runtime/kiBuddyRuntime.dom.test.ts
+++ b/tests/unit/renderer/services/runtime/kiBuddyRuntime.dom.test.ts
@@ -2,11 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { KI_BUDDY_PRODUCT_CAPABILITY } from '@/common/platform/ki-buddy';
 import {
   getProductExperience,
+  getKiBuddyAccountSettingsItem,
   getKiBuddyProductBootstrapError,
   getKiBuddyProductRuntime,
   getKiBuddyRendererRuntime,
   getKiBuddyRouteComponents,
-  withKiBuddySettingsItem,
 } from '@/renderer/services/runtime/kiBuddyRuntime';
 
 const translateKey = (key: string) => key;
@@ -22,7 +22,7 @@ describe('Ki-Buddy renderer runtime selection', () => {
   it('keeps product routes and settings absent without the product capability', () => {
     expect(getKiBuddyRendererRuntime()).toBeNull();
     expect(getKiBuddyRouteComponents()).toBeNull();
-    expect(withKiBuddySettingsItem([], translateKey)).toEqual([]);
+    expect(getKiBuddyAccountSettingsItem(translateKey)).toBeNull();
   });
 
   it('exposes product branding independently of authentication', () => {
@@ -48,7 +48,7 @@ describe('Ki-Buddy renderer runtime selection', () => {
       LoginPage: expect.any(Object),
       StartupGate: expect.any(Object),
     });
-    expect(withKiBuddySettingsItem([], translateKey)[0]).toMatchObject({ id: 'account', path: 'account' });
+    expect(getKiBuddyAccountSettingsItem(translateKey)).toMatchObject({ id: 'account', path: 'account' });
   });
 
   it('does not access the preload capability after bootstrap', () => {


### PR DESCRIPTION
# Pull Request

## Description

本 PR 使用统一的 settings registry 和 `ProductExperience` 投影 Ki-Buddy 的设置菜单、设置路由与 Appearance 子能力。

- Ki-Buddy 设置按固定顺序显示 Account、Agent、Model、Skills、Tools、Appearance、System 和 About。
- 停用 WebUI、Pet、Extension settings 等未开放入口及路由；直接访问旧地址时转到首个启用页面。
- 停用页面不会挂载相关 hooks、IPC 请求或事件订阅，包括 Guid 的 WebUI 状态行为和移动端 Extension settings hooks。
- Appearance 保留字体、UI scale 与快捷 light/dark mode，隐藏主题预设、主题市场和自定义主题。
- 完整 AionUi 保留原有设置、主题与 WebUI 能力。

## Related Issues

- Closes #47

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — 4077 passed, 5 skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

不适用。本次变更由产品能力策略控制已有设置界面的注册与挂载，不新增视觉样式。

## Additional Context

- Standards 与 Spec 两个独立审查均无发现。
- `bun run package` 通过；构建仅报告仓库已有的动态导入、循环 chunk 与体积提示。
- i18n 校验通过；输出包含仓库已有的翻译缺失和未知 key 警告。
