### PR TITLE
feat(ki-buddy): project main workspace experience

### DIFF
--- a/docs/adr/0011-control-aionui-with-product-experience-policy.md
+++ b/docs/adr/0011-control-aionui-with-product-experience-policy.md
@@ -10,6 +10,8 @@ Ki-Buddy 长期跟随 AionUi 演进，但首个正式版本只开放经过产品
 
 AionUi 与 Ki-Buddy 分别提供 adapter。产品 capability 完全缺失时使用完整 AionUi 行为；运行环境已经识别为 Ki-Buddy，但策略缺失、字段未知、依赖矛盾或版本不支持时显示安装完整性错误，不能退回 AionUi。AionUi 新增产品能力后，Ki-Buddy 必须明确声明启用或停用，构建校验才能通过。
 
+当前 ProductExperience schema v1 要求 `guid` 保持 `enabled`，作为 Ki-Buddy 认证后的必选入口。随包策略将 `guid` 声明为 `disabled` 时属于安装完整性错误；未来若要发布不含 Guid 的产品版本，必须先定义替代入口并升级策略契约。
+
 路由、导航、资源 catalog 和生命周期分别根据同一策略生成投影。导航 registry 保持稳定顺序，产品策略不复制菜单和路由结构。停用功能的代码继续随上游基线打包，使后续 Ki-Buddy 版本可以通过更新策略重新开放能力；产品功能状态只约束客户端产品行为，不替代 Agents 平台或 AionCore 的安全授权。
 
 ## 上游接缝与同步维护
@@ -60,10 +62,12 @@ MCP requirement 使用独立注册表和稳定后端资源 ID。#41 接入前注
 - 分别配置可见路由、导航和设置项：同一能力可能出现入口隐藏、路由可达或副作用仍启动的不一致状态。
 - 在各个 AionUi 页面直接判断 Ki-Buddy：产品规则会分散到上游文件，增加每次基线同步的冲突和遗漏风险。
 - 由服务端或用户设置动态覆盖策略：会增加远程状态、缓存和启动时序问题，首个正式版本没有该需求。
+- 允许关闭 Guid 并从 workspace 与 settings registry 动态选择认证后的入口：当前版本明确保留新建对话，增加动态入口选择会扩大策略组合和测试范围；等产品确实需要无 Guid 版本时再随策略契约升级引入。
 
 ## Consequences
 
 - `ki-buddy-product.json` 升级为 schema v3，并完整声明当前产品能力；schema v2 不进行运行时迁移。
+- ProductExperience schema v1 拒绝 `guid: disabled`；该错误沿产品配置加载路径进入安装完整性界面，不启动业务生命周期，也不退回 AionUi。
 - 产品内置资源缺失时，受影响能力显示安装完整性错误，不按名称选择相似上游资源替代；账户和诊断功能仍然可用。
 - Ki-Buddy 首个正式版本使用独立且没有历史产品数据的运行空间；#40 不处理 AionUi、开发版或预发布 Ki-Buddy 数据兼容。
 - Scheduled Tasks 只选择 Assistant，并使用产品策略投影后的 Assistant catalog；Team 不是定时任务执行者。

--- a/packages/desktop/src/common/platform/ki-buddy/productExperience.ts
+++ b/packages/desktop/src/common/platform/ki-buddy/productExperience.ts
@@ -170,6 +170,9 @@ export function parseProductExperiencePolicy(value: unknown): ProductExperienceS
       throw new Error(`Product feature ${child} requires enabled parent ${parent}`);
     }
   }
+  if (features.guid !== 'enabled') {
+    throw new Error('Product feature guid must be enabled');
+  }
 
   const rawResources = requireRecord(policy.resources, 'Product experience resources');
   requireExactKeys(rawResources, PRODUCT_RESOURCE_KINDS, 'Product experience resources');

