### PR TITLE
feat(ki-buddy): disable unavailable product lifecycles

### DIFF
--- a/packages/desktop/src/common/config/configMigration.ts
+++ b/packages/desktop/src/common/config/configMigration.ts
@@ -29,7 +29,6 @@ const LEGACY_CHANNEL_KEYS = [
 const LEGACY_CHANNEL_PLATFORMS = ['telegram', 'lark', 'dingtalk', 'weixin', 'wecom'] as const;
 
 type LegacyChannelConfigKey = (typeof LEGACY_CHANNEL_KEYS)[number];
-type LegacyChannelPlatform = (typeof LEGACY_CHANNEL_PLATFORMS)[number];
 type LegacyBusinessConfigKey =
   | 'google.config'
   | 'acp.promptTimeout'
@@ -137,8 +136,6 @@ export async function migrateConfigStorage(configFile: ConfigFile): Promise<void
       );
     }
   }
-
-  await migrateLegacyChannelSettings(legacyConfigFile);
 }
 
 export async function migrateLegacyMcpConfigToDb(configFile: ConfigFile): Promise<void> {
@@ -199,7 +196,9 @@ function normalizeLegacyMcpServer(
   };
 }
 
-async function migrateLegacyChannelSettings(configFile: LegacyChannelConfigFile): Promise<void> {
+/** Migrates legacy per-platform channel settings through the dedicated channel APIs. */
+export async function migrateLegacyChannelSettings(configFile: ConfigFile): Promise<void> {
+  const legacyConfigFile = configFile as LegacyChannelConfigFile;
   const assistants: ChannelAssistantCandidate[] = await ipcBridge.assistants.list
     .invoke()
     .catch((): ChannelAssistantCandidate[] => []);
@@ -213,8 +212,8 @@ async function migrateLegacyChannelSettings(configFile: LegacyChannelConfigFile)
     const defaultModelKey = `assistant.${platform}.defaultModel` as const;
 
     const [legacyAssistant, legacyDefaultModel, currentSettings] = await Promise.all([
-      configFile.get(assistantKey).catch((): undefined => undefined),
-      configFile.get(defaultModelKey).catch((): undefined => undefined),
+      legacyConfigFile.get(assistantKey).catch((): undefined => undefined),
+      legacyConfigFile.get(defaultModelKey).catch((): undefined => undefined),
       ipcBridge.channel.getPlatformSettings.invoke({ platform }).catch((): null => null),
     ]);
 

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -67,6 +67,7 @@ import {
 import {
   createOrUpdateTray,
   configureTrayBrand,
+  configureTrayProductExperience,
   destroyTray,
   getCloseToTrayEnabled,
   getIsQuitting,
@@ -80,11 +81,14 @@ import {
   createKiBuddyProductBootstrap,
   createKiBuddyProductIntegrityWindow,
   createKiBuddyRuntime,
+  resolveMainProductExperience,
+  runProductBackendMigrations,
   readKiBuddyRuntimeIdentity,
   resolveKiBuddyCoreDataPath,
   resolveKiBuddyProtocolScheme,
   shouldEnsureDefaultCoreUser,
   shouldStartProductBusinessLifecycle,
+  startMainProductLifecyclePhase,
 } from '@process/ki-buddy';
 // @ts-expect-error - electron-squirrel-startup doesn't have types
 import electronSquirrelStartup from 'electron-squirrel-startup';
@@ -204,6 +208,7 @@ const kiBuddyRuntimeSelection = createKiBuddyRuntime({
   webUi: isWebUIMode,
 });
 const kiBuddyRuntime = kiBuddyRuntimeSelection.runtime;
+const productExperience = resolveMainProductExperience(kiBuddyRuntimeSelection, packagedKiBuddyRuntime);
 const kiBuddyProductBootstrap = createKiBuddyProductBootstrap(kiBuddyRuntimeSelection);
 const kiBuddyProductInvalid = kiBuddyRuntimeSelection.status === 'invalid';
 const productBusinessLifecycleEnabled = shouldStartProductBusinessLifecycle(kiBuddyRuntimeSelection);
@@ -212,6 +217,7 @@ configureNotificationBrandIcon(kiBuddyProductInvalid ? null : (kiBuddyRuntime?.b
 if (kiBuddyRuntime) {
   configureTrayBrand(kiBuddyRuntime.brand);
 }
+if (productExperience) configureTrayProductExperience(productExperience);
 const kiBuddyCoreAuthOptions = kiBuddyRuntime?.coreAuthOptions ?? null;
 const ensureDefaultCoreUser = shouldEnsureDefaultCoreUser(kiBuddyRuntimeSelection.status !== 'absent');
 const resolveBackendDataPath = (dataPath: string): string =>
@@ -379,8 +385,8 @@ const scheduleBackendMigrations = (): void => {
   backendMigrationsScheduled = true;
   void (async () => {
     try {
-      const { runBackendMigrations } = await import('./process/utils/runBackendMigrations');
-      await runBackendMigrations(ProcessConfig);
+      if (!productExperience) return;
+      await runProductBackendMigrations(ProcessConfig, productExperience);
       console.info('[AionUi] runBackendMigrations completed');
     } catch (error) {
       console.error('[AionUi] Backend migration hook threw:', error);
@@ -414,7 +420,11 @@ function markBackendReady(backendPort: number, source: string): void {
   if (backendStartedOk) return;
   console.log(`[AionUi] ${source} ready (port=${backendPort})`);
   exposeBackendPort(backendPort);
-  registerCronResumeBridge(backendPort);
+  if (productExperience) {
+    startMainProductLifecyclePhase(productExperience, 'backendReady', {
+      scheduledTasks: () => registerCronResumeBridge(backendPort),
+    });
+  }
   backendStartedOk = true;
   backendStartupFailed = false;
   backendStartupFailureInfo = null;
@@ -751,7 +761,8 @@ const handleAppReady = async (): Promise<void> => {
   try {
     await import('./process/bridge/feedbackBridge');
     const { initializeProcess } = await import('./process');
-    await initializeProcess();
+    if (!productExperience) throw new Error('Product experience is unavailable for the business lifecycle');
+    await initializeProcess(productExperience);
     const savedLanguage = ProcessConfig.getSync('language');
     rendererInitialLanguage = kiBuddyRuntime?.resolveLanguage(savedLanguage, app.getLocale()) ?? savedLanguage ?? null;
     mark('initializeProcess');
@@ -945,6 +956,11 @@ const handleAppReady = async (): Promise<void> => {
       app.exit(1);
     }
   } else if (isWebUIMode) {
+    if (productExperience?.featureState('webUi') !== 'enabled') {
+      console.error('[AionUi] WebUI is disabled by the selected product experience.');
+      app.exit(1);
+      return;
+    }
     const userConfigInfo = loadUserWebUIConfig();
     if (userConfigInfo.exists && userConfigInfo.path) {
       // Config file loaded from user directory
@@ -1038,24 +1054,35 @@ const handleAppReady = async (): Promise<void> => {
     mark('createWindow');
 
     // Initialize desktop pet (delayed to not block main window)
-    if (!kiBuddyProductInvalid) {
-      setTimeout(() => {
-        void (async () => {
-          try {
-            const petEnabled = await ProcessConfig.get('pet.enabled');
-            if (petEnabled === true) {
-              // Read pet sub-settings before creating the pet so flags are honored
-              // on the first createPetWindow() call (which is sync).
-              const confirmEnabled = (await ProcessConfig.get('pet.confirmEnabled')) ?? true;
-              const { createPetWindow, setPetConfirmEnabled } = await import('./process/pet/petManager');
-              setPetConfirmEnabled(confirmEnabled);
-              createPetWindow();
-            }
-          } catch (error) {
-            console.error('[Pet] Failed to initialize:', error);
-          }
-        })();
-      }, 3000);
+    if (productExperience) {
+      startMainProductLifecyclePhase(productExperience, 'desktopReady', {
+        desktopPet: () => {
+          setTimeout(() => {
+            void (async () => {
+              try {
+                const petEnabled = await ProcessConfig.get('pet.enabled');
+                if (petEnabled === true) {
+                  // Read pet sub-settings before creating the pet so flags are honored
+                  // on the first createPetWindow() call (which is sync).
+                  const confirmEnabled = (await ProcessConfig.get('pet.confirmEnabled')) ?? true;
+                  const { createPetWindow, setPetConfirmEnabled } = await import('./process/pet/petManager');
+                  setPetConfirmEnabled(confirmEnabled);
+                  createPetWindow();
+                }
+              } catch (error) {
+                console.error('[Pet] Failed to initialize:', error);
+              }
+            })();
+          }, 3000);
+        },
+        webUi: () => {
+          if (isE2ETestMode) return;
+          // 窗口创建后异步恢复 WebUI，不阻塞 UI / Restore WebUI async after window creation, non-blocking
+          restoreDesktopWebUIFromPreferences().catch((error) => {
+            console.error('[WebUI] Failed to auto-restore:', error);
+          });
+        },
+      });
     }
 
     // 读取语言设置并初始化主进程 i18n，然后刷新托盘菜单
@@ -1074,13 +1101,6 @@ const handleAppReady = async (): Promise<void> => {
     if (!kiBuddyProductInvalid) {
       onLanguageChanged(() => {
         void refreshTrayMenu();
-      });
-    }
-
-    if (!isE2ETestMode && !kiBuddyProductInvalid) {
-      // 窗口创建后异步恢复 WebUI，不阻塞 UI / Restore WebUI async after window creation, non-blocking
-      restoreDesktopWebUIFromPreferences().catch((error) => {
-        console.error('[WebUI] Failed to auto-restore:', error);
       });
     }
 
@@ -1182,12 +1202,13 @@ installQuitCleanup({
   // Stop aioncore subprocess — backend shutdown kills all agent children
   // transitively (no separate frontend workerTaskManager remains).
   stopBackend: () => (productBusinessLifecycleEnabled ? backendManager.stop() : Promise.resolve()),
-  destroyPetWindow: productBusinessLifecycleEnabled
-    ? async () => {
-        const { destroyPetWindow } = await import('./process/pet/petManager');
-        destroyPetWindow();
-      }
-    : () => Promise.resolve(),
+  destroyPetWindow:
+    productBusinessLifecycleEnabled && productExperience?.featureState('desktopPet') === 'enabled'
+      ? async () => {
+          const { destroyPetWindow } = await import('./process/pet/petManager');
+          destroyPetWindow();
+        }
+      : () => Promise.resolve(),
   logInfo: console.log,
   logWarn: console.warn,
   logError: console.error,

--- a/packages/desktop/src/process/bridge/index.ts
+++ b/packages/desktop/src/process/bridge/index.ts
@@ -7,23 +7,27 @@
 import { initApplicationBridge } from './applicationBridge';
 import { initDialogBridge } from './dialogBridge';
 import { initUpdateBridge } from './updateBridge';
-import { initSystemSettingsBridge } from './systemSettingsBridge';
+import { initPetSettingsBridge, initSystemSettingsBridge } from './systemSettingsBridge';
 import { initWindowControlsBridge } from './windowControlsBridge';
 import { initNotificationBridge } from './notificationBridge';
 import { initWebuiBridge } from './webuiBridge';
 import { initThemeBridge } from './themeBridge';
+import type { ProductExperience } from '@/common/platform/ki-buddy';
 
-export type BridgeDependencies = Record<string, never>;
+export type BridgeDependencies = Readonly<{
+  productExperience: ProductExperience;
+}>;
 
-export function initAllBridges(_deps: BridgeDependencies = {}): void {
+export function initAllBridges({ productExperience }: BridgeDependencies): void {
   initDialogBridge();
   initApplicationBridge();
   initWindowControlsBridge();
   initUpdateBridge();
   initSystemSettingsBridge();
   initNotificationBridge();
-  initWebuiBridge();
   initThemeBridge();
+  if (productExperience.featureState('desktopPet') === 'enabled') initPetSettingsBridge();
+  if (productExperience.featureState('webUi') === 'enabled') initWebuiBridge();
 }
 
 export {
@@ -31,6 +35,7 @@ export {
   initDialogBridge,
   initNotificationBridge,
   initSystemSettingsBridge,
+  initPetSettingsBridge,
   initThemeBridge,
   initUpdateBridge,
   initWindowControlsBridge,

--- a/packages/desktop/src/process/bridge/systemSettingsBridge.ts
+++ b/packages/desktop/src/process/bridge/systemSettingsBridge.ts
@@ -56,8 +56,10 @@ export function initSystemSettingsBridge(): void {
       console.error('[SystemSettings] Main process changeLanguage failed:', error);
     });
   });
+}
 
-  // Desktop pet settings
+/** Registers Desktop Pet settings only when the product exposes that lifecycle. */
+export function initPetSettingsBridge(): void {
   ipcBridge.systemSettings.getPetEnabled.provider(async () => {
     const value = await ProcessConfig.get('pet.enabled');
     return value ?? false;

--- a/packages/desktop/src/process/index.ts
+++ b/packages/desktop/src/process/index.ts
@@ -17,13 +17,15 @@ if (app.isPackaged) {
   process.env.PREBUILDS_ONLY = '1';
 }
 import initStorage from './utils/initStorage';
-import './utils/initBridge';
+import initBridge from './utils/initBridge';
 import './services/i18n'; // Initialize i18n for main process
+import type { ProductExperience } from '@/common/platform/ki-buddy';
 
-export const initializeProcess = async () => {
+export const initializeProcess = async (productExperience: ProductExperience) => {
   const t0 = performance.now();
   const mark = (label: string) => console.log(`[AionUi:process] ${label} +${Math.round(performance.now() - t0)}ms`);
 
+  initBridge({ productExperience });
   await initStorage();
   mark('initStorage');
 };

--- a/packages/desktop/src/process/ki-buddy/index.ts
+++ b/packages/desktop/src/process/ki-buddy/index.ts
@@ -8,6 +8,7 @@ import type { SupportedLanguage } from '@/common/config/i18n';
 import {
   KI_BUDDY_CORE_TRANSPORT_CHANNEL,
   KI_BUDDY_PRODUCT_CONFIG_RESULT,
+  createAionUiProductExperience,
   createKiBuddyProductCapability,
   createKiBuddyProductExperience,
   deepFreeze,
@@ -27,6 +28,7 @@ import { createKiBuddyUpdateBridgeConfiguration, createKiBuddyUpdateFeedConfigur
 import type { UpdateBridgeConfiguration } from '@process/bridge/updateBridge';
 import type { UpdateFeedConfiguration } from '@process/services/updateFeed';
 import { BrowserWindow } from 'electron';
+import type { runBackendMigrations } from '@process/utils/runBackendMigrations';
 
 export type KiBuddyRuntime = {
   brand: {
@@ -41,7 +43,6 @@ export type KiBuddyRuntime = {
   registerAuthBridge: (getCoreBaseUrl: () => string) => AgentsAuthService;
   resolveDataPath: (dataPath: string) => string;
   resolveLanguage: (savedLanguage: string | null | undefined, systemLanguage: string | null) => SupportedLanguage;
-  startFeatureLifecycles: (lifecycles: readonly ProductFeatureLifecycle[]) => void;
   updateBridge: UpdateBridgeConfiguration;
   updateFeed: UpdateFeedConfiguration;
 };
@@ -135,6 +136,69 @@ export function startProductFeatureLifecycles(
   }
 }
 
+type BackendReadyLifecycleStarters = Readonly<{
+  scheduledTasks: () => void;
+}>;
+
+type DesktopReadyLifecycleStarters = Readonly<{
+  desktopPet: () => void;
+  webUi: () => void;
+}>;
+
+export function startMainProductLifecyclePhase(
+  productExperience: ProductExperience,
+  phase: 'backendReady',
+  starters: BackendReadyLifecycleStarters
+): void;
+export function startMainProductLifecyclePhase(
+  productExperience: ProductExperience,
+  phase: 'desktopReady',
+  starters: DesktopReadyLifecycleStarters
+): void;
+/** Runs the production main-process lifecycle plan for one startup phase. */
+export function startMainProductLifecyclePhase(
+  productExperience: ProductExperience,
+  phase: 'backendReady' | 'desktopReady',
+  starters: BackendReadyLifecycleStarters | DesktopReadyLifecycleStarters
+): void {
+  if (phase === 'backendReady') {
+    const { scheduledTasks } = starters as BackendReadyLifecycleStarters;
+    startProductFeatureLifecycles(productExperience, [{ featureId: 'scheduledTasks', start: scheduledTasks }]);
+    return;
+  }
+  const { desktopPet, webUi } = starters as DesktopReadyLifecycleStarters;
+  startProductFeatureLifecycles(productExperience, [
+    { featureId: 'desktopPet', start: desktopPet },
+    { featureId: 'webUi', start: webUi },
+  ]);
+}
+
+/** Resolves the main-process adapter without activating product runtime side effects. */
+export function resolveMainProductExperience(
+  selection: KiBuddyRuntimeSelection,
+  productIdentity: boolean,
+  productConfigResult: KiBuddyProductConfigLoadResult = KI_BUDDY_PRODUCT_CONFIG_RESULT
+): ProductExperience | null {
+  if (selection.runtime) return selection.runtime.productExperience;
+  if (selection.status === 'invalid') return null;
+  if (productIdentity && productConfigResult.config) {
+    return createKiBuddyProductExperience(productConfigResult.config.experience);
+  }
+  return createAionUiProductExperience();
+}
+
+/** Runs generic migrations, then product-owned migrations whose lifecycle is enabled. */
+export async function runProductBackendMigrations(
+  configFile: Parameters<typeof runBackendMigrations>[0],
+  productExperience: ProductExperience
+): Promise<void> {
+  const { runBackendMigrations } = await import('@process/utils/runBackendMigrations');
+  await runBackendMigrations(configFile);
+  if (productExperience.featureState('channels') !== 'enabled') return;
+  const { migrateLegacyChannelSettings } = await import('@/common/config/configMigration');
+  await migrateLegacyChannelSettings(configFile);
+}
+
 /** Creates and installs the main-process Ki-Buddy runtime when explicit product metadata selects it. */
 export function createKiBuddyRuntime(
   options: {
@@ -191,7 +255,6 @@ export function createKiBuddyRuntime(
         productLanguage: config.defaults.language,
         systemLanguage,
       }),
-    startFeatureLifecycles: (lifecycles) => startProductFeatureLifecycles(productExperience, lifecycles),
     updateBridge: createKiBuddyUpdateBridgeConfiguration(config),
     updateFeed: createKiBuddyUpdateFeedConfiguration(config),
   };

--- a/packages/desktop/src/process/ki-buddy/runtimeIdentity.ts
+++ b/packages/desktop/src/process/ki-buddy/runtimeIdentity.ts
@@ -11,8 +11,14 @@ import {
   resolveKiBuddyRuntimeIdentity,
   type KiBuddyProductConfigLoadResult,
 } from '@/common/platform/ki-buddy';
+import { configureCliSafeDirectoryNames, type CliSafeDirectoryNames } from '@process/utils';
 
 export { KI_BUDDY_PRODUCT_RUNTIME, resolveKiBuddyRuntimeIdentity } from '@/common/platform/ki-buddy';
+
+const KI_BUDDY_CLI_SAFE_DIRECTORIES: CliSafeDirectoryNames = Object.freeze({
+  config: '.ki-buddy-config',
+  data: '.ki-buddy',
+});
 
 /** Reads the effective packaged metadata and fails closed when it is unavailable or invalid. */
 export function readKiBuddyRuntimeIdentity(appPath: string): boolean {
@@ -21,6 +27,11 @@ export function readKiBuddyRuntimeIdentity(appPath: string): boolean {
   } catch {
     return false;
   }
+}
+
+/** Selects Ki-Buddy's home-directory aliases before storage modules resolve their default paths. */
+export function configureKiBuddyCliSafeDirectories(appPath: string): void {
+  configureCliSafeDirectoryNames(readKiBuddyRuntimeIdentity(appPath) ? KI_BUDDY_CLI_SAFE_DIRECTORIES : null);
 }
 
 /** Resolves the packaged product protocol without enabling any product runtime side effects. */

--- a/packages/desktop/src/process/utils/configureChromium.ts
+++ b/packages/desktop/src/process/utils/configureChromium.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import os from 'os';
 import { getDevAppName } from '@/common/platform';
+import { configureKiBuddyCliSafeDirectories } from '@process/ki-buddy/runtimeIdentity';
 import { applyGpuRecoveryFlags } from './gpuRecovery';
 
 // ============ E2E test isolation ============
@@ -39,6 +40,8 @@ if (!app.isPackaged && !e2eUserDataDir) {
   const appSupportDir = path.dirname(app.getPath('userData'));
   app.setPath('userData', path.join(appSupportDir, devAppName));
 }
+
+configureKiBuddyCliSafeDirectories(app.getAppPath());
 
 // app.disableHardwareAcceleration() must run before app is ready.
 applyGpuRecoveryFlags();

--- a/packages/desktop/src/process/utils/index.ts
+++ b/packages/desktop/src/process/utils/index.ts
@@ -8,6 +8,7 @@ export {
   getTempPath,
   getDataPath,
   getConfigPath,
+  configureCliSafeDirectoryNames,
   generateHashWithFullName,
   readDirectoryRecursive,
   copyDirectoryRecursively,
@@ -16,3 +17,4 @@ export {
   ensureDirectory,
   resolveCliSafePath,
 } from './utils';
+export type { CliSafeDirectoryNames } from './utils';

--- a/packages/desktop/src/process/utils/initBridge.ts
+++ b/packages/desktop/src/process/utils/initBridge.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { initAllBridges } from '../bridge';
+import { initAllBridges, type BridgeDependencies } from '../bridge';
 
-initAllBridges();
+/** Registers main-process IPC providers for the selected product experience. */
+export default function initBridge(dependencies: BridgeDependencies): void {
+  initAllBridges(dependencies);
+}

--- a/packages/desktop/src/process/utils/tray.ts
+++ b/packages/desktop/src/process/utils/tray.ts
@@ -14,6 +14,7 @@ import {
 import * as path from 'path';
 import { ipcBridge } from '@/common';
 import i18n from '@process/services/i18n';
+import type { ProductExperience } from '@/common/platform/ki-buddy';
 
 let tray: TrayInstance | null = null;
 let closeToTrayEnabled = false;
@@ -21,6 +22,7 @@ let isQuitting = false;
 let mainWindowRef: BrowserWindow | null = null;
 let cachedActiveCount = 0;
 let trayBrand = { iconPath: 'app.png', productName: 'AionUi' };
+let desktopPetTrayEnabled = true;
 
 /** Replaces the upstream product name in tray locale text with the selected product name. */
 export function formatTrayBrandText(text: string, productName: string): string {
@@ -30,6 +32,11 @@ export function formatTrayBrandText(text: string, productName: string): string {
 /** Configures the generic tray surface from the selected product runtime. */
 export function configureTrayBrand(brand: { iconPath: string; productName: string }): void {
   trayBrand = brand;
+}
+
+/** Projects Desktop Pet tray availability from the selected product adapter. */
+export function configureTrayProductExperience(productExperience: ProductExperience): void {
+  desktopPetTrayEnabled = productExperience.featureState('desktopPet') === 'enabled';
 }
 
 export const setTrayMainWindow = (win: BrowserWindow): void => {
@@ -105,7 +112,8 @@ const getTrayIcon = (): Electron.NativeImage => {
 /**
  * Build tray context menu (async to support dynamic content).
  */
-const buildTrayContextMenu = async (): Promise<Electron.Menu> => {
+/** Builds the current tray menu after product lifecycle projection. */
+export const buildTrayContextMenu = async (): Promise<Electron.Menu> => {
   const getRecentConversations = async (): Promise<Array<{ id: string; title: string }>> => {
     try {
       const result = await ipcBridge.database.getUserConversations.invoke({ limit: 5 });
@@ -175,58 +183,60 @@ const buildTrayContextMenu = async (): Promise<Electron.Menu> => {
     },
   });
 
-  template.push({ type: 'separator' });
-  template.push({
-    label: `🐾 ${i18n.t('pet.desktopPet')}`,
-    submenu: [
-      {
-        label: i18n.t('pet.showHide'),
-        click: async () => {
-          try {
-            const petManager = await import('../pet/petManager');
-            // Toggle: if pet windows exist, hide; otherwise show/create
-            petManager.showPetWindow();
-          } catch {
-            /* pet not available */
-          }
+  if (desktopPetTrayEnabled) {
+    template.push({ type: 'separator' });
+    template.push({
+      label: `🐾 ${i18n.t('pet.desktopPet')}`,
+      submenu: [
+        {
+          label: i18n.t('pet.showHide'),
+          click: async () => {
+            try {
+              const petManager = await import('../pet/petManager');
+              // Toggle: if pet windows exist, hide; otherwise show/create
+              petManager.showPetWindow();
+            } catch {
+              /* pet not available */
+            }
+          },
         },
-      },
-      { type: 'separator' as const },
-      {
-        label: i18n.t('pet.sizeSmall', { px: 200 }),
-        click: async () => {
-          try {
-            const { resizePetWindow } = await import('../pet/petManager');
-            resizePetWindow(200);
-          } catch {
-            /* ignore */
-          }
+        { type: 'separator' as const },
+        {
+          label: i18n.t('pet.sizeSmall', { px: 200 }),
+          click: async () => {
+            try {
+              const { resizePetWindow } = await import('../pet/petManager');
+              resizePetWindow(200);
+            } catch {
+              /* ignore */
+            }
+          },
         },
-      },
-      {
-        label: i18n.t('pet.sizeMedium', { px: 280 }),
-        click: async () => {
-          try {
-            const { resizePetWindow } = await import('../pet/petManager');
-            resizePetWindow(280);
-          } catch {
-            /* ignore */
-          }
+        {
+          label: i18n.t('pet.sizeMedium', { px: 280 }),
+          click: async () => {
+            try {
+              const { resizePetWindow } = await import('../pet/petManager');
+              resizePetWindow(280);
+            } catch {
+              /* ignore */
+            }
+          },
         },
-      },
-      {
-        label: i18n.t('pet.sizeLarge', { px: 360 }),
-        click: async () => {
-          try {
-            const { resizePetWindow } = await import('../pet/petManager');
-            resizePetWindow(360);
-          } catch {
-            /* ignore */
-          }
+        {
+          label: i18n.t('pet.sizeLarge', { px: 360 }),
+          click: async () => {
+            try {
+              const { resizePetWindow } = await import('../pet/petManager');
+              resizePetWindow(360);
+            } catch {
+              /* ignore */
+            }
+          },
         },
-      },
-    ],
-  });
+      ],
+    });
+  }
   template.push({ type: 'separator' });
   template.push({
     label: i18n.t('common.tray.checkUpdate'),

--- a/packages/desktop/src/process/utils/utils.ts
+++ b/packages/desktop/src/process/utils/utils.ts
@@ -11,6 +11,23 @@ import { existsSync, lstatSync, mkdirSync, readlinkSync, realpathSync, symlinkSy
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+
+export type CliSafeDirectoryNames = Readonly<{
+  config: string;
+  data: string;
+}>;
+
+const AIONUI_CLI_SAFE_DIRECTORY_NAMES: CliSafeDirectoryNames = Object.freeze({
+  config: '.aionui-config',
+  data: '.aionui',
+});
+let cliSafeDirectoryNames = AIONUI_CLI_SAFE_DIRECTORY_NAMES;
+
+/** Configures product-owned home-directory aliases while preserving AionUi defaults when omitted. */
+export function configureCliSafeDirectoryNames(names: CliSafeDirectoryNames | null): void {
+  cliSafeDirectoryNames = names ? Object.freeze({ ...names }) : AIONUI_CLI_SAFE_DIRECTORY_NAMES;
+}
+
 export const hasElectronAppPath = (): boolean => {
   return typeof process.versions.electron === 'string';
 };
@@ -98,7 +115,7 @@ const ensureCliSafeSymlink = (targetPath: string, symlinkName: string): string =
 export const getDataPath = (): string => {
   const rootPath = getElectronPathOrFallback('userData');
   const dataPath = path.join(rootPath, 'aionui');
-  return ensureCliSafeSymlink(dataPath, getEnvAwareName('.aionui'));
+  return ensureCliSafeSymlink(dataPath, getEnvAwareName(cliSafeDirectoryNames.data));
 };
 
 /**
@@ -110,7 +127,7 @@ export const getDataPath = (): string => {
 export const getConfigPath = (): string => {
   const rootPath = getElectronPathOrFallback('userData');
   const configPath = path.join(rootPath, 'config');
-  return ensureCliSafeSymlink(configPath, getEnvAwareName('.aionui-config'));
+  return ensureCliSafeSymlink(configPath, getEnvAwareName(cliSafeDirectoryNames.config));
 };
 
 /**

--- a/packages/desktop/src/renderer/hooks/agent/usePresetAssistantInfo.ts
+++ b/packages/desktop/src/renderer/hooks/agent/usePresetAssistantInfo.ts
@@ -10,8 +10,12 @@ import type { TChatConversation } from '@/common/config/storage';
 import { ipcBridge } from '@/common';
 import { assistantRuntimeKey, type Assistant } from '@/common/types/agent/assistantTypes';
 import { resolveLocaleKey } from '@/common/utils';
-import { adaptProductConversationAssistantIdentity } from '@/renderer/services/runtime/productBrandRuntime';
-import type { AgentLogoMap } from '@/renderer/utils/model/agentLogo';
+import {
+  adaptProductConversationAssistantIdentity,
+  resolveProductConversationRuntimeAccess,
+  type ConversationRuntimeAccess,
+} from '@/renderer/services/runtime/productBrandRuntime';
+import { isProductFeatureEnabled } from '@/renderer/services/runtime/kiBuddyRuntime';
 import { resolveAgentLogo, useAgentLogos } from '@/renderer/utils/model/agentLogo';
 import { isLikelyLocalFilePath, resolveAssistantAvatar } from '@/renderer/utils/model/assistantAvatar';
 import useSWR from 'swr';
@@ -23,6 +27,12 @@ export interface PresetAssistantInfo {
   backend?: string;
   assistantId?: string;
 }
+
+type PresetAssistantState = {
+  info: PresetAssistantInfo | null;
+  isLoading: boolean;
+  runtimeAccess: ConversationRuntimeAccess;
+};
 
 /**
  * 从 conversation extra 中解析预设助手 ID
@@ -91,14 +101,55 @@ function findAssistantByIdentityCandidates(
   return undefined;
 }
 
-function hasExplicitAssistantIdentity(conversation: TChatConversation): boolean {
-  const extra = conversation.extra as {
-    assistant_id?: unknown;
-    preset_assistant_id?: unknown;
+type AssistantCatalogResolution = Readonly<{
+  displayAssistant: Assistant | undefined;
+  explicitCandidates: string[];
+  legacyCandidates: string[];
+  requiresClassification: boolean;
+  runtimeAssistant: Assistant | undefined;
+}>;
+
+function resolveAssistantCatalog(
+  conversation: TChatConversation | undefined,
+  assistants: Assistant[] | null | undefined
+): AssistantCatalogResolution {
+  if (!conversation) {
+    return {
+      displayAssistant: undefined,
+      explicitCandidates: [],
+      legacyCandidates: [],
+      requiresClassification: false,
+      runtimeAssistant: undefined,
+    };
+  }
+
+  const explicitCandidates = collectExplicitAssistantIdentityCandidates(conversation);
+  const legacyCandidates = collectLegacyAssistantIdentityCandidates(conversation);
+  const snapshotCandidates = conversation.assistant
+    ? [conversation.assistant.id, ...explicitCandidates, ...legacyCandidates].filter(
+        (value, index, values) => Boolean(value) && values.indexOf(value) === index
+      )
+    : [];
+  const displayCandidates = snapshotCandidates.length
+    ? snapshotCandidates
+    : explicitCandidates.length
+      ? explicitCandidates
+      : legacyCandidates;
+  const runtimeCandidates = [...snapshotCandidates, ...explicitCandidates, ...legacyCandidates].filter(
+    (value, index, values) => Boolean(value) && values.indexOf(value) === index
+  );
+
+  return {
+    displayAssistant: findAssistantByIdentityCandidates(assistants, displayCandidates),
+    explicitCandidates,
+    legacyCandidates,
+    requiresClassification: Boolean(
+      conversation.assistant ||
+      explicitCandidates.length ||
+      (legacyCandidates.length && extractLegacyPresetPayload(conversation).hasPayload)
+    ),
+    runtimeAssistant: findAssistantByIdentityCandidates(assistants, runtimeCandidates),
   };
-  const assistant_id = typeof extra?.assistant_id === 'string' ? extra.assistant_id.trim() : '';
-  const preset_assistant_id = typeof extra?.preset_assistant_id === 'string' ? extra.preset_assistant_id.trim() : '';
-  return Boolean(assistant_id || preset_assistant_id);
 }
 
 function resolveLegacyRuntimeRowId(conversation: TChatConversation): string | null {
@@ -275,21 +326,20 @@ function inferLegacyAssistantInfo(
  * @param conversation - 会话对象 / Conversation object
  * @returns 预设助手信息或 null / Preset assistant info or null
  */
-export function usePresetAssistantInfo(conversation: TChatConversation | undefined): {
-  info: PresetAssistantInfo | null;
-  isLoading: boolean;
-} {
+export function usePresetAssistantInfo(conversation: TChatConversation | undefined): PresetAssistantState {
   const { i18n } = useTranslation();
   const logos = useAgentLogos();
 
   // Merged assistant catalog (builtin + user) from backend
-  const { data: assistantsList, isLoading: isLoadingAssistants } = useSWR('assistants.list', () =>
+  const { data: assistantCatalog, isLoading: isLoadingAssistants } = useSWR('assistants.list', () =>
     ipcBridge.assistants.list.invoke().catch(() => [] as Assistant[])
   );
 
   // Extension-contributed ACP adapters (for ext:{extensionName}:{adapterId} conversations)
-  const { data: extensionAcpAdapters, isLoading: isLoadingExtAdapters } = useSWR('extensions.acpAdapters', () =>
-    ipcBridge.extensions.getAcpAdapters.invoke().catch(() => [] as Record<string, unknown>[])
+  const extensionRuntimeEnabled = isProductFeatureEnabled('extensionRuntime');
+  const { data: extensionAcpAdapters, isLoading: isLoadingExtAdapters } = useSWR(
+    extensionRuntimeEnabled ? 'extensions.acpAdapters' : null,
+    () => ipcBridge.extensions.getAcpAdapters.invoke().catch(() => [] as Record<string, unknown>[])
   );
 
   // Remote agent for remote conversations
@@ -300,7 +350,24 @@ export function usePresetAssistantInfo(conversation: TChatConversation | undefin
     () => (remoteAgentId ? ipcBridge.remoteAgent.get.invoke({ id: remoteAgentId }) : null)
   );
 
-  return useMemo(() => {
+  const assistantResolution = useMemo(
+    () => resolveAssistantCatalog(conversation, assistantCatalog),
+    [assistantCatalog, conversation]
+  );
+
+  const runtimeAccess = resolveProductConversationRuntimeAccess({
+    conversation,
+    assistantCatalog: {
+      matchedAssistant: assistantResolution.runtimeAssistant,
+      requiresClassification: assistantResolution.requiresClassification,
+      status: isLoadingAssistants ? 'loading' : 'ready',
+    },
+  });
+
+  const assistantState = useMemo<Omit<PresetAssistantState, 'runtimeAccess'>>(() => {
+    if (runtimeAccess !== 'allowed') {
+      return { info: null, isLoading: runtimeAccess === 'pending' };
+    }
     if (!conversation) return { info: null, isLoading: false };
 
     const locale = i18n.language || 'en-US';
@@ -309,14 +376,8 @@ export function usePresetAssistantInfo(conversation: TChatConversation | undefin
       const snapshotAvatar =
         typeof conversation.assistant.avatar === 'string' ? conversation.assistant.avatar.trim() : '';
       if (snapshotAvatar && isLikelyLocalFilePath(snapshotAvatar)) {
-        const snapshotCandidates = [
-          conversation.assistant.id,
-          ...collectExplicitAssistantIdentityCandidates(conversation),
-          ...collectLegacyAssistantIdentityCandidates(conversation),
-        ].filter((value, index, values) => Boolean(value) && values.indexOf(value) === index);
-        const catalogAssistant = findAssistantByIdentityCandidates(assistantsList, snapshotCandidates);
-        if (catalogAssistant) {
-          return { info: buildPresetInfoFromAssistant(catalogAssistant, locale), isLoading: false };
+        if (assistantResolution.displayAssistant) {
+          return { info: buildPresetInfoFromAssistant(assistantResolution.displayAssistant, locale), isLoading: false };
         }
         if (isLoadingAssistants) return { info: null, isLoading: true };
       }
@@ -345,12 +406,10 @@ export function usePresetAssistantInfo(conversation: TChatConversation | undefin
       return { info: null, isLoading: false };
     }
 
-    const explicitAssistantCandidates = collectExplicitAssistantIdentityCandidates(conversation);
-    const legacyAssistantCandidates = collectLegacyAssistantIdentityCandidates(conversation);
-    const hasExplicitAssistantId = hasExplicitAssistantIdentity(conversation);
-    const assistantMatch = hasExplicitAssistantId
-      ? findAssistantByIdentityCandidates(assistantsList, explicitAssistantCandidates)
-      : findAssistantByIdentityCandidates(assistantsList, legacyAssistantCandidates);
+    const explicitAssistantCandidates = assistantResolution.explicitCandidates;
+    const legacyAssistantCandidates = assistantResolution.legacyCandidates;
+    const hasExplicitAssistantId = explicitAssistantCandidates.length > 0;
+    const assistantMatch = assistantResolution.displayAssistant;
     const runtimeRowAgentId = resolveLegacyRuntimeRowId(conversation);
     const adapterIdentity = (hasExplicitAssistantId ? explicitAssistantCandidates : legacyAssistantCandidates).find(
       (candidate) => candidate.startsWith('ext:')
@@ -378,7 +437,7 @@ export function usePresetAssistantInfo(conversation: TChatConversation | undefin
       return { info: buildPresetInfoFromAssistant(assistantMatch, locale), isLoading: false };
     }
 
-    const inferredInfo = inferLegacyAssistantInfo(conversation, locale, assistantsList);
+    const inferredInfo = inferLegacyAssistantInfo(conversation, locale, assistantCatalog);
     if (inferredInfo) return { info: inferredInfo, isLoading: false };
 
     const { hasPayload } = extractLegacyPresetPayload(conversation);
@@ -435,12 +494,17 @@ export function usePresetAssistantInfo(conversation: TChatConversation | undefin
     conversation,
     i18n.language,
     logos,
-    assistantsList,
+    assistantCatalog,
+    assistantResolution,
+    extensionRuntimeEnabled,
     isLoadingAssistants,
     extensionAcpAdapters,
     isLoadingExtAdapters,
     remoteAgentId,
     remoteAgent,
     isLoadingRemoteAgent,
+    runtimeAccess,
   ]);
+
+  return useMemo(() => ({ ...assistantState, runtimeAccess }), [assistantState, runtimeAccess]);
 }

--- a/packages/desktop/src/renderer/hooks/mcp/useMcpServers.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/useMcpServers.ts
@@ -23,6 +23,7 @@ export const useMcpServers = () => {
   const [isMcpServersLoading, setIsMcpServersLoading] = useState(true);
 
   useEffect(() => {
+    const productExperience = getProductExperience();
     void ensureBackendMcpCatalog()
       .then(({ entries = [], hiddenResources = [] }) => {
         setMcpCatalogEntries(entries);
@@ -36,6 +37,8 @@ export const useMcpServers = () => {
       .finally(() => {
         setIsMcpServersLoading(false);
       });
+
+    if (productExperience.featureState('extensionRuntime') !== 'enabled') return;
 
     void ipcBridge.extensions.getMcpServers
       .invoke()
@@ -58,7 +61,7 @@ export const useMcpServers = () => {
         }));
         const projection = projectMcpCatalogCandidates(
           converted.map((server) => ({ server, origin: 'extension' as const })),
-          getProductExperience()
+          productExperience
         );
         reportHiddenProductResources('mcp', projection.hiddenResources);
         setExtensionMcpCatalogEntries(projection.entries);

--- a/packages/desktop/src/renderer/hooks/system/useExtI18n.ts
+++ b/packages/desktop/src/renderer/hooks/system/useExtI18n.ts
@@ -7,6 +7,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { extensions as extensionsIpc, type IExtensionSettingsTab } from '@/common/adapter/ipcBridge';
+import { isExtensionSettingsContributionEnabled } from '@/renderer/services/runtime/kiBuddyRuntime';
 
 type NestedRecord = Record<string, unknown>;
 
@@ -41,18 +42,22 @@ export function useExtI18n(): {
 } {
   const { i18n } = useTranslation();
   const [extI18nData, setExtI18nData] = useState<Record<string, unknown>>({});
+  const extensionSettingsEnabled = isExtensionSettingsContributionEnabled();
 
   useEffect(() => {
+    if (!extensionSettingsEnabled) return;
     const locale = i18n.language;
     void extensionsIpc.getExtI18nForLocale
       .invoke({ locale })
       .then((data) => setExtI18nData(data ?? {}))
       .catch((err) => console.error('[useExtI18n] Failed to load ext i18n:', err));
-  }, [i18n.language]);
+  }, [extensionSettingsEnabled, i18n.language]);
 
   const resolveExtTabName = useCallback(
     (tab: IExtensionSettingsTab): string => {
-      const nsData = extI18nData[tab.extensionName] as NestedRecord | undefined;
+      const nsData = extensionSettingsEnabled
+        ? (extI18nData[tab.extensionName] as NestedRecord | undefined)
+        : undefined;
       const localTabId = getLocalSettingsTabId(tab);
       if (nsData) {
         const translated =
@@ -61,7 +66,7 @@ export function useExtI18n(): {
       }
       return tab.label;
     },
-    [extI18nData]
+    [extI18nData, extensionSettingsEnabled]
   );
 
   return { resolveExtTabName };

--- a/packages/desktop/src/renderer/hooks/system/useExtensionSettingsTabs.ts
+++ b/packages/desktop/src/renderer/hooks/system/useExtensionSettingsTabs.ts
@@ -6,6 +6,7 @@
 
 import { useEffect, useState } from 'react';
 import { extensions as extensionsIpc, type IExtensionSettingsTab } from '@/common/adapter/ipcBridge';
+import { isExtensionSettingsContributionEnabled } from '@/renderer/services/runtime/kiBuddyRuntime';
 
 // Module-scope cache: settings tabs rarely change during a session, and multiple
 // components (SettingsSider, SettingsPageWrapper, ExtensionSettingsPage, SettingsModal)
@@ -57,9 +58,11 @@ function ensureStateListener(): void {
  * extensions.state-changed events.
  */
 export function useExtensionSettingsTabs(): IExtensionSettingsTab[] {
-  const [tabs, setTabs] = useState<IExtensionSettingsTab[]>(() => cachedTabs ?? []);
+  const extensionSettingsEnabled = isExtensionSettingsContributionEnabled();
+  const [tabs, setTabs] = useState<IExtensionSettingsTab[]>(() => (extensionSettingsEnabled ? (cachedTabs ?? []) : []));
 
   useEffect(() => {
+    if (!extensionSettingsEnabled) return;
     subscribers.add(setTabs);
     ensureStateListener();
 
@@ -73,7 +76,7 @@ export function useExtensionSettingsTabs(): IExtensionSettingsTab[] {
     return () => {
       subscribers.delete(setTabs);
     };
-  }, []);
+  }, [extensionSettingsEnabled]);
 
-  return tabs;
+  return extensionSettingsEnabled ? tabs : [];
 }

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -56,6 +56,7 @@ import {
   getKiBuddyProductBootstrapError,
   getKiBuddyProductRuntime,
   getKiBuddyRendererRuntime,
+  isProductFeatureEnabled,
 } from './services/runtime/kiBuddyRuntime';
 import { initializeRendererBrand, installProductAssistantCatalogAdapter } from './services/runtime/productBrandRuntime';
 import { FeedbackProvider } from './hooks/context/FeedbackContext';
@@ -339,7 +340,7 @@ const Main = () => {
   }, [ready]);
 
   useEffect(() => {
-    if (!ready) return;
+    if (!ready || !isProductFeatureEnabled('scheduledTasks')) return;
     void repairAllCronJobTimeZonesOnce();
   }, [ready]);
 

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -265,13 +265,18 @@ const ChatConversation: React.FC<{
   const isMobile = Boolean(layout?.isMobile);
 
   const isAionrsConversation = conversation?.type === 'aionrs';
-  const isLegacyReadOnlyConversation = isLegacyReadOnlyConversationType(conversation?.type);
-  const resolvedHideSendBox = hideSendBox || isLegacyReadOnlyConversationType(conversation?.type);
-
   // 使用统一的 Hook 获取预设助手信息（ACP/Codex 会话）
   // Use unified hook for preset assistant info (ACP/Codex conversations)
   const acpConversation = isAionrsConversation ? undefined : conversation;
-  const { info: presetAssistantInfo, isLoading: isLoadingPreset } = usePresetAssistantInfo(acpConversation);
+  const {
+    info: presetAssistantInfo,
+    isLoading: isLoadingPreset,
+    runtimeAccess,
+  } = usePresetAssistantInfo(acpConversation);
+  const isConversationRuntimePending = runtimeAccess === 'pending';
+  const isLegacyReadOnlyConversation =
+    isLegacyReadOnlyConversationType(conversation?.type) || runtimeAccess === 'blocked';
+  const resolvedHideSendBox = hideSendBox || isLegacyReadOnlyConversation;
   const acpAssistantId = presetAssistantInfo?.assistantId;
   const resolvedConversationBackend = resolveConversationBackend(conversation, presetAssistantInfo?.backend);
 
@@ -283,6 +288,7 @@ const ChatConversation: React.FC<{
     if (isLegacyReadOnlyConversation) {
       return <LegacyReadOnlyConversation key={conversation.id} conversation={conversation} />;
     }
+    if (isConversationRuntimePending) return null;
     switch (conversation.type) {
       case 'acp':
       // Antigravity reports its own conversation type but renders through the
@@ -318,6 +324,7 @@ const ChatConversation: React.FC<{
     conversation,
     isAionrsConversation,
     isLegacyReadOnlyConversation,
+    isConversationRuntimePending,
     resolvedConversationBackend,
     assistantDisplayName,
     cronJobId,
@@ -341,6 +348,7 @@ const ChatConversation: React.FC<{
     if (!conversation || isAionrsConversation) return undefined;
     if (isMobile) return undefined;
     if (isLegacyReadOnlyConversation) return undefined;
+    if (isConversationRuntimePending) return undefined;
     // Antigravity included: the backend discovers agy's model list and writes it
     // into the same catalog the ACP picker reads, so it must not fall through to
     // the disabled selector below.
@@ -356,7 +364,14 @@ const ChatConversation: React.FC<{
       );
     }
     return <GoogleModelSelector disabled={true} />;
-  }, [conversation, isAionrsConversation, isMobile, isLegacyReadOnlyConversation, resolvedConversationBackend]);
+  }, [
+    conversation,
+    isAionrsConversation,
+    isMobile,
+    isLegacyReadOnlyConversation,
+    isConversationRuntimePending,
+    resolvedConversationBackend,
+  ]);
 
   if (conversation && conversation.type === 'aionrs') {
     return <AionrsConversationPanel key={conversation.id} conversation={conversation} sliderTitle={sliderTitle} />;

--- a/packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyAssistantCatalog.ts
+++ b/packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyAssistantCatalog.ts
@@ -11,15 +11,10 @@ import {
 import { ipcBridge } from '@/common';
 import type { Assistant } from '@/common/types/agent/assistantTypes';
 import { getProductExperience } from '../kiBuddyRuntime';
-import { KI_BUDDY_ASSISTANT_IDENTITIES } from './kiBuddyAssistantIdentity';
+import { KI_BUDDY_ASSISTANT_IDENTITIES, resolveKiBuddyAssistantOrigin } from './kiBuddyAssistantIdentity';
 
 export { KI_BUDDY_PRODUCT_ASSISTANT_IDS } from './kiBuddyAssistantIdentity';
 
-const PRODUCT_OFFICIAL_ASSISTANT_IDS = new Set<string>(
-  Object.values(KI_BUDDY_ASSISTANT_IDENTITIES)
-    .filter(({ assistantSource }) => assistantSource === 'builtin')
-    .map(({ assistantId }) => assistantId)
-);
 const KI_CLI_ASSISTANT_IDENTITY = KI_BUDDY_ASSISTANT_IDENTITIES.kiCli;
 
 const PRODUCT_BUILTIN_ASSISTANT_REQUIREMENTS: readonly ProductBuiltinResourceRequirement[] = Object.values(
@@ -57,12 +52,8 @@ const isKiCliAssistant = (assistant: Assistant): boolean =>
 
 const resolveProductAssistantOrigin = (assistant: Assistant): ProductResourceOrigin => {
   if (assistant.agent?.source === 'extension') return 'extension';
-  if (assistant.source === 'user') return 'custom';
-  if (assistant.source === 'builtin') {
-    return PRODUCT_OFFICIAL_ASSISTANT_IDS.has(assistant.id) ? 'productBuiltin' : 'upstreamBuiltin';
-  }
-  if (isKiCliAssistant(assistant)) return 'productBuiltin';
-  return 'unclassified';
+  if (assistant.source === 'generated') return isKiCliAssistant(assistant) ? 'productBuiltin' : 'unclassified';
+  return resolveKiBuddyAssistantOrigin(assistant);
 };
 
 /** Applies product access from stable Assistant identity and structured source fields. */

--- a/packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyAssistantIdentity.ts
+++ b/packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyAssistantIdentity.ts
@@ -1,3 +1,23 @@
+import type { TChatConversation, TConversationAssistantIdentity } from '@/common/config/storage';
+import type { ProductExperience, ProductResourceOrigin } from '@/common/platform/ki-buddy';
+import type { Assistant } from '@/common/types/agent/assistantTypes';
+
+type AssistantOriginIdentity = Readonly<{
+  id: string;
+  source: string;
+}>;
+
+export type ConversationRuntimeAccess = 'allowed' | 'blocked' | 'pending';
+
+export type KiBuddyConversationRuntimeAccessInput = Readonly<{
+  assistantCatalog: Readonly<{
+    matchedAssistant: Assistant | undefined;
+    requiresClassification: boolean;
+    status: 'loading' | 'ready';
+  }>;
+  conversation: TChatConversation | undefined;
+}>;
+
 export const KI_CLI_PRODUCT_RESOURCE_ID = '632f31d2';
 
 export const KI_BUDDY_ASSISTANT_IDENTITIES = {
@@ -29,3 +49,74 @@ export const KI_BUDDY_ASSISTANT_IDENTITIES = {
 export const KI_BUDDY_PRODUCT_ASSISTANT_IDS = Object.values(KI_BUDDY_ASSISTANT_IDENTITIES).map(
   ({ assistantId }) => assistantId
 );
+
+/** Identifies the product-owned internal CLI across current and historical snapshot IDs. */
+export function isKiCliConversationAssistant(assistant: TConversationAssistantIdentity): boolean {
+  return (
+    assistant.backend === 'aionrs' &&
+    assistant.source === 'generated' &&
+    (assistant.id === KI_BUDDY_ASSISTANT_IDENTITIES.kiCli.assistantId ||
+      assistant.id === 'bare-aionrs' ||
+      assistant.id === 'aionrs')
+  );
+}
+
+/** Resolves an Assistant's stable identity to the shared product resource origin. */
+export function resolveKiBuddyAssistantOrigin(assistant: AssistantOriginIdentity): ProductResourceOrigin {
+  if (assistant.source === 'extension') return 'extension';
+  if (assistant.source === 'user') return 'custom';
+  if (
+    Object.values(KI_BUDDY_ASSISTANT_IDENTITIES).some(
+      (identity) => assistant.id === identity.assistantId && assistant.source === identity.assistantSource
+    )
+  ) {
+    return 'productBuiltin';
+  }
+  if (assistant.source === 'builtin') return 'upstreamBuiltin';
+  return 'unclassified';
+}
+
+/** Resolves a persisted conversation Assistant snapshot, including historical Ki CLI identities. */
+export function resolveKiBuddyConversationAssistantOrigin(
+  assistant: TConversationAssistantIdentity
+): ProductResourceOrigin {
+  return isKiCliConversationAssistant(assistant) ? 'productBuiltin' : resolveKiBuddyAssistantOrigin(assistant);
+}
+
+function readConversationString(extra: TChatConversation['extra'], key: string): string {
+  const value = (extra as Record<string, unknown> | undefined)?.[key];
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function hasExtensionRuntimeIdentity(conversation: TChatConversation): boolean {
+  const identities = [
+    conversation.assistant?.id,
+    conversation.assistant?.backend,
+    readConversationString(conversation.extra, 'assistant_id'),
+    readConversationString(conversation.extra, 'preset_assistant_id'),
+    readConversationString(conversation.extra, 'custom_agent_id'),
+    readConversationString(conversation.extra, 'backend'),
+  ];
+  return conversation.assistant?.source === 'extension' || identities.some((identity) => identity?.startsWith('ext:'));
+}
+
+/** Resolves whether a persisted conversation may mount its runtime under the Ki-Buddy product policy. */
+export function resolveKiBuddyConversationRuntimeAccess(
+  input: KiBuddyConversationRuntimeAccessInput,
+  experience: ProductExperience
+): ConversationRuntimeAccess {
+  const { conversation, assistantCatalog } = input;
+  if (!conversation || experience.featureState('extensionRuntime') === 'enabled') return 'allowed';
+  if (hasExtensionRuntimeIdentity(conversation)) return 'blocked';
+
+  if (
+    assistantCatalog.matchedAssistant?.agent?.source === 'extension' ||
+    (assistantCatalog.matchedAssistant &&
+      resolveKiBuddyAssistantOrigin(assistantCatalog.matchedAssistant) === 'extension')
+  ) {
+    return 'blocked';
+  }
+
+  if (!assistantCatalog.requiresClassification) return 'allowed';
+  return assistantCatalog.status === 'loading' ? 'pending' : 'allowed';
+}

--- a/packages/desktop/src/renderer/services/runtime/kiBuddyPresentationAdapter.ts
+++ b/packages/desktop/src/renderer/services/runtime/kiBuddyPresentationAdapter.ts
@@ -2,7 +2,7 @@ import type { TConversationAssistantIdentity } from '@/common/config/storage';
 import type { AssistantDetail } from '@/common/types/agent/assistantTypes';
 import type { KiBuddyProductRuntime } from './kiBuddyRuntime';
 import type { AgentIdentity, AssistantIdentity, ProductPresentationAdapter } from './productPresentationContract';
-import { KI_BUDDY_ASSISTANT_IDENTITIES } from './catalogs/kiBuddyAssistantIdentity';
+import { isKiCliConversationAssistant } from './catalogs/kiBuddyAssistantIdentity';
 
 const documentThemeObservers = new WeakMap<Document, MutationObserver>();
 
@@ -72,13 +72,7 @@ export function createKiBuddyPresentationAdapter(runtime: KiBuddyProductRuntime)
       };
     },
     adaptConversationAssistantIdentity<T extends TConversationAssistantIdentity>(assistant: T): T {
-      const isBuiltinCli =
-        assistant.backend === 'aionrs' &&
-        assistant.source === 'generated' &&
-        (assistant.id === KI_BUDDY_ASSISTANT_IDENTITIES.kiCli.assistantId ||
-          assistant.id === 'bare-aionrs' ||
-          assistant.id === 'aionrs');
-      if (!isBuiltinCli) return assistant;
+      if (!isKiCliConversationAssistant(assistant)) return assistant;
       return {
         ...assistant,
         name: brand.cliName,

--- a/packages/desktop/src/renderer/services/runtime/kiBuddyRuntime.ts
+++ b/packages/desktop/src/renderer/services/runtime/kiBuddyRuntime.ts
@@ -103,6 +103,11 @@ export function isProductFeatureEnabled(featureId: ProductFeatureId): boolean {
   return getProductExperience().featureState(featureId) === 'enabled';
 }
 
+/** Keeps Extension settings data and subscriptions on the same product capability decision. */
+export function isExtensionSettingsContributionEnabled(): boolean {
+  return isProductFeatureEnabled('extensionRuntime') && isProductFeatureEnabled('extensionSettings');
+}
+
 /** Resolves the authenticated Ki-Buddy runtime only when both capabilities are present. */
 export function getKiBuddyRendererRuntime(): KiBuddyRendererRuntime | null {
   const productRuntime = getKiBuddyProductRuntime();

--- a/packages/desktop/src/renderer/services/runtime/productBrandRuntime.ts
+++ b/packages/desktop/src/renderer/services/runtime/productBrandRuntime.ts
@@ -4,6 +4,11 @@ import type { TConversationAssistantIdentity } from '@/common/config/storage';
 import type { Assistant, AssistantAgent, AssistantDetail } from '@/common/types/agent/assistantTypes';
 import { loadProductAgentCatalog, type ProductManagedAgent } from './kiBuddyAgentCatalog';
 import { projectProductAssistantCatalog } from './catalogs/kiBuddyAssistantCatalog';
+import {
+  resolveKiBuddyConversationRuntimeAccess,
+  type ConversationRuntimeAccess,
+  type KiBuddyConversationRuntimeAccessInput,
+} from './catalogs/kiBuddyAssistantIdentity';
 import { reportHiddenProductResources } from './catalogs/kiBuddyProductResourceDiagnostics';
 import { getKiBuddyProductRuntime } from './kiBuddyRuntime';
 import { createKiBuddyPresentationAdapter } from './kiBuddyPresentationAdapter';
@@ -13,6 +18,8 @@ import type {
   ProductPresentationAdapter,
   RendererBrand,
 } from './productPresentationContract';
+
+export type { ConversationRuntimeAccess } from './catalogs/kiBuddyAssistantIdentity';
 
 declare const __APP_VERSION__: string;
 declare const __KI_BUDDY_VERSION__: string;
@@ -96,6 +103,14 @@ export function adaptProductAssistantDetailIdentity<T extends AssistantDetail>(d
 /** Applies product identity to the built-in CLI snapshot stored on existing conversations. */
 export function adaptProductConversationAssistantIdentity<T extends TConversationAssistantIdentity>(assistant: T): T {
   return getProductPresentationAdapter().adaptConversationAssistantIdentity(assistant);
+}
+
+/** Resolves persisted-conversation runtime access without exposing product policy to upstream callers. */
+export function resolveProductConversationRuntimeAccess(
+  input: KiBuddyConversationRuntimeAccessInput
+): ConversationRuntimeAccess {
+  const runtime = getKiBuddyProductRuntime();
+  return runtime ? resolveKiBuddyConversationRuntimeAccess(input, runtime.productExperience) : 'allowed';
 }
 
 /** Installs product identity once at the shared assistant catalog boundary. */

--- a/tests/integration/ProductExperienceLifecycleHost.dom.test.tsx
+++ b/tests/integration/ProductExperienceLifecycleHost.dom.test.tsx
@@ -1,0 +1,179 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const bridgeStarts = vi.hoisted(() => ({
+  application: vi.fn(),
+  dialog: vi.fn(),
+  notification: vi.fn(),
+  petSettings: vi.fn(),
+  systemSettings: vi.fn(),
+  theme: vi.fn(),
+  update: vi.fn(),
+  webUi: vi.fn(),
+  windowControls: vi.fn(),
+}));
+const trayMenu = vi.hoisted(() => ({
+  buildFromTemplate: vi.fn((template: Electron.MenuItemConstructorOptions[]) => template),
+  getConversations: vi.fn().mockResolvedValue({ items: [] }),
+}));
+const extensionRenderer = vi.hoisted(() => ({
+  featureState: vi.fn(() => 'enabled'),
+  getSettingsTabs: vi.fn(),
+  getTranslations: vi.fn(),
+  subscribeState: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    database: { getUserConversations: { invoke: trayMenu.getConversations } },
+  },
+}));
+vi.mock('@/common/electronSafe', () => ({
+  electronApp: { exit: vi.fn(), isPackaged: false, relaunch: vi.fn() },
+  electronMenu: { buildFromTemplate: trayMenu.buildFromTemplate },
+  electronNativeImage: { createFromPath: vi.fn() },
+  electronTray: vi.fn(),
+}));
+vi.mock('@/common/adapter/ipcBridge', () => ({
+  extensions: {
+    getExtI18nForLocale: { invoke: extensionRenderer.getTranslations },
+    getSettingsTabs: { invoke: extensionRenderer.getSettingsTabs },
+    stateChanged: { on: extensionRenderer.subscribeState },
+  },
+}));
+vi.mock('@/process/services/i18n', () => ({
+  default: { t: (key: string) => key },
+}));
+vi.mock('@/renderer/services/runtime/kiBuddyRuntime', () => ({
+  isExtensionSettingsContributionEnabled: () =>
+    extensionRenderer.featureState('extensionRuntime') === 'enabled' &&
+    extensionRenderer.featureState('extensionSettings') === 'enabled',
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ i18n: { language: 'en-US' } }),
+}));
+
+vi.mock('@/process/bridge/applicationBridge', () => ({ initApplicationBridge: bridgeStarts.application }));
+vi.mock('@/process/bridge/dialogBridge', () => ({ initDialogBridge: bridgeStarts.dialog }));
+vi.mock('@/process/bridge/notificationBridge', () => ({ initNotificationBridge: bridgeStarts.notification }));
+vi.mock('@/process/bridge/systemSettingsBridge', () => ({
+  initPetSettingsBridge: bridgeStarts.petSettings,
+  initSystemSettingsBridge: bridgeStarts.systemSettings,
+}));
+vi.mock('@/process/bridge/themeBridge', () => ({ initThemeBridge: bridgeStarts.theme }));
+vi.mock('@/process/bridge/updateBridge', () => ({ initUpdateBridge: bridgeStarts.update }));
+vi.mock('@/process/bridge/webuiBridge', () => ({ initWebuiBridge: bridgeStarts.webUi }));
+vi.mock('@/process/bridge/windowControlsBridge', () => ({
+  initWindowControlsBridge: bridgeStarts.windowControls,
+  registerWindowMaximizeListeners: vi.fn(),
+}));
+
+const { initAllBridges } = await import('@/process/bridge');
+const { startMainProductLifecyclePhase } = await import('@/process/ki-buddy');
+const { buildTrayContextMenu, configureTrayProductExperience } = await import('@/process/utils/tray');
+const { useExtI18n } = await import('@/renderer/hooks/system/useExtI18n');
+const { useExtensionSettingsTabs } = await import('@/renderer/hooks/system/useExtensionSettingsTabs');
+const { KI_BUDDY_PRODUCT_CONFIG_RESULT, createAionUiProductExperience, createKiBuddyProductExperience } =
+  await import('@/common/platform/ki-buddy');
+
+const kiBuddyExperience = createKiBuddyProductExperience(KI_BUDDY_PRODUCT_CONFIG_RESULT.config?.experience);
+
+describe('ProductExperience lifecycle host across main and renderer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    extensionRenderer.featureState.mockReturnValue('enabled');
+    extensionRenderer.getSettingsTabs.mockResolvedValue([]);
+    extensionRenderer.getTranslations.mockResolvedValue({});
+  });
+
+  it('does not fetch or subscribe to Extension settings contributions when their runtime is disabled', () => {
+    extensionRenderer.featureState.mockImplementation((featureId: string) => kiBuddyExperience.featureState(featureId));
+
+    const settingsTabs = renderHook(() => useExtensionSettingsTabs());
+    const translations = renderHook(() => useExtI18n());
+    const tab = {
+      extensionName: 'legacy-extension',
+      id: 'legacy',
+      label: 'Legacy extension',
+      order: 0,
+      url: '/legacy-extension',
+    };
+
+    expect(settingsTabs.result.current).toEqual([]);
+    expect(translations.result.current.resolveExtTabName(tab)).toBe(tab.label);
+    expect(extensionRenderer.getSettingsTabs).not.toHaveBeenCalled();
+    expect(extensionRenderer.getTranslations).not.toHaveBeenCalled();
+    expect(extensionRenderer.subscribeState).not.toHaveBeenCalled();
+  });
+
+  it('preserves Extension settings contributions for the complete AionUi adapter', async () => {
+    extensionRenderer.getSettingsTabs.mockResolvedValue([
+      {
+        extensionName: 'sample-extension',
+        id: 'sample',
+        label: 'Sample extension',
+        order: 0,
+        url: '/sample-extension',
+      },
+    ]);
+
+    const settingsTabs = renderHook(() => useExtensionSettingsTabs());
+    renderHook(() => useExtI18n());
+
+    await waitFor(() => expect(settingsTabs.result.current).toHaveLength(1));
+    expect(extensionRenderer.getSettingsTabs).toHaveBeenCalledOnce();
+    expect(extensionRenderer.getTranslations).toHaveBeenCalledWith({ locale: 'en-US' });
+    expect(extensionRenderer.subscribeState).toHaveBeenCalledOnce();
+  });
+
+  it('keeps disabled Ki-Buddy lifecycles free of startup side effects', async () => {
+    initAllBridges({ productExperience: kiBuddyExperience });
+    configureTrayProductExperience(kiBuddyExperience);
+    const starts = {
+      petAutostart: vi.fn(),
+      scheduledTasks: vi.fn(),
+      webUiAutostart: vi.fn(),
+    };
+
+    startMainProductLifecyclePhase(kiBuddyExperience, 'backendReady', {
+      scheduledTasks: starts.scheduledTasks,
+    });
+    startMainProductLifecyclePhase(kiBuddyExperience, 'desktopReady', {
+      desktopPet: starts.petAutostart,
+      webUi: starts.webUiAutostart,
+    });
+
+    expect(bridgeStarts.petSettings).not.toHaveBeenCalled();
+    expect(bridgeStarts.webUi).not.toHaveBeenCalled();
+    expect(starts.petAutostart).not.toHaveBeenCalled();
+    expect(starts.webUiAutostart).not.toHaveBeenCalled();
+    expect(starts.scheduledTasks).toHaveBeenCalledOnce();
+    expect(await buildTrayContextMenu()).not.toContainEqual(expect.objectContaining({ label: '🐾 pet.desktopPet' }));
+  });
+
+  it('preserves every existing lifecycle through the AionUi adapter', async () => {
+    const experience = createAionUiProductExperience();
+    configureTrayProductExperience(experience);
+    const starts = {
+      pet: vi.fn(),
+      scheduledTasks: vi.fn(),
+      webUi: vi.fn(),
+    };
+
+    initAllBridges({ productExperience: experience });
+    startMainProductLifecyclePhase(experience, 'backendReady', {
+      scheduledTasks: starts.scheduledTasks,
+    });
+    startMainProductLifecyclePhase(experience, 'desktopReady', {
+      desktopPet: starts.pet,
+      webUi: starts.webUi,
+    });
+
+    expect(bridgeStarts.petSettings).toHaveBeenCalledOnce();
+    expect(bridgeStarts.webUi).toHaveBeenCalledOnce();
+    expect(starts.pet).toHaveBeenCalledOnce();
+    expect(starts.scheduledTasks).toHaveBeenCalledOnce();
+    expect(starts.webUi).toHaveBeenCalledOnce();
+    expect(await buildTrayContextMenu()).toContainEqual(expect.objectContaining({ label: '🐾 pet.desktopPet' }));
+  });
+});

--- a/tests/unit/common-config/configMigration.test.ts
+++ b/tests/unit/common-config/configMigration.test.ts
@@ -37,7 +37,12 @@ vi.mock('@/common', () => ({
 }));
 
 // Import after mocks are registered
-import { migrateConfigStorage, migrateProviders, type ConfigFile } from '@/common/config/configMigration';
+import {
+  migrateConfigStorage,
+  migrateLegacyChannelSettings,
+  migrateProviders,
+  type ConfigFile,
+} from '@/common/config/configMigration';
 import { httpRequest } from '@/common/adapter/httpBridge';
 import { ipcBridge } from '@/common';
 
@@ -226,7 +231,7 @@ describe('configMigration', () => {
       ]);
       vi.spyOn(console, 'info').mockImplementation(() => {});
 
-      await migrateConfigStorage(configFile);
+      await migrateLegacyChannelSettings(configFile);
 
       expect(httpRequest).not.toHaveBeenCalledWith('PUT', '/api/settings/client', {
         'assistant.telegram.agent': expect.anything(),
@@ -275,7 +280,7 @@ describe('configMigration', () => {
       });
       vi.spyOn(console, 'info').mockImplementation(() => {});
 
-      await migrateConfigStorage(configFile);
+      await migrateLegacyChannelSettings(configFile);
 
       expect(ipcBridge.channel.setAssistantSetting.invoke).not.toHaveBeenCalled();
       expect(ipcBridge.channel.setDefaultModelSetting.invoke).not.toHaveBeenCalled();

--- a/tests/unit/process/ki-buddy/runtimeFacade.test.ts
+++ b/tests/unit/process/ki-buddy/runtimeFacade.test.ts
@@ -10,6 +10,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const installTransportMock = vi.fn();
+const productMigrationMocks = vi.hoisted(() => ({
+  channel: vi.fn(),
+  generic: vi.fn(),
+}));
 
 vi.mock('@/common/adapter/httpBridge', () => ({
   setHttpRequestTransport: installTransportMock,
@@ -20,16 +24,29 @@ vi.mock('electron', () => ({
   ipcMain: { handle: vi.fn() },
   session: { defaultSession: { cookies: { remove: vi.fn(), set: vi.fn() } } },
 }));
+vi.mock('@/common/config/configMigration', () => ({
+  migrateLegacyChannelSettings: productMigrationMocks.channel,
+}));
+vi.mock('@/process/utils/runBackendMigrations', () => ({
+  runBackendMigrations: productMigrationMocks.generic,
+}));
 
 const {
   createKiBuddyProductBootstrap,
   createKiBuddyProductIntegrityWindow,
   createKiBuddyRuntime,
+  resolveMainProductExperience,
+  runProductBackendMigrations,
   shouldStartProductBusinessLifecycle,
   startProductFeatureLifecycles,
 } = await import('@/process/ki-buddy');
+const { configureKiBuddyCliSafeDirectories } = await import('@/process/ki-buddy/runtimeIdentity');
 const { BrowserWindow } = await import('electron');
-const { KI_BUDDY_PRODUCT_CONFIG_RESULT, createAionUiProductExperience } = await import('@/common/platform/ki-buddy');
+const { KI_BUDDY_PRODUCT_CONFIG_RESULT, createAionUiProductExperience, createKiBuddyProductExperience } =
+  await import('@/common/platform/ki-buddy');
+const { NodePlatformServices } = await import('@/common/platform/NodePlatformServices');
+const { registerPlatformServices } = await import('@/common/platform');
+const { getConfigPath, getDataPath } = await import('@process/utils');
 const { KiBuddyGitHubProvider } = await import('@/process/ki-buddy/update/githubUpdateProvider');
 
 function createAppPath(productRuntime?: string): string {
@@ -45,6 +62,19 @@ describe('Ki-Buddy main-process runtime facade', () => {
     installTransportMock.mockReset();
     vi.mocked(BrowserWindow).mockReset();
     for (const appPath of appPaths.splice(0)) rmSync(appPath, { recursive: true, force: true });
+  });
+
+  it('runs Channels migration only for product adapters that enable its lifecycle', async () => {
+    const configFile = {} as never;
+    const kiBuddyExperience = createKiBuddyProductExperience(KI_BUDDY_PRODUCT_CONFIG_RESULT.config?.experience);
+
+    await runProductBackendMigrations(configFile, kiBuddyExperience);
+    expect(productMigrationMocks.generic).toHaveBeenCalledOnce();
+    expect(productMigrationMocks.channel).not.toHaveBeenCalled();
+
+    await runProductBackendMigrations(configFile, createAionUiProductExperience());
+    expect(productMigrationMocks.generic).toHaveBeenCalledTimes(2);
+    expect(productMigrationMocks.channel).toHaveBeenCalledOnce();
   });
 
   it('does not initialize product transport when the runtime capability is absent', () => {
@@ -108,6 +138,31 @@ describe('Ki-Buddy main-process runtime facade', () => {
     expect(installTransportMock).toHaveBeenCalledOnce();
   });
 
+  it('uses the Ki-Buddy data alias while preserving AionUi defaults', () => {
+    const homePath = mkdtempSync(join(tmpdir(), 'ki-buddy-home-'));
+    const dataPath = join(homePath, 'Application Support', 'Ki-Buddy');
+    const kiBuddyAppPath = createAppPath('ki-buddy');
+    const aionUiAppPath = createAppPath();
+    appPaths.push(homePath, kiBuddyAppPath, aionUiAppPath);
+    const platformServices = new NodePlatformServices();
+    platformServices.paths = {
+      ...platformServices.paths,
+      getDataDir: () => dataPath,
+      getHomeDir: () => homePath,
+      isPackaged: () => true,
+      needsCliSafeSymlinks: () => true,
+    };
+    registerPlatformServices(platformServices);
+
+    configureKiBuddyCliSafeDirectories(kiBuddyAppPath);
+    expect(getDataPath()).toBe(join(homePath, '.ki-buddy'));
+    expect(getConfigPath()).toBe(join(homePath, '.ki-buddy-config'));
+
+    configureKiBuddyCliSafeDirectories(aionUiAppPath);
+    expect(getDataPath()).toBe(join(homePath, '.aionui'));
+    expect(getConfigPath()).toBe(join(homePath, '.aionui-config'));
+  });
+
   it('keeps a recognized Ki-Buddy runtime invalid without starting product side effects', () => {
     const appPath = createAppPath('ki-buddy');
     appPaths.push(appPath);
@@ -131,6 +186,7 @@ describe('Ki-Buddy main-process runtime facade', () => {
       error: expect.stringContaining('missing team'),
     });
     expect(shouldStartProductBusinessLifecycle(selection)).toBe(false);
+    expect(resolveMainProductExperience(selection, true, { config: null, error: 'missing team' })).toBeNull();
     expect(installTransportMock).not.toHaveBeenCalled();
   });
 
@@ -149,6 +205,19 @@ describe('Ki-Buddy main-process runtime facade', () => {
     expect(selection.status).toBe('invalid');
     expect(createKiBuddyProductBootstrap(selection).status).toBe('invalid');
     expect(shouldStartProductBusinessLifecycle(selection)).toBe(false);
+  });
+
+  it('keeps the Ki-Buddy lifecycle policy in WebUI mode without starting product transport', () => {
+    const appPath = createAppPath('ki-buddy');
+    appPaths.push(appPath);
+
+    const selection = createKiBuddyRuntime({ appPath, resetPassword: false, webUi: true });
+    const experience = resolveMainProductExperience(selection, true);
+
+    expect(selection.status).toBe('absent');
+    expect(experience.featureState('webUi')).toBe('disabled');
+    expect(experience.featureState('scheduledTasks')).toBe('enabled');
+    expect(installTransportMock).not.toHaveBeenCalled();
   });
 
   it('starts the business lifecycle for valid Ki-Buddy and ordinary AionUi selections', () => {
@@ -193,22 +262,6 @@ describe('Ki-Buddy main-process runtime facade', () => {
     expect(integrityWindow.loadFile).toHaveBeenCalledWith('/app/renderer/index.html');
     expect(integrityWindow.loadURL).not.toHaveBeenCalled();
     expect(integrityWindow.show).toHaveBeenCalledOnce();
-  });
-
-  it('skips disabled Team main lifecycles while retaining enabled Ki-Buddy lifecycles', () => {
-    const appPath = createAppPath('ki-buddy');
-    appPaths.push(appPath);
-    const runtime = createKiBuddyRuntime({ appPath, resetPassword: false, webUi: false }).runtime!;
-    const startTeam = vi.fn();
-    const startScheduledTasks = vi.fn();
-
-    runtime.startFeatureLifecycles([
-      { featureId: 'team', start: startTeam },
-      { featureId: 'scheduledTasks', start: startScheduledTasks },
-    ]);
-
-    expect(startTeam).not.toHaveBeenCalled();
-    expect(startScheduledTasks).toHaveBeenCalledOnce();
   });
 
   it('retains existing Team main lifecycles for the AionUi adapter', () => {

--- a/tests/unit/renderer/ChatConversation.legacy.dom.test.tsx
+++ b/tests/unit/renderer/ChatConversation.legacy.dom.test.tsx
@@ -85,7 +85,7 @@ describe('ChatConversation legacy runtime rendering', () => {
     usePresetAssistantInfoMock.mockReset();
     acpChatMock.mockClear();
     acpModelSelectorMock.mockClear();
-    usePresetAssistantInfoMock.mockReturnValue({ info: undefined, isLoading: false });
+    usePresetAssistantInfoMock.mockReturnValue({ info: undefined, isLoading: false, runtimeAccess: 'allowed' });
   });
 
   it.each(['gemini', 'codex', 'openclaw-gateway', 'nanobot', 'remote'] as const)(
@@ -183,5 +183,68 @@ describe('ChatConversation legacy runtime rendering', () => {
         waitForWarmup: true,
       })
     );
+  });
+
+  it('renders blocked historical Extension conversations without mounting ACP runtime UI', () => {
+    usePresetAssistantInfoMock.mockReturnValue({
+      info: null,
+      isLoading: false,
+      runtimeAccess: 'blocked',
+    });
+
+    render(
+      <ChatConversation
+        conversation={
+          {
+            id: 'conv-extension-history',
+            user_id: 'user-1',
+            name: 'Extension history',
+            type: 'acp',
+            model: {},
+            extra: { workspace: '/tmp/aionui-history', backend: 'ext:example:agent' },
+            status: 'finished',
+            source: 'aionui',
+            created_at: 1,
+            modified_at: 1,
+            pinned: false,
+          } as TChatConversation
+        }
+      />
+    );
+
+    expect(screen.getByText('message history')).toBeInTheDocument();
+    expect(screen.queryByTestId('mock-acp-chat')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-acp-model-selector')).not.toBeInTheDocument();
+  });
+
+  it('does not mount ACP runtime UI before historical assistant access is classified', () => {
+    usePresetAssistantInfoMock.mockReturnValue({
+      info: null,
+      isLoading: true,
+      runtimeAccess: 'pending',
+    });
+
+    render(
+      <ChatConversation
+        conversation={
+          {
+            id: 'conv-pending-history',
+            user_id: 'user-1',
+            name: 'Pending history',
+            type: 'acp',
+            model: {},
+            extra: { workspace: '/tmp/aionui-history', assistant_id: 'assistant-pending' },
+            status: 'finished',
+            source: 'aionui',
+            created_at: 1,
+            modified_at: 1,
+            pinned: false,
+          } as TChatConversation
+        }
+      />
+    );
+
+    expect(screen.queryByTestId('mock-acp-chat')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-acp-model-selector')).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/renderer/hooks/useMcpServers.dom.test.ts
+++ b/tests/unit/renderer/hooks/useMcpServers.dom.test.ts
@@ -130,7 +130,13 @@ describe('useMcpServers', () => {
     await waitFor(() => expect(result.current.mcpServers).toHaveLength(1));
   });
 
-  it('hides extension MCP servers and retains a structured diagnostic record in Ki-Buddy', async () => {
+  it('does not load extension MCP contributions when the Extension runtime is disabled', async () => {
+    getProductExperienceMock.mockReturnValue({
+      behaviorDefaults: () => ({ scheduledTaskExecutor: 'assistant', autoInjectedSkillExclusions: [] }),
+      featureState: (featureId: string) => (featureId === 'extensionRuntime' ? 'disabled' : 'enabled'),
+      resourceAccess: (_kind: string, origin: string) =>
+        origin === 'custom' ? 'manage' : origin === 'productBuiltin' ? 'use' : 'hidden',
+    });
     getExtensionMcpServersMock.mockResolvedValue([
       {
         id: 'extension-1',
@@ -145,18 +151,11 @@ describe('useMcpServers', () => {
 
     const { result } = renderHook(() => useMcpServers());
 
-    await waitFor(() => expect(getExtensionMcpServersMock).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(result.current.hiddenResources).toHaveLength(1));
+    await waitFor(() => expect(result.current.isMcpServersLoading).toBe(false));
 
+    expect(getExtensionMcpServersMock).not.toHaveBeenCalled();
     expect(result.current.extensionMcpServers).toEqual([]);
-    expect(result.current.hiddenResources).toEqual([
-      expect.objectContaining({
-        code: 'product_resource_hidden',
-        kind: 'mcp',
-        resourceId: 'extension-1',
-        origin: 'extension',
-      }),
-    ]);
+    expect(result.current.hiddenResources).toEqual([]);
   });
 
   it('keeps extension MCP servers visible under the complete AionUi resource policy', async () => {

--- a/tests/unit/renderer/usePresetAssistantInfo.dom.test.ts
+++ b/tests/unit/renderer/usePresetAssistantInfo.dom.test.ts
@@ -72,6 +72,214 @@ describe('usePresetAssistantInfo', () => {
     window.__kiBuddyProductPresentation = null;
   });
 
+  it('does not request Extension ACP contributions when the runtime is disabled', () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    useSWRMock.mockReturnValue({ data: undefined, isLoading: false });
+
+    renderHook(() => usePresetAssistantInfo(undefined));
+
+    expect(useSWRMock).toHaveBeenNthCalledWith(2, null, expect.any(Function));
+  });
+
+  it('blocks historical Extension adapter backends when the runtime is disabled', () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    useSWRMock.mockReturnValue({ data: [], isLoading: false });
+
+    const { result } = renderHook(() => usePresetAssistantInfo(makeConversation({ backend: 'ext:example:agent' })));
+
+    expect(result.current).toEqual({ info: null, isLoading: false, runtimeAccess: 'blocked' });
+  });
+
+  it('does not restore an assistant backed by a historical Extension record when the runtime is disabled', () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    useSWRMock.mockImplementation((key: unknown) => {
+      if (key === 'assistants.list') {
+        return {
+          data: [
+            {
+              id: 'assistant-extension-legacy',
+              name: 'Legacy Extension Assistant',
+              avatar: '🧩',
+              name_i18n: {},
+              agent: { source: 'extension', type: 'legacy-extension' },
+            },
+          ],
+          isLoading: false,
+        };
+      }
+      return { data: undefined, isLoading: false };
+    });
+
+    const conversation = makeConversation({
+      custom_agent_id: 'assistant-extension-legacy',
+      preset_context: '# Legacy Extension Assistant',
+    });
+    const { result } = renderHook(() => usePresetAssistantInfo(conversation));
+
+    expect(result.current).toEqual({ info: null, isLoading: false, runtimeAccess: 'blocked' });
+  });
+
+  it('does not restore a modern assistant snapshot backed by an Extension agent when the runtime is disabled', () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    useSWRMock.mockImplementation((key: unknown) => {
+      if (key === 'assistants.list') {
+        return {
+          data: [
+            {
+              id: 'assistant-extension-snapshot',
+              name: 'Snapshot Extension Assistant',
+              avatar: '🧩',
+              name_i18n: {},
+              agent: { source: 'extension', type: 'snapshot-extension' },
+            },
+          ],
+          isLoading: false,
+        };
+      }
+      return { data: undefined, isLoading: false };
+    });
+
+    const conversation = {
+      ...makeConversation({ assistant_id: 'assistant-extension-snapshot' }),
+      assistant: {
+        id: 'assistant-extension-snapshot',
+        source: 'generated',
+        name: 'Snapshot Extension Assistant',
+        avatar: '🧩',
+        backend: 'snapshot-extension',
+      },
+    };
+    const { result } = renderHook(() => usePresetAssistantInfo(conversation));
+
+    expect(result.current).toEqual({ info: null, isLoading: false, runtimeAccess: 'blocked' });
+  });
+
+  it('keeps an unclassified snapshot pending while the assistant catalog is loading', () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    useSWRMock.mockImplementation((key: unknown) =>
+      key === 'assistants.list' ? { data: undefined, isLoading: true } : { data: undefined, isLoading: false }
+    );
+    const conversation = {
+      ...makeConversation({ assistant_id: 'assistant-extension-snapshot' }),
+      assistant: {
+        id: 'assistant-extension-snapshot',
+        source: 'generated',
+        name: 'Snapshot Extension Assistant',
+        avatar: '🧩',
+        backend: 'snapshot-extension',
+      },
+    };
+
+    const { result } = renderHook(() => usePresetAssistantInfo(conversation));
+
+    expect(result.current).toEqual({ info: null, isLoading: true, runtimeAccess: 'pending' });
+  });
+
+  it('restores an unclassified snapshot when no Extension origin can be proven', () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    useSWRMock.mockImplementation((key: unknown) =>
+      key === 'assistants.list' ? { data: [], isLoading: false } : { data: undefined, isLoading: false }
+    );
+    const conversation = {
+      ...makeConversation({ assistant_id: 'assistant-deleted-snapshot' }),
+      assistant: {
+        id: 'assistant-deleted-snapshot',
+        source: 'generated',
+        name: 'Historical Assistant',
+        avatar: '🧩',
+        backend: 'claude',
+      },
+    };
+
+    const { result } = renderHook(() => usePresetAssistantInfo(conversation));
+
+    expect(result.current).toEqual({
+      info: {
+        name: 'Historical Assistant',
+        logo: '🧩',
+        isEmoji: true,
+        backend: 'claude',
+        assistantId: 'assistant-deleted-snapshot',
+      },
+      isLoading: false,
+      runtimeAccess: 'allowed',
+    });
+  });
+
+  it('keeps historical assistant runtime pending until Ki-Buddy can classify its catalog record', () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    useSWRMock.mockImplementation((key: unknown) =>
+      key === 'assistants.list' ? { data: undefined, isLoading: true } : { data: undefined, isLoading: false }
+    );
+
+    const { result } = renderHook(() =>
+      usePresetAssistantInfo(makeConversation({ assistant_id: 'assistant-pending', backend: 'claude' }))
+    );
+
+    expect(result.current).toEqual({ info: null, isLoading: true, runtimeAccess: 'pending' });
+  });
+
+  it('allows an unclassified historical assistant after the Ki-Buddy catalog finishes loading', () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    useSWRMock.mockImplementation((key: unknown) =>
+      key === 'assistants.list' ? { data: [], isLoading: false } : { data: undefined, isLoading: false }
+    );
+
+    const { result } = renderHook(() =>
+      usePresetAssistantInfo(makeConversation({ assistant_id: 'assistant-deleted', backend: 'claude' }))
+    );
+
+    expect(result.current).toEqual({ info: null, isLoading: false, runtimeAccess: 'allowed' });
+  });
+
+  it('allows an unclassified legacy assistant payload after its catalog record was deleted', () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    useSWRMock.mockImplementation((key: unknown) =>
+      key === 'assistants.list' ? { data: [], isLoading: false } : { data: undefined, isLoading: false }
+    );
+
+    const { result } = renderHook(() =>
+      usePresetAssistantInfo(
+        makeConversation({
+          custom_agent_id: 'assistant-deleted',
+          preset_context: '# Deleted Assistant',
+          backend: 'claude',
+        })
+      )
+    );
+
+    expect(result.current.runtimeAccess).toBe('allowed');
+    expect(result.current.info?.name).toBe('Claude');
+  });
+
+  it('keeps legacy ACP runtime rows available in Ki-Buddy when they have no assistant payload', () => {
+    window.__kiBuddyProductPresentation = KI_BUDDY_PRODUCT_CAPABILITY;
+    useSWRMock.mockImplementation((key: unknown) =>
+      key === 'assistants.list' ? { data: [], isLoading: false } : { data: undefined, isLoading: false }
+    );
+
+    const { result } = renderHook(() =>
+      usePresetAssistantInfo(
+        makeConversation({ custom_agent_id: 'runtime-social', agent_name: 'Gemini Runtime', backend: 'gemini' })
+      )
+    );
+
+    expect(result.current.runtimeAccess).toBe('allowed');
+    expect(result.current.info?.name).toBe('Gemini Runtime');
+  });
+
+  it('allows the same historical assistant path in AionUi', () => {
+    useSWRMock.mockImplementation((key: unknown) =>
+      key === 'assistants.list' ? { data: undefined, isLoading: true } : { data: undefined, isLoading: false }
+    );
+
+    const { result } = renderHook(() =>
+      usePresetAssistantInfo(makeConversation({ assistant_id: 'assistant-pending', backend: 'claude' }))
+    );
+
+    expect(result.current.runtimeAccess).toBe('allowed');
+  });
+
   it('prefers preset assistant avatar over custom runtime metadata when both identities exist', () => {
     useSWRMock.mockImplementation((key: unknown) => {
       if (key === 'assistants.list') {
@@ -209,6 +417,7 @@ describe('usePresetAssistantInfo', () => {
       backend: 'aionrs',
       assistantId: 'bare-aionrs',
     });
+    expect(result.current.runtimeAccess).toBe('allowed');
   });
 
   it('restores local absolute assistant snapshot avatars from the backend assistant catalog', () => {


### PR DESCRIPTION
## Description

本 PR 让 Ki-Buddy 的 main 与 renderer 专属生命周期统一遵循产品能力策略：

- 停用 Pet、Pet autostart、Pet tray contribution、WebUI、Channels 与 Extension runtime 的专属初始化和 renderer 订阅。
- 保留系统设置中的开机启动、基础 Tray 与关闭到托盘功能，仅移除停用的 Pet 菜单贡献。
- 保持 Scheduled Tasks 的初始化和时区维护，不受其他停用能力影响。
- Extension runtime 停用时不加载扩展贡献；明确属于 Extension 的历史会话只显示消息历史，不挂载 runtime UI。
- 普通、custom、builtin、已删除或来源不明的非 Extension 历史 Assistant 仍可继续使用。
- Ki-Buddy 默认数据目录改为 `~/.ki-buddy`，默认配置目录改为 `~/.ki-buddy-config`；完整 AionUi 保持原目录和原有行为。

本次只修改 Ki-Buddy 仓库中的 Electron main、renderer 与 AionUi 集成层。固定 Ki-Core / AionCore 的现有 backend startup 行为作为已知限制记录，不在本 PR 中修改。

## Related Issues

- Closes #50

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

不适用。本 PR 调整后台生命周期、历史会话访问策略和默认目录，不新增界面。

## Additional Context

`just push` 已通过 lint、format check、TypeScript、i18n validation 和完整 Vitest。完整测试结果：479 个测试文件通过、1 个跳过；4134 项测试通过、5 项跳过。测试输出包含仓库已有的 `MaxListenersExceededWarning`，退出码为 0。