--- a/packages/desktop/src/renderer/components/layout/Router.tsx
+++ b/packages/desktop/src/renderer/components/layout/Router.tsx
@@ -63,7 +63,12 @@ const ProtectedLayout: React.FC<{ layout: React.ReactElement }> = ({ layout }) =
 const PanelRoute: React.FC<{ layout: React.ReactElement }> = ({ layout }) => {
   const { status } = useAuth();
   const kiBuddyRoutes = getKiBuddyRouteComponents();
+  const guidEnabled = isProductFeatureEnabled('guid');
+  const conversationEnabled = isProductFeatureEnabled('conversation');
+  const assistantsEnabled = isProductFeatureEnabled('assistants');
+  const scheduledTasksEnabled = isProductFeatureEnabled('scheduledTasks');
   const teamEnabled = isProductFeatureEnabled('team');
+  const componentShowcaseEnabled = isProductFeatureEnabled('componentShowcase');
   const settingsProjection = getSettingsExperienceProjection({
     includeProductEntries: Boolean(kiBuddyRoutes),
     isDesktop: true,
@@ -89,14 +94,17 @@ const PanelRoute: React.FC<{ layout: React.ReactElement }> = ({ layout }) => {
         />
         <Route element={<ProtectedLayout layout={layout} />}>
           <Route index element={<Navigate to='/guid' replace />} />
-          <Route path='/guid' element={withRouteFallback(Guid)} />
-          <Route path='/conversation/:id' element={withRouteFallback(Conversation)} />
+          {guidEnabled && <Route path='/guid' element={withRouteFallback(Guid)} />}
+          {conversationEnabled && <Route path='/conversation/:id' element={withRouteFallback(Conversation)} />}
           {teamEnabled && <Route path='/team/:id' element={withRouteFallback(TeamIndex)} />}
           {enabledSettings.has('model') && <Route path='/settings/model' element={withRouteFallback(ModeSettings)} />}
-          <Route path='/assistants' element={withRouteFallback(AssistantSettings)} />
+          {assistantsEnabled && <Route path='/assistants' element={withRouteFallback(AssistantSettings)} />}
           {/* Assistants moved out of Settings to a top-level entry; keep a redirect
               so old deep links / back-nav still land on the new page. */}
-          <Route path='/settings/assistants' element={<Navigate to='/assistants' replace />} />
+          <Route
+            path='/settings/assistants'
+            element={<Navigate to={assistantsEnabled ? '/assistants' : '/guid'} replace />}
+          />
           {enabledSettings.has('agent') && (
             <>
               <Route path='/settings/agent' element={withRouteFallback(AgentSettings)} />
@@ -152,9 +160,15 @@ const PanelRoute: React.FC<{ layout: React.ReactElement }> = ({ layout }) => {
           )}
           <Route path='/settings' element={<Navigate to={defaultSettingsPath} replace />} />
           <Route path='/settings/*' element={<Navigate to={defaultSettingsPath} replace />} />
-          <Route path='/test/components' element={withRouteFallback(ComponentsShowcase)} />
-          <Route path='/scheduled' element={withRouteFallback(ScheduledTasksPage)} />
-          <Route path='/scheduled/:job_id' element={withRouteFallback(TaskDetailPage)} />
+          {componentShowcaseEnabled && (
+            <Route path='/test/components' element={withRouteFallback(ComponentsShowcase)} />
+          )}
+          {scheduledTasksEnabled && (
+            <>
+              <Route path='/scheduled' element={withRouteFallback(ScheduledTasksPage)} />
+              <Route path='/scheduled/:job_id' element={withRouteFallback(TaskDetailPage)} />
+            </>
+          )}
         </Route>
         <Route path='*' element={<Navigate to={status === 'authenticated' ? '/guid' : '/login'} replace />} />
       </Routes>

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderNav/SiderToolbar.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderNav/SiderToolbar.tsx
@@ -19,6 +19,7 @@ interface SiderToolbarProps {
   siderTooltipProps: SiderTooltipProps;
   onNewChat: () => void;
   onToggleBatchMode: () => void;
+  showHistoryActions?: boolean;
 }
 
 const SiderToolbar: React.FC<SiderToolbarProps> = ({
@@ -28,6 +29,7 @@ const SiderToolbar: React.FC<SiderToolbarProps> = ({
   siderTooltipProps,
   onNewChat,
   onToggleBatchMode,
+  showHistoryActions = true,
 }) => {
   const { t } = useTranslation();
 
@@ -80,25 +82,27 @@ const SiderToolbar: React.FC<SiderToolbarProps> = ({
           </span>
         </div>
       </Tooltip>
-      <Tooltip
-        {...siderTooltipProps}
-        content={isBatchMode ? t('conversation.history.batchModeExit') : t('conversation.history.batchManage')}
-        position='right'
-      >
-        <div
-          className={classNames(
-            'size-26px rd-6px flex items-center justify-center cursor-pointer shrink-0 transition-colors border border-solid border-transparent text-t-secondary hover:text-t-primary',
-            isMobile && 'sider-action-icon-btn-mobile',
-            {
-              'hover:bg-fill-3': !isBatchMode,
-              'bg-[rgba(var(--primary-6),0.12)] border-[rgba(var(--primary-6),0.24)] !text-primary': isBatchMode,
-            }
-          )}
-          onClick={onToggleBatchMode}
+      {showHistoryActions && (
+        <Tooltip
+          {...siderTooltipProps}
+          content={isBatchMode ? t('conversation.history.batchModeExit') : t('conversation.history.batchManage')}
+          position='right'
         >
-          <ListCheckbox theme='outline' size='14' className='block leading-none shrink-0' style={{ lineHeight: 0 }} />
-        </div>
-      </Tooltip>
+          <div
+            className={classNames(
+              'size-26px rd-6px flex items-center justify-center cursor-pointer shrink-0 transition-colors border border-solid border-transparent text-t-secondary hover:text-t-primary',
+              isMobile && 'sider-action-icon-btn-mobile',
+              {
+                'hover:bg-fill-3': !isBatchMode,
+                'bg-[rgba(var(--primary-6),0.12)] border-[rgba(var(--primary-6),0.24)] !text-primary': isBatchMode,
+              }
+            )}
+            onClick={onToggleBatchMode}
+          >
+            <ListCheckbox theme='outline' size='14' className='block leading-none shrink-0' style={{ lineHeight: 0 }} />
+          </div>
+        </Tooltip>
+      )}
     </div>
   );
 };

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderNav/index.ts
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderNav/index.ts
@@ -2,3 +2,4 @@ export { default as SiderAssistantEntry } from './SiderAssistantEntry';
 export { default as SiderScheduledEntry } from './SiderScheduledEntry';
 export { default as SiderSearchEntry } from './SiderSearchEntry';
 export { default as SiderToolbar } from './SiderToolbar';
+export { getWorkspaceNavigationProjection } from './workspaceRegistry';

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderNav/workspaceRegistry.ts
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderNav/workspaceRegistry.ts
@@ -1,0 +1,31 @@
+import type { ProductFeatureId } from '@/common/platform/ki-buddy';
+import { isProductFeatureEnabled } from '@/renderer/services/runtime/kiBuddyRuntime';
+
+export type WorkspaceNavigationId =
+  | 'newConversation'
+  | 'conversationSearch'
+  | 'assistants'
+  | 'scheduledTasks'
+  | 'conversationHistory'
+  | 'team';
+
+export type WorkspaceNavigationRegistryEntry = Readonly<{
+  featureId: ProductFeatureId;
+  id: WorkspaceNavigationId;
+  placement: 'primary' | 'history';
+}>;
+
+/** Stable workspace navigation order shared by the complete and product-projected UIs. */
+export const WORKSPACE_NAVIGATION_REGISTRY = [
+  { id: 'newConversation', featureId: 'guid', placement: 'primary' },
+  { id: 'conversationSearch', featureId: 'conversation', placement: 'primary' },
+  { id: 'assistants', featureId: 'assistants', placement: 'primary' },
+  { id: 'scheduledTasks', featureId: 'scheduledTasks', placement: 'primary' },
+  { id: 'conversationHistory', featureId: 'conversation', placement: 'history' },
+  { id: 'team', featureId: 'team', placement: 'history' },
+] as const satisfies readonly WorkspaceNavigationRegistryEntry[];
+
+/** Projects the registry through the active ProductExperience without duplicating navigation arrays. */
+export function getWorkspaceNavigationProjection(): ReadonlyArray<(typeof WORKSPACE_NAVIGATION_REGISTRY)[number]> {
+  return WORKSPACE_NAVIGATION_REGISTRY.filter(({ featureId }) => isProductFeatureEnabled(featureId));
+}

--- a/packages/desktop/src/renderer/components/layout/Sider/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/index.tsx
@@ -7,11 +7,16 @@ import { useAuth } from '@renderer/hooks/context/AuthContext';
 import { useLayoutContext } from '@renderer/hooks/context/LayoutContext';
 import { blurActiveElement } from '@renderer/utils/ui/focus';
 import { useThemeContext } from '@renderer/hooks/context/ThemeContext';
-import { SiderToolbar, SiderSearchEntry, SiderScheduledEntry, SiderAssistantEntry } from './SiderNav';
+import {
+  getWorkspaceNavigationProjection,
+  SiderAssistantEntry,
+  SiderScheduledEntry,
+  SiderSearchEntry,
+  SiderToolbar,
+} from './SiderNav';
 import SiderFooter, { shouldShowAionUiSiderLogout } from './SiderFooter';
 import TeamSiderSection from './TeamSiderSection';
 import siderStyles from './Sider.module.css';
-import { isProductFeatureEnabled } from '@/renderer/services/runtime/kiBuddyRuntime';
 
 const WorkspaceGroupedHistory = React.lazy(() => import('@renderer/pages/conversation/GroupedHistory'));
 const SettingsSider = React.lazy(() => import('@renderer/pages/settings/components/SettingsSider'));
@@ -38,7 +43,11 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
     authenticated: status === 'authenticated',
     electronDesktop: typeof window !== 'undefined' && Boolean(window.electronAPI),
   });
-  const teamEnabled = isProductFeatureEnabled('team');
+  const navigationProjection = getWorkspaceNavigationProjection();
+  const enabledNavigation = new Set(navigationProjection.map(({ id }) => id));
+  const primaryNavigation = navigationProjection.filter(({ placement }) => placement === 'primary');
+  const conversationHistoryEnabled = enabledNavigation.has('conversationHistory');
+  const teamEnabled = enabledNavigation.has('team');
 
   useEffect(() => {
     if (!pathname.startsWith('/settings')) {
@@ -174,6 +183,14 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
     batchMode: isBatchMode,
     onBatchModeChange: setIsBatchMode,
   };
+  const teamNavigation = teamEnabled ? (
+    <TeamSiderSection
+      collapsed={collapsed}
+      pathname={pathname}
+      siderTooltipProps={siderTooltipProps}
+      onSessionClick={onSessionClick}
+    />
+  ) : null;
 
   return (
     <div className='size-full flex flex-col'>
@@ -185,41 +202,59 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
           </Suspense>
         ) : (
           <div className='size-full flex flex-col gap-2px'>
-            <SiderToolbar
-              isMobile={isMobile}
-              isBatchMode={isBatchMode}
-              collapsed={collapsed}
-              siderTooltipProps={siderTooltipProps}
-              onNewChat={handleNewChat}
-              onToggleBatchMode={() => setIsBatchMode((prev) => !prev)}
-            />
-            {/* Search entry — desktop moves this into the titlebar toolbar;
-                mobile keeps it here in the sidebar. */}
-            {isMobile && (
-              <SiderSearchEntry
-                isMobile={isMobile}
-                collapsed={collapsed}
-                siderTooltipProps={siderTooltipProps}
-                onConversationSelect={handleConversationSelect}
-                onSessionClick={onSessionClick}
-              />
-            )}
-            {/* Assistant nav entry - fixed above Scheduled */}
-            <SiderAssistantEntry
-              isMobile={isMobile}
-              isActive={pathname.startsWith('/assistants')}
-              collapsed={collapsed}
-              siderTooltipProps={siderTooltipProps}
-              onClick={handleAssistantClick}
-            />
-            {/* Scheduled tasks nav entry - fixed above scroll */}
-            <SiderScheduledEntry
-              isMobile={isMobile}
-              isActive={pathname === '/scheduled'}
-              collapsed={collapsed}
-              siderTooltipProps={siderTooltipProps}
-              onClick={handleScheduledClick}
-            />
+            {primaryNavigation.map(({ id }) => {
+              if (id === 'newConversation') {
+                return (
+                  <SiderToolbar
+                    key={id}
+                    isMobile={isMobile}
+                    isBatchMode={isBatchMode}
+                    collapsed={collapsed}
+                    siderTooltipProps={siderTooltipProps}
+                    onNewChat={handleNewChat}
+                    onToggleBatchMode={() => setIsBatchMode((prev) => !prev)}
+                    showHistoryActions={conversationHistoryEnabled}
+                  />
+                );
+              }
+              if (id === 'conversationSearch') {
+                return isMobile ? (
+                  <SiderSearchEntry
+                    key={id}
+                    isMobile={isMobile}
+                    collapsed={collapsed}
+                    siderTooltipProps={siderTooltipProps}
+                    onConversationSelect={handleConversationSelect}
+                    onSessionClick={onSessionClick}
+                  />
+                ) : null;
+              }
+              if (id === 'assistants') {
+                return (
+                  <SiderAssistantEntry
+                    key={id}
+                    isMobile={isMobile}
+                    isActive={pathname.startsWith('/assistants')}
+                    collapsed={collapsed}
+                    siderTooltipProps={siderTooltipProps}
+                    onClick={handleAssistantClick}
+                  />
+                );
+              }
+              if (id === 'scheduledTasks') {
+                return (
+                  <SiderScheduledEntry
+                    key={id}
+                    isMobile={isMobile}
+                    isActive={pathname === '/scheduled'}
+                    collapsed={collapsed}
+                    siderTooltipProps={siderTooltipProps}
+                    onClick={handleScheduledClick}
+                  />
+                );
+              }
+              return null;
+            })}
             {/* Divider between fixed top nav and scrollable content area */}
             <div
               className={classNames(
@@ -229,23 +264,12 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
             />
             {/* Scrollable content: pinned → team (slot) → projects → conversations */}
             <div className={classNames('flex-1 min-h-0 overflow-y-auto', siderStyles.scrollArea)}>
-              <Suspense fallback={<div className='min-h-200px' />}>
-                <WorkspaceGroupedHistory
-                  {...workspaceHistoryProps}
-                  afterPinnedContent={
-                    <>
-                      {teamEnabled && (
-                        <TeamSiderSection
-                          collapsed={collapsed}
-                          pathname={pathname}
-                          siderTooltipProps={siderTooltipProps}
-                          onSessionClick={onSessionClick}
-                        />
-                      )}
-                    </>
-                  }
-                />
-              </Suspense>
+              {conversationHistoryEnabled && (
+                <Suspense fallback={<div className='min-h-200px' />}>
+                  <WorkspaceGroupedHistory {...workspaceHistoryProps} afterPinnedContent={teamNavigation} />
+                </Suspense>
+              )}
+              {!conversationHistoryEnabled && teamNavigation}
             </div>
           </div>
         )}

--- a/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
+++ b/packages/desktop/src/renderer/components/layout/Titlebar/index.tsx
@@ -98,6 +98,7 @@ const SidebarIcon: React.FC<{ size?: number; strokeWidth?: number }> = ({ size =
 );
 
 const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
+  const conversationEnabled = isProductFeatureEnabled('conversation');
   const teamEnabled = isProductFeatureEnabled('team');
   const { t } = useTranslation();
   const appTitle = getRendererBrand().productName;
@@ -162,7 +163,7 @@ const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
   // Conversation search moved from the sidebar into the titlebar toolbar
   // (between the sidebar toggle and the back/forward nav). Desktop only —
   // mobile keeps search inside the sidebar.
-  const showSearchButton = !layout?.isMobile;
+  const showSearchButton = conversationEnabled && !layout?.isMobile;
   const searchTooltip = t('conversation.historySearch.tooltip', { defaultValue: 'Search conversations' });
 
   const handleSiderToggle = () => {

--- a/packages/desktop/src/renderer/pages/guid/components/QuickActionButtons.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/QuickActionButtons.tsx
@@ -131,7 +131,9 @@ const QuickActionButtons: React.FC<QuickActionButtonsProps> = ({
   const { t } = useTranslation();
   const repositoryUrl = getRendererBrand().links.repository;
   const [hoveredQuickAction, setHoveredQuickAction] = useState<'bugReport' | 'repo' | 'webui' | null>(null);
-  const webUiEnabled = isProductFeatureEnabled('guidWebUi') && isProductFeatureEnabled('webUi');
+  const feedbackEnabled = isProductFeatureEnabled('guidFeedback');
+  const githubStarEnabled = isProductFeatureEnabled('guidGithubStar');
+  const webUiEnabled = isProductFeatureEnabled('guidWebUi');
 
   const quickActionStyle = useCallback(
     (isActive: boolean) => ({
@@ -143,65 +145,71 @@ const QuickActionButtons: React.FC<QuickActionButtonsProps> = ({
     [activeShadow, inactiveBorderColor]
   );
 
+  if (!feedbackEnabled && !githubStarEnabled && !webUiEnabled) return null;
+
   return (
     <div
       className={`absolute left-50% -translate-x-1/2 flex flex-col justify-center items-center ${styles.guidQuickActions}`}
     >
       <div className='flex justify-center items-center gap-24px'>
-        <div
-          className='group inline-flex items-center justify-center h-36px min-w-36px max-w-36px px-0 rd-999px bg-fill-0 cursor-pointer overflow-hidden whitespace-nowrap hover:max-w-170px hover:px-14px hover:justify-start hover:gap-8px transition-[max-width,padding,border-radius,box-shadow] duration-420 ease-in-out'
-          style={quickActionStyle(hoveredQuickAction === 'bugReport')}
-          onMouseEnter={() => setHoveredQuickAction('bugReport')}
-          onMouseLeave={() => setHoveredQuickAction(null)}
-          onClick={onOpenBugReport}
-        >
-          <svg
-            className='flex-shrink-0 text-[var(--color-text-3)] group-hover:text-[#2C7FFF] transition-colors duration-300'
-            width='20'
-            height='20'
-            viewBox='0 0 20 20'
-            fill='none'
-            xmlns='http://www.w3.org/2000/svg'
+        {feedbackEnabled && (
+          <div
+            className='group inline-flex items-center justify-center h-36px min-w-36px max-w-36px px-0 rd-999px bg-fill-0 cursor-pointer overflow-hidden whitespace-nowrap hover:max-w-170px hover:px-14px hover:justify-start hover:gap-8px transition-[max-width,padding,border-radius,box-shadow] duration-420 ease-in-out'
+            style={quickActionStyle(hoveredQuickAction === 'bugReport')}
+            onMouseEnter={() => setHoveredQuickAction('bugReport')}
+            onMouseLeave={() => setHoveredQuickAction(null)}
+            onClick={onOpenBugReport}
           >
-            <path
-              d='M6.58335 16.6674C8.17384 17.4832 10.0034 17.7042 11.7424 17.2905C13.4814 16.8768 15.0155 15.8555 16.0681 14.4108C17.1208 12.9661 17.6229 11.1929 17.4838 9.41082C17.3448 7.6287 16.5738 5.95483 15.3099 4.69085C14.0459 3.42687 12.372 2.6559 10.5899 2.51687C8.80776 2.37784 7.03458 2.8799 5.58987 3.93256C4.14516 4.98523 3.12393 6.51928 2.71021 8.25828C2.29648 9.99729 2.51747 11.8269 3.33335 13.4174L1.66669 18.334L6.58335 16.6674Z'
-              stroke='currentColor'
-              strokeWidth='1.66667'
-              strokeLinecap='round'
-              strokeLinejoin='round'
-            />
-          </svg>
-          <span className='opacity-0 max-w-0 overflow-hidden text-14px text-[var(--color-text-2)] group-hover:opacity-100 group-hover:max-w-128px transition-all duration-360 ease-in-out'>
-            {t('conversation.welcome.quickActionFeedback')}
-          </span>
-        </div>
-        <div
-          className='group inline-flex items-center justify-center h-36px min-w-36px max-w-36px px-0 rd-999px bg-fill-0 cursor-pointer overflow-hidden whitespace-nowrap hover:max-w-150px hover:px-14px hover:justify-start hover:gap-8px transition-[max-width,padding,border-radius,box-shadow] duration-420 ease-in-out'
-          style={quickActionStyle(hoveredQuickAction === 'repo')}
-          onMouseEnter={() => setHoveredQuickAction('repo')}
-          onMouseLeave={() => setHoveredQuickAction(null)}
-          onClick={() => onOpenLink(repositoryUrl)}
-        >
-          <svg
-            className='flex-shrink-0 text-[var(--color-text-3)] group-hover:text-[#FE9900] transition-colors duration-300'
-            width='20'
-            height='20'
-            viewBox='0 0 20 20'
-            fill='none'
-            xmlns='http://www.w3.org/2000/svg'
+            <svg
+              className='flex-shrink-0 text-[var(--color-text-3)] group-hover:text-[#2C7FFF] transition-colors duration-300'
+              width='20'
+              height='20'
+              viewBox='0 0 20 20'
+              fill='none'
+              xmlns='http://www.w3.org/2000/svg'
+            >
+              <path
+                d='M6.58335 16.6674C8.17384 17.4832 10.0034 17.7042 11.7424 17.2905C13.4814 16.8768 15.0155 15.8555 16.0681 14.4108C17.1208 12.9661 17.6229 11.1929 17.4838 9.41082C17.3448 7.6287 16.5738 5.95483 15.3099 4.69085C14.0459 3.42687 12.372 2.6559 10.5899 2.51687C8.80776 2.37784 7.03458 2.8799 5.58987 3.93256C4.14516 4.98523 3.12393 6.51928 2.71021 8.25828C2.29648 9.99729 2.51747 11.8269 3.33335 13.4174L1.66669 18.334L6.58335 16.6674Z'
+                stroke='currentColor'
+                strokeWidth='1.66667'
+                strokeLinecap='round'
+                strokeLinejoin='round'
+              />
+            </svg>
+            <span className='opacity-0 max-w-0 overflow-hidden text-14px text-[var(--color-text-2)] group-hover:opacity-100 group-hover:max-w-128px transition-all duration-360 ease-in-out'>
+              {t('conversation.welcome.quickActionFeedback')}
+            </span>
+          </div>
+        )}
+        {githubStarEnabled && (
+          <div
+            className='group inline-flex items-center justify-center h-36px min-w-36px max-w-36px px-0 rd-999px bg-fill-0 cursor-pointer overflow-hidden whitespace-nowrap hover:max-w-150px hover:px-14px hover:justify-start hover:gap-8px transition-[max-width,padding,border-radius,box-shadow] duration-420 ease-in-out'
+            style={quickActionStyle(hoveredQuickAction === 'repo')}
+            onMouseEnter={() => setHoveredQuickAction('repo')}
+            onMouseLeave={() => setHoveredQuickAction(null)}
+            onClick={() => onOpenLink(repositoryUrl)}
           >
-            <path
-              d='M9.60416 1.91176C9.64068 1.83798 9.6971 1.77587 9.76704 1.73245C9.83698 1.68903 9.91767 1.66602 9.99999 1.66602C10.0823 1.66602 10.163 1.68903 10.233 1.73245C10.3029 1.77587 10.3593 1.83798 10.3958 1.91176L12.3208 5.81093C12.4476 6.06757 12.6348 6.2896 12.8663 6.45797C13.0979 6.62634 13.3668 6.73602 13.65 6.77759L17.955 7.40759C18.0366 7.41941 18.1132 7.45382 18.1762 7.50693C18.2393 7.56003 18.2862 7.62972 18.3117 7.7081C18.3372 7.78648 18.3402 7.87043 18.3205 7.95046C18.3007 8.03048 18.259 8.10339 18.2 8.16093L15.0867 11.1926C14.8813 11.3927 14.7277 11.6397 14.639 11.9123C14.5503 12.1849 14.5292 12.475 14.5775 12.7576L15.3125 17.0409C15.3269 17.1225 15.3181 17.2064 15.2871 17.2832C15.2561 17.3599 15.2041 17.4264 15.1371 17.4751C15.0701 17.5237 14.9908 17.5526 14.9082 17.5583C14.8256 17.5641 14.7431 17.5465 14.67 17.5076L10.8217 15.4843C10.5681 15.3511 10.286 15.2816 9.99958 15.2816C9.71318 15.2816 9.43106 15.3511 9.17749 15.4843L5.32999 17.5076C5.25694 17.5463 5.17449 17.5637 5.09204 17.5578C5.00958 17.5519 4.93043 17.5231 4.86357 17.4744C4.79672 17.4258 4.74485 17.3594 4.71387 17.2828C4.68289 17.2061 4.67404 17.1223 4.68833 17.0409L5.42249 12.7584C5.47099 12.4757 5.44998 12.1854 5.36128 11.9126C5.27257 11.6398 5.11883 11.3927 4.91333 11.1926L1.79999 8.16176C1.74049 8.10429 1.69832 8.03126 1.6783 7.95099C1.65827 7.87072 1.66119 7.78644 1.68673 7.70775C1.71226 7.62906 1.75938 7.55913 1.82272 7.50591C1.88607 7.4527 1.96308 7.41834 2.04499 7.40676L6.34916 6.77759C6.63271 6.73634 6.90199 6.62681 7.13381 6.45842C7.36564 6.29002 7.55308 6.06782 7.67999 5.81093L9.60416 1.91176Z'
-              stroke='currentColor'
-              strokeWidth='1.66667'
-              strokeLinecap='round'
-              strokeLinejoin='round'
-            />
-          </svg>
-          <span className='opacity-0 max-w-0 overflow-hidden text-14px text-[var(--color-text-2)] group-hover:opacity-100 group-hover:max-w-120px transition-all duration-360 ease-in-out'>
-            {t('conversation.welcome.quickActionStar')}
-          </span>
-        </div>
+            <svg
+              className='flex-shrink-0 text-[var(--color-text-3)] group-hover:text-[#FE9900] transition-colors duration-300'
+              width='20'
+              height='20'
+              viewBox='0 0 20 20'
+              fill='none'
+              xmlns='http://www.w3.org/2000/svg'
+            >
+              <path
+                d='M9.60416 1.91176C9.64068 1.83798 9.6971 1.77587 9.76704 1.73245C9.83698 1.68903 9.91767 1.66602 9.99999 1.66602C10.0823 1.66602 10.163 1.68903 10.233 1.73245C10.3029 1.77587 10.3593 1.83798 10.3958 1.91176L12.3208 5.81093C12.4476 6.06757 12.6348 6.2896 12.8663 6.45797C13.0979 6.62634 13.3668 6.73602 13.65 6.77759L17.955 7.40759C18.0366 7.41941 18.1132 7.45382 18.1762 7.50693C18.2393 7.56003 18.2862 7.62972 18.3117 7.7081C18.3372 7.78648 18.3402 7.87043 18.3205 7.95046C18.3007 8.03048 18.259 8.10339 18.2 8.16093L15.0867 11.1926C14.8813 11.3927 14.7277 11.6397 14.639 11.9123C14.5503 12.1849 14.5292 12.475 14.5775 12.7576L15.3125 17.0409C15.3269 17.1225 15.3181 17.2064 15.2871 17.2832C15.2561 17.3599 15.2041 17.4264 15.1371 17.4751C15.0701 17.5237 14.9908 17.5526 14.9082 17.5583C14.8256 17.5641 14.7431 17.5465 14.67 17.5076L10.8217 15.4843C10.5681 15.3511 10.286 15.2816 9.99958 15.2816C9.71318 15.2816 9.43106 15.3511 9.17749 15.4843L5.32999 17.5076C5.25694 17.5463 5.17449 17.5637 5.09204 17.5578C5.00958 17.5519 4.93043 17.5231 4.86357 17.4744C4.79672 17.4258 4.74485 17.3594 4.71387 17.2828C4.68289 17.2061 4.67404 17.1223 4.68833 17.0409L5.42249 12.7584C5.47099 12.4757 5.44998 12.1854 5.36128 11.9126C5.27257 11.6398 5.11883 11.3927 4.91333 11.1926L1.79999 8.16176C1.74049 8.10429 1.69832 8.03126 1.6783 7.95099C1.65827 7.87072 1.66119 7.78644 1.68673 7.70775C1.71226 7.62906 1.75938 7.55913 1.82272 7.50591C1.88607 7.4527 1.96308 7.41834 2.04499 7.40676L6.34916 6.77759C6.63271 6.73634 6.90199 6.62681 7.13381 6.45842C7.36564 6.29002 7.55308 6.06782 7.67999 5.81093L9.60416 1.91176Z'
+                stroke='currentColor'
+                strokeWidth='1.66667'
+                strokeLinecap='round'
+                strokeLinejoin='round'
+              />
+            </svg>
+            <span className='opacity-0 max-w-0 overflow-hidden text-14px text-[var(--color-text-2)] group-hover:opacity-100 group-hover:max-w-120px transition-all duration-360 ease-in-out'>
+              {t('conversation.welcome.quickActionStar')}
+            </span>
+          </div>
+        )}
         {webUiEnabled && (
           <WebuiQuickAction
             onHoverChange={(hovered) => setHoveredQuickAction(hovered ? 'webui' : null)}

--- a/tests/fixtures/kiBuddyProduct.ts
+++ b/tests/fixtures/kiBuddyProduct.ts
@@ -1,0 +1,21 @@
+import {
+  KI_BUDDY_PRODUCT_CAPABILITY,
+  type ProductFeatureId,
+  type ProductFeatureState,
+} from '@/common/platform/ki-buddy';
+
+/** Activates a valid Ki-Buddy bootstrap capability with optional feature-state overrides. */
+export function activateKiBuddyProduct(
+  featureOverrides: Partial<Record<ProductFeatureId, ProductFeatureState>> = {}
+): void {
+  window.__kiBuddyProductPresentation = {
+    ...KI_BUDDY_PRODUCT_CAPABILITY,
+    experience: {
+      ...KI_BUDDY_PRODUCT_CAPABILITY.experience,
+      features: {
+        ...KI_BUDDY_PRODUCT_CAPABILITY.experience.features,
+        ...featureOverrides,
+      },
+    },
+  };
+}

--- a/tests/integration/ProductExperienceSettingsHost.dom.test.tsx
+++ b/tests/integration/ProductExperienceSettingsHost.dom.test.tsx
@@ -2,9 +2,11 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter, Outlet } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { KI_BUDDY_PRODUCT_CAPABILITY } from '@/common/platform/ki-buddy';
+import { activateKiBuddyProduct } from '../fixtures/kiBuddyProduct';
 
 const mocks = vi.hoisted(() => ({
+  assistantPageRender: vi.fn(),
+  authStatus: 'authenticated' as 'authenticated' | 'checking' | 'unauthenticated',
   configGet: vi.fn(() => []),
   extensionPageRender: vi.fn(),
   extensionThemes: vi.fn(async () => []),
@@ -12,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   extensionTranslations: vi.fn(() => ({ resolveExtTabName: (tab: { label: string }) => tab.label })),
   isMobile: false,
   petPageRender: vi.fn(),
+  showcasePageRender: vi.fn(),
   themeSettingsRender: vi.fn(),
   webuiGetStatus: vi.fn(async () => ({ running: false })),
   webuiPageRender: vi.fn(),
@@ -22,7 +25,7 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en-US' } }),
 }));
 vi.mock('@/renderer/hooks/context/AuthContext', () => ({
-  useAuth: () => ({ status: 'authenticated' }),
+  useAuth: () => ({ status: mocks.authStatus }),
 }));
 vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
   useLayoutContext: () => ({ isMobile: mocks.isMobile }),
@@ -85,7 +88,12 @@ vi.mock('@renderer/pages/settings/AgentSettings', () => ({ default: () => <div>a
 vi.mock('@renderer/pages/settings/AgentSettings/AgentRepairPage', () => ({
   default: () => <div>agent-repair-page</div>,
 }));
-vi.mock('@renderer/pages/settings/AssistantSettings', () => ({ default: () => <div>assistant-settings-page</div> }));
+vi.mock('@renderer/pages/settings/AssistantSettings', () => ({
+  default: () => {
+    mocks.assistantPageRender();
+    return <div>assistant-settings-page</div>;
+  },
+}));
 vi.mock('@renderer/pages/settings/SkillsSettings/SkillsHubSettings', () => ({
   default: () => <div>skills-settings-page</div>,
 }));
@@ -116,7 +124,12 @@ vi.mock('@renderer/pages/settings/ExtensionSettingsPage', () => ({
     return <div>extension-settings-page</div>;
   },
 }));
-vi.mock('@renderer/pages/TestShowcase', () => ({ default: () => <div>showcase-page</div> }));
+vi.mock('@renderer/pages/TestShowcase', () => ({
+  default: () => {
+    mocks.showcasePageRender();
+    return <div>showcase-page</div>;
+  },
+}));
 vi.mock('@renderer/pages/cron/ScheduledTasksPage', () => ({ default: () => <div>scheduled-page</div> }));
 vi.mock('@renderer/pages/cron/ScheduledTasksPage/TaskDetailPage', () => ({
   default: () => <div>scheduled-detail-page</div>,
@@ -169,8 +182,12 @@ function activateKiBuddy(): void {
     },
   };
   window.__kiBuddyProductBootstrapError = null;
-  window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+  activateKiBuddyProduct();
 }
+
+beforeEach(() => {
+  mocks.authStatus = 'authenticated';
+});
 
 describe('Product experience settings navigation', () => {
   beforeEach(() => {
@@ -232,8 +249,10 @@ describe('Product experience settings navigation', () => {
 
 describe('Product experience settings routes', () => {
   beforeEach(() => {
+    mocks.assistantPageRender.mockClear();
     mocks.extensionPageRender.mockClear();
     mocks.petPageRender.mockClear();
+    mocks.showcasePageRender.mockClear();
     mocks.webuiPageRender.mockClear();
     window.location.hash = '#/guid';
     window.__kiBuddyProductBootstrapError = null;
@@ -274,6 +293,98 @@ describe('Product experience settings routes', () => {
 
     expect(await screen.findByText('webui-settings-page')).toBeInTheDocument();
     expect(mocks.webuiPageRender).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['/guid', 'guid-page'],
+    ['/conversation/conversation-1', 'conversation-page'],
+    ['/assistants', 'assistant-settings-page'],
+    ['/scheduled', 'scheduled-page'],
+    ['/scheduled/job-1', 'scheduled-detail-page'],
+  ])('keeps enabled Ki-Buddy workspace route %s available on direct refresh', async (path, pageText) => {
+    activateKiBuddy();
+    window.location.hash = `#${path}`;
+
+    render(<PanelRoute layout={<TestLayout />} />);
+
+    expect(await screen.findByText(pageText)).toBeInTheDocument();
+    expect(window.location.hash).toBe(`#${path}`);
+  });
+
+  it('replaces the Assistants legacy address with the enabled workspace page', async () => {
+    activateKiBuddy();
+    window.location.hash = '#/settings/assistants';
+    const replaceState = vi.spyOn(window.history, 'replaceState');
+
+    render(<PanelRoute layout={<TestLayout />} />);
+
+    expect(await screen.findByText('assistant-settings-page')).toBeInTheDocument();
+    await waitFor(() => expect(window.location.hash).toBe('#/assistants'));
+    expect(mocks.assistantPageRender).toHaveBeenCalled();
+    expect(replaceState.mock.calls.some(([, , url]) => String(url).endsWith('#/assistants'))).toBe(true);
+    replaceState.mockRestore();
+  });
+
+  it.each([
+    ['/conversation/conversation-1', { conversation: 'disabled' as const }],
+    ['/assistants', { assistants: 'disabled' as const }],
+    ['/scheduled', { scheduledTasks: 'disabled' as const }],
+  ])('does not register disabled workspace route %s', async (path, featureOverrides) => {
+    activateKiBuddy();
+    activateKiBuddyProduct(featureOverrides);
+    window.location.hash = `#${path}`;
+
+    render(<PanelRoute layout={<TestLayout />} />);
+
+    expect(await screen.findByText('guid-page')).toBeInTheDocument();
+    await waitFor(() => expect(window.location.hash).toBe('#/guid'));
+  });
+
+  it.each([
+    ['authenticated' as const, 'guid-page', '#/guid'],
+    ['unauthenticated' as const, 'login-page', '#/login'],
+  ])('replaces the disabled Assistants legacy address for an %s user', async (authStatus, pageText, expectedHash) => {
+    activateKiBuddy();
+    activateKiBuddyProduct({ assistants: 'disabled' });
+    mocks.authStatus = authStatus;
+    window.location.hash = '#/settings/assistants';
+    const replaceState = vi.spyOn(window.history, 'replaceState');
+
+    render(<PanelRoute layout={<TestLayout />} />);
+
+    expect(await screen.findByText(pageText)).toBeInTheDocument();
+    await waitFor(() => expect(window.location.hash).toBe(expectedHash));
+    expect(mocks.assistantPageRender).not.toHaveBeenCalled();
+    expect(replaceState.mock.calls.some(([, , url]) => String(url).endsWith(expectedHash))).toBe(true);
+    replaceState.mockRestore();
+  });
+
+  it.each([
+    ['authenticated' as const, 'guid-page', '#/guid'],
+    ['unauthenticated' as const, 'login-page', '#/login'],
+  ])('replaces a disabled showcase address for an %s user', async (authStatus, pageText, expectedHash) => {
+    activateKiBuddy();
+    mocks.authStatus = authStatus;
+    window.location.hash = '#/test/components';
+    const replaceState = vi.spyOn(window.history, 'replaceState');
+
+    render(<PanelRoute layout={<TestLayout />} />);
+
+    expect(await screen.findByText(pageText)).toBeInTheDocument();
+    await waitFor(() => expect(window.location.hash).toBe(expectedHash));
+    expect(replaceState.mock.calls.some(([, , url]) => String(url).endsWith(expectedHash))).toBe(true);
+    expect(mocks.showcasePageRender).not.toHaveBeenCalled();
+    replaceState.mockRestore();
+  });
+
+  it('keeps the AionUi showcase route registered', async () => {
+    window.electronAPI = { ...window.electronAPI, kiBuddyAuth: undefined };
+    window.location.hash = '#/test/components';
+
+    render(<PanelRoute layout={<TestLayout />} />);
+
+    expect(await screen.findByText('showcase-page')).toBeInTheDocument();
+    expect(mocks.showcasePageRender).toHaveBeenCalled();
   });
 });
 
@@ -348,7 +459,7 @@ describe('Product experience Guid WebUI projection', () => {
     window.__kiBuddyProductPresentation = null;
   });
 
-  it('does not mount WebUI status behavior in Ki-Buddy', () => {
+  it('does not render Guid feedback, GitHub star, or WebUI actions in Ki-Buddy', () => {
     activateKiBuddy();
 
     render(
@@ -362,12 +473,14 @@ describe('Product experience Guid WebUI projection', () => {
       </MemoryRouter>
     );
 
+    expect(screen.queryByText('conversation.welcome.quickActionFeedback')).not.toBeInTheDocument();
+    expect(screen.queryByText('conversation.welcome.quickActionStar')).not.toBeInTheDocument();
     expect(screen.queryByText(/settings\.webui ·/)).not.toBeInTheDocument();
     expect(mocks.webuiGetStatus).not.toHaveBeenCalled();
     expect(mocks.webuiStatusChanged).not.toHaveBeenCalled();
   });
 
-  it('keeps the AionUi WebUI quick action and status behavior', async () => {
+  it('keeps all AionUi Guid quick actions and WebUI status behavior', async () => {
     render(
       <MemoryRouter>
         <QuickActionButtons
@@ -379,8 +492,81 @@ describe('Product experience Guid WebUI projection', () => {
       </MemoryRouter>
     );
 
+    expect(screen.getByText('conversation.welcome.quickActionFeedback')).toBeInTheDocument();
+    expect(screen.getByText('conversation.welcome.quickActionStar')).toBeInTheDocument();
     expect(await screen.findByText(/settings\.webui ·/)).toBeInTheDocument();
     await waitFor(() => expect(mocks.webuiGetStatus).toHaveBeenCalledOnce());
     expect(mocks.webuiStatusChanged).toHaveBeenCalledOnce();
   });
+
+  it.each([
+    {
+      disabledFeature: 'guidFeedback',
+      featureOverrides: {
+        guidFeedback: 'disabled',
+        guidGithubStar: 'enabled',
+        guidWebUi: 'enabled',
+        webUi: 'enabled',
+      },
+      feedbackVisible: false,
+      githubStarVisible: true,
+      webUiVisible: true,
+    },
+    {
+      disabledFeature: 'guidGithubStar',
+      featureOverrides: {
+        guidFeedback: 'enabled',
+        guidGithubStar: 'disabled',
+        guidWebUi: 'enabled',
+        webUi: 'enabled',
+      },
+      feedbackVisible: true,
+      githubStarVisible: false,
+      webUiVisible: true,
+    },
+    {
+      disabledFeature: 'guidWebUi',
+      featureOverrides: {
+        guidFeedback: 'enabled',
+        guidGithubStar: 'enabled',
+        guidWebUi: 'disabled',
+      },
+      feedbackVisible: true,
+      githubStarVisible: true,
+      webUiVisible: false,
+    },
+  ] as const)(
+    'projects $disabledFeature independently from the other Guid quick actions',
+    async ({ featureOverrides, feedbackVisible, githubStarVisible, webUiVisible }) => {
+      activateKiBuddy();
+      activateKiBuddyProduct(featureOverrides);
+
+      render(
+        <MemoryRouter>
+          <QuickActionButtons
+            activeShadow='none'
+            inactiveBorderColor='transparent'
+            onOpenBugReport={vi.fn()}
+            onOpenLink={vi.fn()}
+          />
+        </MemoryRouter>
+      );
+
+      const feedback = screen.queryByText('conversation.welcome.quickActionFeedback');
+      const githubStar = screen.queryByText('conversation.welcome.quickActionStar');
+      if (feedbackVisible) expect(feedback).toBeInTheDocument();
+      else expect(feedback).not.toBeInTheDocument();
+      if (githubStarVisible) expect(githubStar).toBeInTheDocument();
+      else expect(githubStar).not.toBeInTheDocument();
+
+      if (webUiVisible) {
+        expect(await screen.findByText(/settings\.webui ·/)).toBeInTheDocument();
+        await waitFor(() => expect(mocks.webuiStatusChanged).toHaveBeenCalledOnce());
+      } else {
+        expect(screen.queryByText(/settings\.webui ·/)).not.toBeInTheDocument();
+        expect(mocks.webuiGetStatus).not.toHaveBeenCalled();
+        expect(mocks.webuiStatusChanged).not.toHaveBeenCalled();
+      }
+    }
+  );
 });

--- a/tests/integration/ProductExperienceSiderHost.dom.test.tsx
+++ b/tests/integration/ProductExperienceSiderHost.dom.test.tsx
@@ -2,15 +2,17 @@ import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { KI_BUDDY_PRODUCT_CAPABILITY } from '@/common/platform/ki-buddy';
+import { activateKiBuddyProduct } from '../fixtures/kiBuddyProduct';
 
-const teamSectionRender = vi.hoisted(() => vi.fn());
+const testState = vi.hoisted(() => ({ isMobile: false, teamSectionRender: vi.fn() }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('@renderer/hooks/context/AuthContext', () => ({
   useAuth: () => ({ logout: vi.fn(), status: 'authenticated' }),
 }));
-vi.mock('@renderer/hooks/context/LayoutContext', () => ({ useLayoutContext: () => ({ isMobile: false }) }));
+vi.mock('@renderer/hooks/context/LayoutContext', () => ({
+  useLayoutContext: () => ({ isMobile: testState.isMobile }),
+}));
 vi.mock('@renderer/hooks/context/ThemeContext', () => ({
   useThemeContext: () => ({ theme: 'light', setTheme: vi.fn() }),
 }));
@@ -22,60 +24,172 @@ vi.mock('@renderer/utils/ui/siderTooltip', () => ({
   cleanupSiderTooltips: vi.fn(),
   getSiderTooltipProps: () => ({}),
 }));
-vi.mock('@renderer/components/layout/Sider/SiderNav', () => ({
-  SiderAssistantEntry: () => null,
-  SiderScheduledEntry: () => null,
-  SiderSearchEntry: () => null,
-  SiderToolbar: () => null,
-}));
+vi.mock('@renderer/components/layout/Sider/SiderNav', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/components/layout/Sider/SiderNav')>();
+  return {
+    ...actual,
+    SiderAssistantEntry: () => <div data-workspace-nav-id='assistants' />,
+    SiderScheduledEntry: () => <div data-workspace-nav-id='scheduledTasks' />,
+    SiderSearchEntry: () => <div data-workspace-nav-id='conversationSearch' />,
+    SiderToolbar: ({ showHistoryActions }: { showHistoryActions?: boolean }) => (
+      <div data-workspace-nav-id='newConversation' data-history-actions={showHistoryActions ? 'visible' : 'hidden'} />
+    ),
+  };
+});
 vi.mock('@renderer/components/layout/Sider/SiderFooter', () => ({
   default: () => null,
   shouldShowAionUiSiderLogout: () => false,
 }));
 vi.mock('@renderer/pages/conversation/GroupedHistory', () => ({
   default: ({ afterPinnedContent }: { afterPinnedContent?: React.ReactNode }) => (
-    <div data-testid='history-host'>{afterPinnedContent}</div>
+    <div data-testid='history-host' data-workspace-nav-id='conversationHistory'>
+      {afterPinnedContent}
+    </div>
   ),
 }));
 vi.mock('@renderer/pages/settings/components/SettingsSider', () => ({ default: () => null }));
 vi.mock('@renderer/components/layout/Sider/TeamSiderSection', () => ({
   default: () => {
-    teamSectionRender();
-    return <div>team-navigation</div>;
+    testState.teamSectionRender();
+    return <div data-workspace-nav-id='team'>team-navigation</div>;
   },
 }));
 
 import Sider from '@/renderer/components/layout/Sider';
 
+function workspaceNavigationIds(container: HTMLElement): Array<string | null> {
+  return Array.from(container.querySelectorAll('[data-workspace-nav-id]')).map((item) =>
+    item.getAttribute('data-workspace-nav-id')
+  );
+}
+
 describe('Product experience Sider host', () => {
   beforeEach(() => {
-    teamSectionRender.mockClear();
+    testState.isMobile = false;
+    testState.teamSectionRender.mockClear();
     window.__kiBuddyProductBootstrapError = null;
     window.__kiBuddyProductPresentation = null;
   });
 
   it('does not mount Team navigation or its subscriptions in Ki-Buddy', async () => {
-    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    activateKiBuddyProduct();
 
-    render(
+    const { container } = render(
       <MemoryRouter initialEntries={['/guid']}>
         <Sider />
       </MemoryRouter>
     );
 
     await screen.findByTestId('history-host');
+    expect(workspaceNavigationIds(container)).toEqual([
+      'newConversation',
+      'assistants',
+      'scheduledTasks',
+      'conversationHistory',
+    ]);
     expect(screen.queryByText('team-navigation')).not.toBeInTheDocument();
-    expect(teamSectionRender).not.toHaveBeenCalled();
+    expect(testState.teamSectionRender).not.toHaveBeenCalled();
   });
 
-  it('keeps Team navigation mounted for the AionUi adapter', async () => {
-    render(
+  it.each([
+    {
+      layout: 'desktop',
+      isMobile: false,
+      featureId: 'assistants',
+      expectedIds: ['newConversation', 'scheduledTasks', 'conversationHistory'],
+      expectedHistoryActions: 'visible',
+    },
+    {
+      layout: 'desktop',
+      isMobile: false,
+      featureId: 'conversation',
+      expectedIds: ['newConversation', 'assistants', 'scheduledTasks'],
+      expectedHistoryActions: 'hidden',
+    },
+    {
+      layout: 'desktop',
+      isMobile: false,
+      featureId: 'scheduledTasks',
+      expectedIds: ['newConversation', 'assistants', 'conversationHistory'],
+      expectedHistoryActions: 'visible',
+    },
+    {
+      layout: 'mobile',
+      isMobile: true,
+      featureId: 'assistants',
+      expectedIds: ['newConversation', 'conversationSearch', 'scheduledTasks', 'conversationHistory'],
+      expectedHistoryActions: 'visible',
+    },
+    {
+      layout: 'mobile',
+      isMobile: true,
+      featureId: 'conversation',
+      expectedIds: ['newConversation', 'assistants', 'scheduledTasks'],
+      expectedHistoryActions: 'hidden',
+    },
+    {
+      layout: 'mobile',
+      isMobile: true,
+      featureId: 'scheduledTasks',
+      expectedIds: ['newConversation', 'conversationSearch', 'assistants', 'conversationHistory'],
+      expectedHistoryActions: 'visible',
+    },
+  ] as const)(
+    'projects $layout workspace navigation independently when $featureId is disabled',
+    async ({ isMobile, featureId, expectedIds, expectedHistoryActions }) => {
+      testState.isMobile = isMobile;
+      activateKiBuddyProduct({ [featureId]: 'disabled' });
+
+      const { container } = render(
+        <MemoryRouter initialEntries={['/guid']}>
+          <Sider />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => expect(workspaceNavigationIds(container)).toEqual(expectedIds));
+      expect(container.querySelector('[data-workspace-nav-id="newConversation"]')).toHaveAttribute(
+        'data-history-actions',
+        expectedHistoryActions
+      );
+      expect(testState.teamSectionRender).not.toHaveBeenCalled();
+    }
+  );
+
+  it('keeps Team navigation independent from conversation history state', async () => {
+    activateKiBuddyProduct({
+      assistants: 'disabled',
+      conversation: 'disabled',
+      scheduledTasks: 'disabled',
+      team: 'enabled',
+    });
+
+    const { container } = render(
       <MemoryRouter initialEntries={['/guid']}>
         <Sider />
       </MemoryRouter>
     );
 
     expect(await screen.findByText('team-navigation')).toBeInTheDocument();
-    await waitFor(() => expect(teamSectionRender).toHaveBeenCalledOnce());
+    expect(workspaceNavigationIds(container)).toEqual(['newConversation', 'team']);
+    expect(screen.queryByTestId('history-host')).not.toBeInTheDocument();
+    expect(testState.teamSectionRender).toHaveBeenCalledOnce();
+  });
+
+  it('keeps Team navigation mounted for the AionUi adapter', async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/guid']}>
+        <Sider />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('team-navigation')).toBeInTheDocument();
+    expect(workspaceNavigationIds(container)).toEqual([
+      'newConversation',
+      'assistants',
+      'scheduledTasks',
+      'conversationHistory',
+      'team',
+    ]);
+    await waitFor(() => expect(testState.teamSectionRender).toHaveBeenCalledOnce());
   });
 });

--- a/tests/unit/common-platform/kiBuddyProductConfig.test.ts
+++ b/tests/unit/common-platform/kiBuddyProductConfig.test.ts
@@ -203,6 +203,24 @@ describe('Ki-Buddy product configuration', () => {
     });
   });
 
+  it('captures a disabled required Guid as an installation integrity error', () => {
+    const result = loadKiBuddyProductConfig({
+      ...validConfig,
+      experience: {
+        ...validConfig.experience,
+        features: {
+          ...validConfig.experience.features,
+          guid: 'disabled',
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      config: null,
+      error: 'Product feature guid must be enabled',
+    });
+  });
+
   it('rejects missing theme resources at startup', () => {
     const { themes: _themes, ...withoutThemes } = validConfig;
     expect(() => parseKiBuddyProductConfig(withoutThemes)).toThrow('missing themes');

--- a/tests/unit/common-platform/productExperience.test.ts
+++ b/tests/unit/common-platform/productExperience.test.ts
@@ -293,4 +293,16 @@ describe('ProductExperience interface', () => {
       })
     ).toThrow('extensionMarketplace');
   });
+
+  it('rejects a product policy without the required Guid landing capability', () => {
+    expect(() =>
+      parseProductExperiencePolicy({
+        ...validPolicy,
+        features: {
+          ...validPolicy.features,
+          guid: 'disabled',
+        },
+      })
+    ).toThrow('Product feature guid must be enabled');
+  });
 });

--- a/tests/unit/renderer/layout/SiderToolbar.dom.test.tsx
+++ b/tests/unit/renderer/layout/SiderToolbar.dom.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@renderer/pages/conversation/GroupedHistory/ConversationSearchPopover', () => ({
+  default: () => null,
+}));
+vi.mock('@arco-design/web-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@arco-design/web-react')>();
+  return {
+    ...actual,
+    Tooltip: ({ children, content }: { children: React.ReactNode; content: React.ReactNode }) => (
+      <div>
+        <span>{content}</span>
+        {children}
+      </div>
+    ),
+  };
+});
+vi.mock('@icon-park/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@icon-park/react')>();
+  return {
+    ...actual,
+    ListCheckbox: () => <span />,
+    Plus: () => <span />,
+  };
+});
+
+import { SiderToolbar } from '@/renderer/components/layout/Sider/SiderNav';
+
+function renderToolbar(showHistoryActions?: boolean): void {
+  render(
+    <SiderToolbar
+      isMobile={false}
+      isBatchMode={false}
+      collapsed={false}
+      siderTooltipProps={{}}
+      onNewChat={vi.fn()}
+      onToggleBatchMode={vi.fn()}
+      showHistoryActions={showHistoryActions}
+    />
+  );
+}
+
+describe('SiderToolbar history action', () => {
+  it.each([
+    ['the AionUi default', undefined, true],
+    ['enabled history', true, true],
+    ['disabled history', false, false],
+  ] as const)('%s controls the batch history action', (_case, showHistoryActions, expectedVisible) => {
+    renderToolbar(showHistoryActions);
+
+    const historyAction = screen.queryByText('conversation.history.batchManage');
+    if (expectedVisible) expect(historyAction).toBeInTheDocument();
+    else expect(historyAction).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/renderer/layout/TitlebarWorkspaceToggle.dom.test.tsx
+++ b/tests/unit/renderer/layout/TitlebarWorkspaceToggle.dom.test.tsx
@@ -1,12 +1,13 @@
 import { act, render, screen } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { KI_BUDDY_PRODUCT_CAPABILITY } from '@/common/platform/ki-buddy';
+import { activateKiBuddyProduct } from '../../../fixtures/kiBuddyProduct';
 
 const platform = vi.hoisted(() => ({ desktop: true, mac: false }));
 const route = vi.hoisted(() => ({ pathname: '/conversation/test' }));
 const layout = vi.hoisted(() => ({ mobile: false }));
 const teamGet = vi.hoisted(() => vi.fn().mockResolvedValue({ name: 'Team One' }));
+const searchRender = vi.hoisted(() => vi.fn());
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -19,7 +20,12 @@ vi.mock('@/common', () => ({
   ipcBridge: { conversation: { get: { invoke: vi.fn() } }, team: { get: { invoke: teamGet } } },
 }));
 vi.mock('@/common/config/constants', () => ({ TEAM_MODE_ENABLED: false }));
-vi.mock('@renderer/pages/conversation/GroupedHistory/ConversationSearchPopover', () => ({ default: () => null }));
+vi.mock('@renderer/pages/conversation/GroupedHistory/ConversationSearchPopover', () => ({
+  default: () => {
+    searchRender();
+    return <div data-testid='conversation-search' />;
+  },
+}));
 vi.mock('@/renderer/components/layout/Titlebar/MobileConversationBrand', () => ({ default: () => null }));
 vi.mock('@/renderer/components/layout/WindowControls', () => ({
   default: () => <div data-testid='window-controls' />,
@@ -36,6 +42,9 @@ vi.mock('@/renderer/hooks/context/FeedbackContext', () => ({
 vi.mock('@/renderer/services/feedback/resolveFeedbackModule', () => ({
   resolveFeedbackModule: () => 'conversation-session',
 }));
+vi.mock('@/renderer/services/runtime/productBrandRuntime', () => ({
+  getRendererBrand: () => ({ productName: 'AionUi' }),
+}));
 vi.mock('@/renderer/utils/platform', () => ({
   isElectronDesktop: () => platform.desktop,
   isMacOS: () => platform.mac,
@@ -50,6 +59,7 @@ describe('Titlebar workspace toggle', () => {
     platform.mac = false;
     route.pathname = '/conversation/test';
     layout.mobile = false;
+    searchRender.mockClear();
     teamGet.mockClear();
     window.__kiBuddyProductBootstrapError = null;
     window.__kiBuddyProductPresentation = null;
@@ -100,7 +110,7 @@ describe('Titlebar workspace toggle', () => {
   it('does not read Team state from a legacy Team address in Ki-Buddy', () => {
     route.pathname = '/team/legacy-team';
     layout.mobile = true;
-    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    activateKiBuddyProduct();
 
     render(<Titlebar workspaceAvailable={false} />);
 
@@ -114,5 +124,26 @@ describe('Titlebar workspace toggle', () => {
     render(<Titlebar workspaceAvailable={false} />);
 
     expect(teamGet).toHaveBeenCalledWith({ id: 'team-1' });
+  });
+
+  it('projects the desktop conversation search from ProductExperience', () => {
+    activateKiBuddyProduct({ conversation: 'disabled' });
+
+    render(<Titlebar workspaceAvailable={false} />);
+
+    expect(screen.queryByTestId('conversation-search')).not.toBeInTheDocument();
+    expect(searchRender).not.toHaveBeenCalled();
+  });
+
+  it('keeps desktop conversation search available in Ki-Buddy and AionUi', () => {
+    activateKiBuddyProduct();
+    const { unmount } = render(<Titlebar workspaceAvailable={false} />);
+
+    expect(screen.getByTestId('conversation-search')).toBeInTheDocument();
+    unmount();
+
+    window.__kiBuddyProductPresentation = null;
+    render(<Titlebar workspaceAvailable={false} />);
+    expect(screen.getByTestId('conversation-search')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

实现 Ki-Buddy 主工作区的 ProductExperience 投影，使导航、路由和页面内入口由统一产品策略控制。

主要变化：

- 使用稳定的 `ProductFeatureId` 控制 Guid、Conversation、Assistants、Scheduled Tasks、Team 和 Component Showcase 的路由与入口。
- 新增统一 workspace registry，侧栏导航顺序由 registry 决定；产品策略只决定功能状态。
- 功能停用时不注册对应路由，也不挂载关联组件、状态请求或订阅。
- 保留 `/settings/assistants` 旧地址，并根据功能状态和认证状态使用 `replace` 跳转。
- 将 Guid 规定为当前 ProductExperience schema v1 的必选认证入口；无效随包策略进入安装完整性错误。
- ProductExperience capability 缺失时保留完整 AionUi 行为。
- 增加首帧、刷新、旧地址、桌面端与移动端导航、独立 feature ID 投影测试。

## Related Issues

- Closes #49

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change that fixes an issue)
- [x] `feat` — New feature (non-breaking change that adds functionality)
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `docs` — Documentation only
- [ ] `chore` — Build process or auxiliary tool changes

## Atomic Change Checklist

- [x] This PR focuses on a single concern
- [x] No unrelated changes are included

## Local Checks

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bunx tsc --noEmit`
- [x] `bun run test`
- [x] `bun run i18n:types` and `node scripts/check-i18n.js`
- [x] New or changed user-facing text uses i18n keys（本次未新增用户可见文案）

## Runtime Verification

- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] Self-review completed

## Screenshots

不适用：本次主要调整产品策略投影、路由注册和入口挂载条件。

## Additional Context

- `just push -u origin feat/ki-buddy-main-workspace-experience` 全部通过：478 个测试文件通过、1 个跳过；4115 个测试通过、5 个跳过。
- lint 报告 868 个既有 warning、0 个 error。
- i18n 校验报告既有 locale 与 7 个 `webFsPicker` 未知 key warning，命令退出码为 0。
- Vitest 期间出现既有 `MaxListenersExceededWarning`，完整测试退出码为 0。
- 未声明完成 macOS、Windows 或 Linux 的应用运行时人工验证。
