### PR TITLE
feat(ki-buddy): enforce product seam consistency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,13 @@ repos:
         files: \.(ts|tsx|js|jsx)$
         pass_filenames: false
 
+      - id: ki-buddy-product-experience-consistency
+        name: Ki-Buddy Product Experience Consistency
+        entry: bun packages/shared-scripts/src/kiBuddyProductExperienceConsistency.ts
+        language: system
+        files: \.(ts|tsx|js|jsx|json)$
+        pass_filenames: false
+
   # Oxfmt (replaces Prettier — auto-fixes staged files only)
   - repo: local
     hooks:

--- a/docs/adr/0011-control-aionui-with-product-experience-policy.md
+++ b/docs/adr/0011-control-aionui-with-product-experience-policy.md
@@ -14,6 +14,31 @@ AionUi 与 Ki-Buddy 分别提供 adapter。产品 capability 完全缺失时使�
 
 路由、导航、资源 catalog 和生命周期分别根据同一策略生成投影。导航 registry 保持稳定顺序，产品策略不复制菜单和路由结构。停用功能的代码继续随上游基线打包，使后续 Ki-Buddy 版本可以通过更新策略重新开放能力；产品功能状态只约束客户端产品行为，不替代 Agents 平台或 AionCore 的安全授权。
 
+## 新增功能与资源
+
+`packages/desktop/src/common/platform/ki-buddy/experience/registry.json` 是 feature ID、依赖关系、必选状态、resource kind 和 resource origin 的单一 contract。Runtime 解析和发布校验均从该文件派生，不得在其他模块复制这些名单。`ki-buddy-product.json` 只声明当前产品版本采用的状态；新增 feature 时，先在 contract 中登记稳定领域 ID，再在产品策略中明确设为 `enabled` 或 `disabled`。
+
+新增可访问页面时，按页面类型登记后再实现调用方：
+
+1. 主工作区页面在 `WORKSPACE_FEATURE_REGISTRY` 中同时登记 route 和 navigation；没有导航入口的直接路由把 `navigation` 留空。
+2. 设置页在 `SETTINGS_REGISTRY` 中登记 `featureId`、导航顺序和全部 `routePaths`；Extension 设置路由使用 `EXTENSION_SETTINGS_ROUTE_REGISTRY`。
+3. Router 和 Sider 只消费 registry 投影，不依据路径、组件名、菜单标题或品牌文本决定状态。
+4. legacy redirect 也必须登记到所属 feature，停用 feature 时只能跳转到可用页面，不得挂载原页面及其 hook。
+
+新增产品内置 Agent、Assistant、Skill 或 MCP 时，在 `KI_BUDDY_PRODUCT_RESOURCE_REGISTRY` 中登记稳定后端 ID、所属 feature 和来源识别字段，再由对应 catalog 派生 requirement 与 `productBuiltin` 分类。显示名称只用于诊断，不参与产品状态或资源身份判断。Model 当前没有产品内置身份；需要增加时应先为 registry 增加对应分类，再接入 Model catalog。
+
+Electron main 的产品专属启动、migration、bridge 和清理行为使用 `MAIN_PRODUCT_LIFECYCLE_REGISTRY`。单项判断通过 `isMainProductLifecycleEnabled` 访问，阶段批处理消费 registry 投影，不得直接调用 `featureState` 维护另一份生命周期名单。Renderer 专属订阅继续通过 `isProductFeatureEnabled` 或已有页面投影访问。
+
+提交前运行：
+
+```bash
+bun run check:product-experience
+```
+
+该轻量 TypeScript 检查通过 Bun 执行，同时由 `bun run lint` 和完整单元测试调用。它只检查稳定的所有权边界，并拒绝：产品策略与 contract 的 feature/resource 不一致、重复 feature 名单、main 进程在 lifecycle policy 模块外直接读取 feature 状态、catalog 外直接读取 resource policy、renderer 绕过 adapter 读取原始 capability，以及用 `Ki-Buddy` 品牌字符串控制功能的条件判断。它不分析函数调用图，也不推断打包客户端的运行行为。
+
+路由、导航、resource catalog 和 lifecycle 的投影行为由单元测试及 renderer/main 集成测试验证。打包后的首帧、登录前后、刷新、重启、窗口、Tray、端口监听和扩展贡献以 [Ki-Buddy #52](https://github.com/xlihub/Ki-Buddy/issues/52) 的 packaged Electron E2E 为最终产品验收；E2E 使用实际随包策略作为输入，并依据首发产品矩阵维护独立预期，不能从同一策略动态生成断言结果。
+
 ## 上游接缝与同步维护
 
 现有 AionUi 扩展点只能分别控制页面或运行模块，不能在首个业务画面前向 main、preload 和 renderer 提供同一份产品能力快照，也不能保证导航、直接路由和生命周期同时停用。因此当前版本保留以下显式接缝：
@@ -24,12 +49,14 @@ AionUi 与 Ki-Buddy 分别提供 adapter。产品 capability 完全缺失时使�
 | `packages/desktop/src/preload/main.ts`、`packages/desktop/src/common/types/platform/electron.ts`                                                                                                                                          | 通过单一 getter 转发不可变 bootstrap snapshot；完整性启动不读取业务 IPC                                        | AionUi preload 继续暴露原有 backend 与 renderer bridge                                           |
 | `packages/desktop/src/renderer/index.html`、`packages/desktop/src/renderer/main.tsx`、`packages/desktop/src/renderer/services/i18n/index.ts`                                                                                              | 在首个业务画面前应用产品 capability；配置损坏时停止业务初始化；登录后目录缺少已注册产品资源时显示完整性错误    | capability 缺失时继续使用 AionUi 标题、主题、i18n 与应用 host                                    |
 | `packages/desktop/src/renderer/components/layout/Layout.tsx`、`Router.tsx`、`Sider/index.tsx`、`Titlebar/index.tsx`                                                                                                                       | 从同一 feature ID 投影 Team 入口、直接路由、订阅和 workspace 控件                                              | `ProductExperience` 的 AionUi adapter 保持 Team 入口、路由与生命周期可用                         |
+| `packages/desktop/src/renderer/components/layout/Sider/SiderNav/workspaceRegistry.ts`、`packages/desktop/src/renderer/pages/settings/components/SettingsSider.tsx`                                                                        | 分别维护 workspace 与 settings 的稳定 route/navigation registry，并从同一 feature ID 同步投影                  | AionUi adapter 投影全部 registry 项，保留现有路由和导航顺序                                      |
 | `packages/desktop/src/renderer/components/layout/Router.tsx`、`Sider/index.tsx`、`packages/desktop/src/renderer/pages/settings/components/SettingsSider.tsx`、`SettingsPageWrapper.tsx`                                                   | 从统一设置 registry 生成菜单、默认页、直接路由和 Extension settings 挂载条件；停用页面不执行 hooks 或请求      | AionUi adapter 注册原有设置页和 Extension settings，旧设置地址继续按原有重定向规则工作           |
 | `packages/desktop/src/renderer/components/settings/SettingsModal/contents/AppearanceModalContent.tsx`、`packages/desktop/src/renderer/pages/settings/AppearanceSettings/CssThemeSettings.tsx`                                             | 分别控制主题预设、主题市场和自定义主题的挂载与数据读取；字体和 UI scale 不受主题能力影响                       | AionUi adapter 保持内置主题、Extension 主题、自定义主题、字体与 UI scale 全部可用                |
 | `packages/desktop/src/renderer/pages/guid/components/QuickActionButtons.tsx`                                                                                                                                                              | 只在 Guid WebUI 与 WebUI 页面同时启用时挂载状态请求、事件订阅和快捷入口                                        | AionUi adapter 保持 WebUI 快捷入口、状态显示和跳转                                               |
 | `packages/desktop/src/renderer/hooks/mcp/catalog.ts`、`useMcpServers.ts`、`packages/desktop/src/renderer/pages/settings/ToolsSettings/`、`packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx` | 按可信 catalog 通道和后端 `product_origin` 投影 MCP 的 `hidden`、`use`、`manage`；隐藏记录只保留非敏感诊断字段 | AionUi adapter 保持全部 MCP 来源可见；extension 原有只读交互和上游 image-generation 配置保持不变 |
 | `packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx`                                                                                                                                                        | 从 behavior defaults 决定 Scheduled Tasks 是否允许 Team 执行者                                                 | AionUi adapter 继续使用 `assistant-or-team`                                                      |
 | `packages/desktop/src/process/bridge/updateBridge.ts`、`notificationBridge.ts`                                                                                                                                                            | 注入产品更新源和通知资源；完整性失败时禁用对应业务服务                                                         | capability 缺失时继续使用 AionUi 更新源、User-Agent 和通知图标                                   |
+| `packages/desktop/src/process/ki-buddy/index.ts`、`packages/desktop/src/process/bridge/index.ts`、`packages/desktop/src/process/utils/tray.ts`                                                                                            | 从统一 main lifecycle registry 投影启动、bridge、migration、Tray 和清理行为                                    | AionUi adapter 启用 registry 中全部 main lifecycle                                               |
 
 AionUi 原行为由以下测试保护：
 
@@ -42,6 +69,7 @@ AionUi 原行为由以下测试保护：
 - `tests/unit/feedback/McpServerHeaderFeedback.dom.test.tsx`、`tests/unit/settings/ToolsModalContentImageGuide.dom.test.tsx`：`use` 允许连接检测但不提供管理操作；AionUi 的 `manage` 操作和 image-generation 配置保持可用。
 - `tests/unit/renderer/services/runtime/productBootstrap.dom.test.ts` 与 `kiBuddyRuntime.dom.test.ts`：capability 存在、缺失和损坏时使用对应启动路径。
 - `tests/integration/ProductExperienceSettingsHost.dom.test.tsx`：Ki-Buddy 设置 registry、默认页、停用路由、移动端 Extension hooks、Appearance 数据读取和 Guid WebUI 订阅均受策略约束；AionUi 原设置、主题和 WebUI 快捷行为保持可用。
+- `tests/unit/assets/kiBuddyProductExperienceConsistency.test.ts`：验证轻量一致性检查能够发现品牌判断、原始 capability 读取、重复 feature 名单、main lifecycle policy 外的 feature 状态读取，以及 catalog 外 resource policy 读取。
 
 每次同步 AionUi 基线时必须复查：
 

--- a/justfile
+++ b/justfile
@@ -300,10 +300,12 @@ dist:
 # Run linter
 lint:
     bun run lint
+    bun packages/shared-scripts/src/kiBuddyProductExperienceConsistency.ts
 
 # Run linter with auto-fix
 lint-fix:
     bun run lint:fix
+    bun packages/shared-scripts/src/kiBuddyProductExperienceConsistency.ts
 
 # Format code
 fmt:
@@ -333,6 +335,7 @@ push *ARGS: lint-strict fmt-check typecheck i18n-check test
 # Lint with only errors reported (for CI/push gates)
 lint-strict:
     bun run lint -- --quiet
+    bun packages/shared-scripts/src/kiBuddyProductExperienceConsistency.ts
 
 # ============================================================
 # Testing

--- a/packages/desktop/src/common/platform/ki-buddy/experience/index.ts
+++ b/packages/desktop/src/common/platform/ki-buddy/experience/index.ts
@@ -1,46 +1,24 @@
-export const PRODUCT_FEATURE_IDS = [
-  'account',
-  'agents',
-  'appearance',
-  'assistants',
-  'channels',
-  'componentShowcase',
-  'conversation',
-  'desktopPet',
-  'extensionMarketplace',
-  'extensionRuntime',
-  'extensionSettings',
-  'guid',
-  'guidFeedback',
-  'guidGithubStar',
-  'guidWebUi',
-  'models',
-  'scheduledTasks',
-  'skills',
-  'system',
-  'team',
-  'themeCustomEditor',
-  'themeMarketplace',
-  'themePresets',
-  'tools',
-  'webUi',
-] as const;
+import productExperienceRegistry from './registry.json';
 
-export const PRODUCT_RESOURCE_KINDS = ['agent', 'assistant', 'model', 'skill', 'mcp'] as const;
-export const PRODUCT_RESOURCE_ORIGINS = [
-  'productBuiltin',
-  'upstreamBuiltin',
-  'custom',
-  'extension',
-  'unclassified',
-] as const;
-
-export type ProductFeatureId = (typeof PRODUCT_FEATURE_IDS)[number];
+export type ProductFeatureId = keyof typeof productExperienceRegistry.features;
 export type ProductFeatureState = 'enabled' | 'disabled';
-export type ProductResourceKind = (typeof PRODUCT_RESOURCE_KINDS)[number];
-export type ProductResourceOrigin = (typeof PRODUCT_RESOURCE_ORIGINS)[number];
+export type ProductResourceKind = keyof typeof productExperienceRegistry.resourceKinds;
+export type ProductResourceOrigin = keyof typeof productExperienceRegistry.resourceOrigins;
 export type ProductResourceAccess = 'hidden' | 'use' | 'manage';
 export type ScheduledTaskExecutorDefault = 'assistant' | 'assistant-or-team';
+
+export const PRODUCT_FEATURE_IDS = Object.freeze(Object.keys(productExperienceRegistry.features) as ProductFeatureId[]);
+export const PRODUCT_RESOURCE_KINDS = Object.freeze(
+  Object.keys(productExperienceRegistry.resourceKinds) as ProductResourceKind[]
+);
+export const PRODUCT_RESOURCE_ORIGINS = Object.freeze(
+  Object.keys(productExperienceRegistry.resourceOrigins) as ProductResourceOrigin[]
+);
+export const PRODUCT_FEATURE_DEPENDENCIES = Object.freeze(
+  Object.entries(productExperienceRegistry.features).flatMap(([featureId, definition]) =>
+    definition.dependsOn.map((parentId) => [featureId as ProductFeatureId, parentId as ProductFeatureId] as const)
+  )
+);
 
 export type DeepReadonly<T> = T extends readonly (infer Item)[]
   ? readonly DeepReadonly<Item>[]
@@ -105,18 +83,6 @@ export type ProductBuiltinResourceState =
   | Readonly<{ missing: readonly []; status: 'pending' | 'ready' }>
   | Readonly<{ missing: readonly MissingProductBuiltinResourceRecord[]; status: 'invalid' }>;
 
-const FEATURE_DEPENDENCIES: ReadonlyArray<readonly [ProductFeatureId, ProductFeatureId]> = [
-  ['extensionMarketplace', 'extensionRuntime'],
-  ['extensionSettings', 'extensionRuntime'],
-  ['guidFeedback', 'guid'],
-  ['guidGithubStar', 'guid'],
-  ['guidWebUi', 'guid'],
-  ['guidWebUi', 'webUi'],
-  ['themeCustomEditor', 'appearance'],
-  ['themeMarketplace', 'appearance'],
-  ['themePresets', 'appearance'],
-];
-
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     throw new Error(`${label} must be an object`);
@@ -165,13 +131,15 @@ export function parseProductExperiencePolicy(value: unknown): ProductExperienceS
     ])
   ) as Record<ProductFeatureId, ProductFeatureState>;
 
-  for (const [child, parent] of FEATURE_DEPENDENCIES) {
+  for (const [child, parent] of PRODUCT_FEATURE_DEPENDENCIES) {
     if (features[child] === 'enabled' && features[parent] !== 'enabled') {
       throw new Error(`Product feature ${child} requires enabled parent ${parent}`);
     }
   }
-  if (features.guid !== 'enabled') {
-    throw new Error('Product feature guid must be enabled');
+  for (const [featureId, definition] of Object.entries(productExperienceRegistry.features)) {
+    if (definition.requiredState && features[featureId as ProductFeatureId] !== definition.requiredState) {
+      throw new Error(`Product feature ${featureId} must be ${definition.requiredState}`);
+    }
   }
 
   const rawResources = requireRecord(policy.resources, 'Product experience resources');

--- a/packages/desktop/src/common/platform/ki-buddy/experience/registry.json
+++ b/packages/desktop/src/common/platform/ki-buddy/experience/registry.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": 1,
+  "features": {
+    "account": { "dependsOn": [], "requiredState": null },
+    "agents": { "dependsOn": [], "requiredState": null },
+    "appearance": { "dependsOn": [], "requiredState": null },
+    "assistants": { "dependsOn": [], "requiredState": null },
+    "channels": { "dependsOn": [], "requiredState": null },
+    "componentShowcase": { "dependsOn": [], "requiredState": null },
+    "conversation": { "dependsOn": [], "requiredState": null },
+    "desktopPet": { "dependsOn": [], "requiredState": null },
+    "extensionMarketplace": { "dependsOn": ["extensionRuntime"], "requiredState": null },
+    "extensionRuntime": { "dependsOn": [], "requiredState": null },
+    "extensionSettings": { "dependsOn": ["extensionRuntime"], "requiredState": null },
+    "guid": { "dependsOn": [], "requiredState": "enabled" },
+    "guidFeedback": { "dependsOn": ["guid"], "requiredState": null },
+    "guidGithubStar": { "dependsOn": ["guid"], "requiredState": null },
+    "guidWebUi": { "dependsOn": ["guid", "webUi"], "requiredState": null },
+    "models": { "dependsOn": [], "requiredState": null },
+    "scheduledTasks": { "dependsOn": [], "requiredState": null },
+    "skills": { "dependsOn": [], "requiredState": null },
+    "system": { "dependsOn": [], "requiredState": null },
+    "team": { "dependsOn": [], "requiredState": null },
+    "themeCustomEditor": { "dependsOn": ["appearance"], "requiredState": null },
+    "themeMarketplace": { "dependsOn": ["appearance"], "requiredState": null },
+    "themePresets": { "dependsOn": ["appearance"], "requiredState": null },
+    "tools": { "dependsOn": [], "requiredState": null },
+    "webUi": { "dependsOn": [], "requiredState": null }
+  },
+  "resourceKinds": {
+    "agent": {},
+    "assistant": {},
+    "model": {},
+    "skill": {},
+    "mcp": {}
+  },
+  "resourceOrigins": {
+    "productBuiltin": {},
+    "upstreamBuiltin": {},
+    "custom": {},
+    "extension": {},
+    "unclassified": {}
+  }
+}

--- a/packages/desktop/src/common/platform/ki-buddy/index.ts
+++ b/packages/desktop/src/common/platform/ki-buddy/index.ts
@@ -15,6 +15,7 @@ export {
 } from './productConfig';
 export {
   PRODUCT_FEATURE_IDS,
+  PRODUCT_FEATURE_DEPENDENCIES,
   PRODUCT_RESOURCE_KINDS,
   PRODUCT_RESOURCE_ORIGINS,
   createAionUiProductExperience,
@@ -23,7 +24,7 @@ export {
   evaluateProductBuiltinResourceState,
   parseProductExperiencePolicy,
   projectProductResources,
-} from './productExperience';
+} from './experience';
 export type {
   DeepReadonly,
   ProductBehaviorDefaults,
@@ -40,7 +41,7 @@ export type {
   ProductBuiltinResourceRequirement,
   ProductBuiltinResourceState,
   MissingProductBuiltinResourceRecord,
-} from './productExperience';
+} from './experience';
 export {
   KI_BUDDY_CORE_TRANSPORT_CHANNEL,
   KI_BUDDY_PRODUCT_BOOTSTRAP_CHANNEL,

--- a/packages/desktop/src/common/platform/ki-buddy/productCapability.ts
+++ b/packages/desktop/src/common/platform/ki-buddy/productCapability.ts
@@ -1,6 +1,6 @@
 import type { KiBuddyProductCapability } from '@/common/types/platform/kiBuddyProduct';
 import { KI_BUDDY_PRODUCT_CONFIG_RESULT, type KiBuddyProductConfig } from './productConfig';
-import { deepFreeze } from './productExperience';
+import { deepFreeze } from './experience';
 
 /** Serializable renderer capability for the configured Ki-Buddy product runtime. */
 export function createKiBuddyProductCapability(config: KiBuddyProductConfig): KiBuddyProductCapability {

--- a/packages/desktop/src/common/platform/ki-buddy/productConfig.ts
+++ b/packages/desktop/src/common/platform/ki-buddy/productConfig.ts
@@ -6,7 +6,7 @@ import {
   parseProductExperiencePolicy,
   type DeepReadonly,
   type ProductExperienceSnapshot,
-} from './productExperience';
+} from './experience';
 
 export const KI_BUDDY_PRODUCT_RUNTIME = 'ki-buddy' as const;
 

--- a/packages/desktop/src/common/types/platform/kiBuddyProduct.ts
+++ b/packages/desktop/src/common/types/platform/kiBuddyProduct.ts
@@ -1,5 +1,5 @@
 import type { KiBuddyProductConfig } from '@/common/platform/ki-buddy/productConfig';
-import type { DeepReadonly } from '@/common/platform/ki-buddy/productExperience';
+import type { DeepReadonly } from '@/common/platform/ki-buddy/experience';
 
 export type KiBuddyProductCapability = DeepReadonly<{
   assets: KiBuddyProductConfig['assets']['renderer'];

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -81,6 +81,7 @@ import {
   createKiBuddyProductBootstrap,
   createKiBuddyProductIntegrityWindow,
   createKiBuddyRuntime,
+  isMainProductLifecycleEnabled,
   resolveMainProductExperience,
   runProductBackendMigrations,
   readKiBuddyRuntimeIdentity,
@@ -956,7 +957,7 @@ const handleAppReady = async (): Promise<void> => {
       app.exit(1);
     }
   } else if (isWebUIMode) {
-    if (productExperience?.featureState('webUi') !== 'enabled') {
+    if (!productExperience || !isMainProductLifecycleEnabled(productExperience, 'webUi')) {
       console.error('[AionUi] WebUI is disabled by the selected product experience.');
       app.exit(1);
       return;
@@ -1203,7 +1204,9 @@ installQuitCleanup({
   // transitively (no separate frontend workerTaskManager remains).
   stopBackend: () => (productBusinessLifecycleEnabled ? backendManager.stop() : Promise.resolve()),
   destroyPetWindow:
-    productBusinessLifecycleEnabled && productExperience?.featureState('desktopPet') === 'enabled'
+    productBusinessLifecycleEnabled &&
+    productExperience &&
+    isMainProductLifecycleEnabled(productExperience, 'desktopPet')
       ? async () => {
           const { destroyPetWindow } = await import('./process/pet/petManager');
           destroyPetWindow();

--- a/packages/desktop/src/process/bridge/index.ts
+++ b/packages/desktop/src/process/bridge/index.ts
@@ -13,6 +13,7 @@ import { initNotificationBridge } from './notificationBridge';
 import { initWebuiBridge } from './webuiBridge';
 import { initThemeBridge } from './themeBridge';
 import type { ProductExperience } from '@/common/platform/ki-buddy';
+import { isMainProductLifecycleEnabled } from '@process/ki-buddy';
 
 export type BridgeDependencies = Readonly<{
   productExperience: ProductExperience;
@@ -26,8 +27,8 @@ export function initAllBridges({ productExperience }: BridgeDependencies): void 
   initSystemSettingsBridge();
   initNotificationBridge();
   initThemeBridge();
-  if (productExperience.featureState('desktopPet') === 'enabled') initPetSettingsBridge();
-  if (productExperience.featureState('webUi') === 'enabled') initWebuiBridge();
+  if (isMainProductLifecycleEnabled(productExperience, 'desktopPet')) initPetSettingsBridge();
+  if (isMainProductLifecycleEnabled(productExperience, 'webUi')) initWebuiBridge();
 }
 
 export {

--- a/packages/desktop/src/process/ki-buddy/index.ts
+++ b/packages/desktop/src/process/ki-buddy/index.ts
@@ -62,6 +62,29 @@ export type ProductFeatureLifecycle = {
   start: () => void;
 };
 
+type MainProductLifecycleDefinition = Readonly<{
+  featureId: ProductFeatureId;
+}>;
+
+/** Stable identities for every product-controlled lifecycle owned by the Electron main process. */
+export const MAIN_PRODUCT_LIFECYCLE_REGISTRY = {
+  accountCoreTransport: { featureId: 'account' },
+  channelsMigration: { featureId: 'channels' },
+  desktopPet: { featureId: 'desktopPet' },
+  scheduledTasks: { featureId: 'scheduledTasks' },
+  webUi: { featureId: 'webUi' },
+} as const satisfies Readonly<Record<string, MainProductLifecycleDefinition>>;
+
+export type MainProductLifecycleId = keyof typeof MAIN_PRODUCT_LIFECYCLE_REGISTRY;
+
+/** Reads a main lifecycle decision through the stable registry instead of feature literals at call sites. */
+export function isMainProductLifecycleEnabled(
+  productExperience: ProductExperience,
+  lifecycleId: MainProductLifecycleId
+): boolean {
+  return productExperience.featureState(MAIN_PRODUCT_LIFECYCLE_REGISTRY[lifecycleId].featureId) === 'enabled';
+}
+
 export type KiBuddyProductIntegrityWindowOptions = {
   isPackaged: boolean;
   preloadPath: string;
@@ -163,13 +186,15 @@ export function startMainProductLifecyclePhase(
 ): void {
   if (phase === 'backendReady') {
     const { scheduledTasks } = starters as BackendReadyLifecycleStarters;
-    startProductFeatureLifecycles(productExperience, [{ featureId: 'scheduledTasks', start: scheduledTasks }]);
+    startProductFeatureLifecycles(productExperience, [
+      { featureId: MAIN_PRODUCT_LIFECYCLE_REGISTRY.scheduledTasks.featureId, start: scheduledTasks },
+    ]);
     return;
   }
   const { desktopPet, webUi } = starters as DesktopReadyLifecycleStarters;
   startProductFeatureLifecycles(productExperience, [
-    { featureId: 'desktopPet', start: desktopPet },
-    { featureId: 'webUi', start: webUi },
+    { featureId: MAIN_PRODUCT_LIFECYCLE_REGISTRY.desktopPet.featureId, start: desktopPet },
+    { featureId: MAIN_PRODUCT_LIFECYCLE_REGISTRY.webUi.featureId, start: webUi },
   ]);
 }
 
@@ -194,9 +219,10 @@ export async function runProductBackendMigrations(
 ): Promise<void> {
   const { runBackendMigrations } = await import('@process/utils/runBackendMigrations');
   await runBackendMigrations(configFile);
-  if (productExperience.featureState('channels') !== 'enabled') return;
-  const { migrateLegacyChannelSettings } = await import('@/common/config/configMigration');
-  await migrateLegacyChannelSettings(configFile);
+  if (isMainProductLifecycleEnabled(productExperience, 'channelsMigration')) {
+    const { migrateLegacyChannelSettings } = await import('@/common/config/configMigration');
+    await migrateLegacyChannelSettings(configFile);
+  }
 }
 
 /** Creates and installs the main-process Ki-Buddy runtime when explicit product metadata selects it. */
@@ -230,7 +256,12 @@ export function createKiBuddyRuntime(
   const productExperience = createKiBuddyProductExperience(config.experience);
   const coreAuthOptions = createKiBuddyCoreAuthOptions();
   const coreTransport = new KiBuddyMainCoreTransport(coreAuthOptions.coreCsrfToken);
-  startProductFeatureLifecycles(productExperience, [{ featureId: 'account', start: () => coreTransport.install() }]);
+  startProductFeatureLifecycles(productExperience, [
+    {
+      featureId: MAIN_PRODUCT_LIFECYCLE_REGISTRY.accountCoreTransport.featureId,
+      start: () => coreTransport.install(),
+    },
+  ]);
 
   const runtime: KiBuddyRuntime = {
     brand: {

--- a/packages/desktop/src/process/utils/tray.ts
+++ b/packages/desktop/src/process/utils/tray.ts
@@ -15,6 +15,7 @@ import * as path from 'path';
 import { ipcBridge } from '@/common';
 import i18n from '@process/services/i18n';
 import type { ProductExperience } from '@/common/platform/ki-buddy';
+import { isMainProductLifecycleEnabled } from '@process/ki-buddy';
 
 let tray: TrayInstance | null = null;
 let closeToTrayEnabled = false;
@@ -36,7 +37,7 @@ export function configureTrayBrand(brand: { iconPath: string; productName: strin
 
 /** Projects Desktop Pet tray availability from the selected product adapter. */
 export function configureTrayProductExperience(productExperience: ProductExperience): void {
-  desktopPetTrayEnabled = productExperience.featureState('desktopPet') === 'enabled';
+  desktopPetTrayEnabled = isMainProductLifecycleEnabled(productExperience, 'desktopPet');
 }
 
 export const setTrayMainWindow = (win: BrowserWindow): void => {

--- a/packages/desktop/src/renderer/components/layout/Router.tsx
+++ b/packages/desktop/src/renderer/components/layout/Router.tsx
@@ -2,7 +2,8 @@ import React, { Suspense } from 'react';
 import { HashRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import AppLoader from '@renderer/components/layout/AppLoader';
 import { useAuth } from '@renderer/hooks/context/AuthContext';
-import { getKiBuddyRouteComponents, isProductFeatureEnabled } from '@/renderer/services/runtime/kiBuddyRuntime';
+import { getKiBuddyRouteComponents } from '@/renderer/services/runtime/kiBuddyRuntime';
+import { getWorkspaceExperienceProjection } from './Sider/SiderNav';
 import { getSettingsExperienceProjection } from '@renderer/pages/settings/components/SettingsSider';
 const Conversation = React.lazy(() => import('@renderer/pages/conversation'));
 const Guid = React.lazy(() => import('@renderer/pages/guid'));
@@ -63,12 +64,14 @@ const ProtectedLayout: React.FC<{ layout: React.ReactElement }> = ({ layout }) =
 const PanelRoute: React.FC<{ layout: React.ReactElement }> = ({ layout }) => {
   const { status } = useAuth();
   const kiBuddyRoutes = getKiBuddyRouteComponents();
-  const guidEnabled = isProductFeatureEnabled('guid');
-  const conversationEnabled = isProductFeatureEnabled('conversation');
-  const assistantsEnabled = isProductFeatureEnabled('assistants');
-  const scheduledTasksEnabled = isProductFeatureEnabled('scheduledTasks');
-  const teamEnabled = isProductFeatureEnabled('team');
-  const componentShowcaseEnabled = isProductFeatureEnabled('componentShowcase');
+  const workspaceProjection = getWorkspaceExperienceProjection();
+  const enabledWorkspaceRoutes = new Set(workspaceProjection.routes.map(({ id }) => id));
+  const guidEnabled = enabledWorkspaceRoutes.has('guid');
+  const conversationEnabled = enabledWorkspaceRoutes.has('conversation');
+  const assistantsEnabled = enabledWorkspaceRoutes.has('assistants');
+  const scheduledTasksEnabled = enabledWorkspaceRoutes.has('scheduledTasks');
+  const teamEnabled = enabledWorkspaceRoutes.has('team');
+  const componentShowcaseEnabled = enabledWorkspaceRoutes.has('componentShowcase');
   const settingsProjection = getSettingsExperienceProjection({
     includeProductEntries: Boolean(kiBuddyRoutes),
     isDesktop: true,

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderNav/index.ts
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderNav/index.ts
@@ -2,4 +2,4 @@ export { default as SiderAssistantEntry } from './SiderAssistantEntry';
 export { default as SiderScheduledEntry } from './SiderScheduledEntry';
 export { default as SiderSearchEntry } from './SiderSearchEntry';
 export { default as SiderToolbar } from './SiderToolbar';
-export { getWorkspaceNavigationProjection } from './workspaceRegistry';
+export { getWorkspaceExperienceProjection, getWorkspaceNavigationProjection } from './workspaceRegistry';

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderNav/workspaceRegistry.ts
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderNav/workspaceRegistry.ts
@@ -15,17 +15,99 @@ export type WorkspaceNavigationRegistryEntry = Readonly<{
   placement: 'primary' | 'history';
 }>;
 
-/** Stable workspace navigation order shared by the complete and product-projected UIs. */
-export const WORKSPACE_NAVIGATION_REGISTRY = [
-  { id: 'newConversation', featureId: 'guid', placement: 'primary' },
-  { id: 'conversationSearch', featureId: 'conversation', placement: 'primary' },
-  { id: 'assistants', featureId: 'assistants', placement: 'primary' },
-  { id: 'scheduledTasks', featureId: 'scheduledTasks', placement: 'primary' },
-  { id: 'conversationHistory', featureId: 'conversation', placement: 'history' },
-  { id: 'team', featureId: 'team', placement: 'history' },
-] as const satisfies readonly WorkspaceNavigationRegistryEntry[];
+export type WorkspaceRouteId =
+  | 'guid'
+  | 'conversation'
+  | 'assistants'
+  | 'assistantsLegacy'
+  | 'componentShowcase'
+  | 'scheduledTasks'
+  | 'scheduledTaskDetail'
+  | 'team';
+
+export type WorkspaceRouteRegistryEntry = Readonly<{
+  featureId: ProductFeatureId;
+  id: WorkspaceRouteId;
+  path: string;
+}>;
+
+type WorkspaceFeatureRegistryEntry = Readonly<{
+  featureId: ProductFeatureId;
+  navigation: readonly Omit<WorkspaceNavigationRegistryEntry, 'featureId'>[];
+  routes: readonly Omit<WorkspaceRouteRegistryEntry, 'featureId'>[];
+}>;
+
+/** Stable route and navigation identities for every product-controlled workspace feature. */
+export const WORKSPACE_FEATURE_REGISTRY = [
+  {
+    featureId: 'guid',
+    navigation: [{ id: 'newConversation', placement: 'primary' }],
+    routes: [{ id: 'guid', path: '/guid' }],
+  },
+  {
+    featureId: 'conversation',
+    navigation: [
+      { id: 'conversationSearch', placement: 'primary' },
+      { id: 'conversationHistory', placement: 'history' },
+    ],
+    routes: [{ id: 'conversation', path: '/conversation/:id' }],
+  },
+  {
+    featureId: 'assistants',
+    navigation: [{ id: 'assistants', placement: 'primary' }],
+    routes: [
+      { id: 'assistants', path: '/assistants' },
+      { id: 'assistantsLegacy', path: '/settings/assistants' },
+    ],
+  },
+  {
+    featureId: 'scheduledTasks',
+    navigation: [{ id: 'scheduledTasks', placement: 'primary' }],
+    routes: [
+      { id: 'scheduledTasks', path: '/scheduled' },
+      { id: 'scheduledTaskDetail', path: '/scheduled/:job_id' },
+    ],
+  },
+  {
+    featureId: 'team',
+    navigation: [{ id: 'team', placement: 'history' }],
+    routes: [{ id: 'team', path: '/team/:id' }],
+  },
+  {
+    featureId: 'componentShowcase',
+    navigation: [],
+    routes: [{ id: 'componentShowcase', path: '/test/components' }],
+  },
+] as const satisfies readonly WorkspaceFeatureRegistryEntry[];
+
+export const WORKSPACE_NAVIGATION_REGISTRY: readonly WorkspaceNavigationRegistryEntry[] =
+  WORKSPACE_FEATURE_REGISTRY.flatMap(({ featureId, navigation }) =>
+    navigation.map((entry) => ({ ...entry, featureId }))
+  );
+
+export const WORKSPACE_ROUTE_REGISTRY: readonly WorkspaceRouteRegistryEntry[] = WORKSPACE_FEATURE_REGISTRY.flatMap(
+  ({ featureId, routes }) => routes.map((entry) => ({ ...entry, featureId }))
+);
+
+export type WorkspaceExperienceProjection = Readonly<{
+  navigation: readonly WorkspaceNavigationRegistryEntry[];
+  routes: readonly WorkspaceRouteRegistryEntry[];
+}>;
+
+/** Projects workspace routes and navigation through one ProductExperience decision per feature. */
+export function getWorkspaceExperienceProjection(): WorkspaceExperienceProjection {
+  const enabledFeatures = new Set<ProductFeatureId>(
+    WORKSPACE_FEATURE_REGISTRY.filter(({ featureId }) => isProductFeatureEnabled(featureId)).map(
+      ({ featureId }) => featureId
+    )
+  );
+  return {
+    navigation: WORKSPACE_NAVIGATION_REGISTRY.filter(({ featureId }) => enabledFeatures.has(featureId)),
+    routes: WORKSPACE_ROUTE_REGISTRY.filter(({ featureId }) => enabledFeatures.has(featureId)),
+  };
+}
 
 /** Projects the registry through the active ProductExperience without duplicating navigation arrays. */
 export function getWorkspaceNavigationProjection(): ReadonlyArray<(typeof WORKSPACE_NAVIGATION_REGISTRY)[number]> {
-  return WORKSPACE_NAVIGATION_REGISTRY.filter(({ featureId }) => isProductFeatureEnabled(featureId));
+  return getWorkspaceExperienceProjection().navigation;
 }

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
@@ -34,7 +34,6 @@ import {
 } from '@/renderer/services/clientBusinessSettings';
 import classNames from 'classnames';
 import { getProductDocumentationUrl } from '@/renderer/services/runtime/productBrandRuntime';
-import { getProductExperience } from '@/renderer/services/runtime/kiBuddyRuntime';
 import type { McpCatalogEntry } from '@/renderer/hooks/mcp/catalog';
 import { useSettingsTabNavigate, useSettingsViewMode } from '../settingsViewContext';
 
@@ -281,7 +280,6 @@ const ModalMcpManagementSection: React.FC<{
 };
 
 const ToolsModalContent: React.FC = () => {
-  const canUseUpstreamBuiltinMcp = getProductExperience().resourceAccess('mcp', 'upstreamBuiltin') !== 'hidden';
   const imageGenerationGuideUrl = getProductDocumentationUrl(
     'https://github.com/iOfficeAI/AionUi/wiki/AionUi-Image-Generation-Tool-Model-Configuration-Guide'
   );
@@ -297,6 +295,7 @@ const ToolsModalContent: React.FC = () => {
     mcpServers,
     mcpCatalogEntries,
     extensionMcpCatalogEntries,
+    canUseUpstreamBuiltinMcp,
     saveMcpServers,
     setMcpServers,
     isMcpServersLoading,

--- a/packages/desktop/src/renderer/hooks/mcp/catalog.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/catalog.ts
@@ -14,6 +14,7 @@ import {
 import { getClientBusinessSetting } from '@/renderer/services/clientBusinessSettings';
 import { reportHiddenProductResources } from '@/renderer/services/runtime/catalogs/kiBuddyProductResourceDiagnostics';
 import { getProductExperience } from '@/renderer/services/runtime/kiBuddyRuntime';
+import { KI_BUDDY_PRODUCT_RESOURCE_REGISTRY } from '@/renderer/services/runtime/catalogs/kiBuddyResourceRegistry';
 
 type BackendMcpTransport = Exclude<IMcpServerTransport, { type: 'streamable_http' }>;
 
@@ -52,8 +53,14 @@ const resolveBackendMcpOrigin = (server: ProductAwareMcpServer): ProductResource
 
 const normalizeServerName = (name: string) => name.trim().toLowerCase();
 
+/** Projects one MCP origin through the catalog policy for consumers that do not load server records. */
+export const isProductMcpOriginVisible = (experience: ProductExperience, origin: ProductResourceOrigin): boolean =>
+  experience.resourceAccess('mcp', origin) !== 'hidden';
+
 /** Product-owned MCP requirements registered by features such as the future Agents Adapter integration. */
-export const PRODUCT_BUILTIN_MCP_REQUIREMENTS: readonly ProductBuiltinResourceRequirement[] = [];
+export const PRODUCT_BUILTIN_MCP_REQUIREMENTS: readonly ProductBuiltinResourceRequirement[] = Object.values(
+  KI_BUDDY_PRODUCT_RESOURCE_REGISTRY.mcp
+);
 
 /** Returns the stable key used to reconcile MCP catalog entries across backend and local sources. */
 export const getMcpCatalogServerKey = (server: Pick<IMcpServer, 'id' | 'name' | 'builtin'>) => {

--- a/packages/desktop/src/renderer/hooks/mcp/useMcpServers.ts
+++ b/packages/desktop/src/renderer/hooks/mcp/useMcpServers.ts
@@ -7,6 +7,7 @@ import { getProductExperience } from '@/renderer/services/runtime/kiBuddyRuntime
 import {
   ensureBackendMcpCatalog,
   getMcpCatalogServerKey,
+  isProductMcpOriginVisible,
   projectMcpCatalogCandidates,
   type McpCatalogEntry,
 } from './catalog';
@@ -16,6 +17,9 @@ import {
  * Combines backend-managed user servers with extension-contributed servers.
  */
 export const useMcpServers = () => {
+  const [canUseUpstreamBuiltinMcp] = useState(() =>
+    isProductMcpOriginVisible(getProductExperience(), 'upstreamBuiltin')
+  );
   const [mcpCatalogEntries, setMcpCatalogEntries] = useState<readonly McpCatalogEntry[]>([]);
   const [extensionMcpCatalogEntries, setExtensionMcpCatalogEntries] = useState<readonly McpCatalogEntry[]>([]);
   const [backendHiddenResources, setBackendHiddenResources] = useState<readonly ProductResourceHiddenRecord[]>([]);
@@ -128,6 +132,7 @@ export const useMcpServers = () => {
     extensionMcpServers,
     extensionMcpCatalogEntries,
     hiddenResources,
+    canUseUpstreamBuiltinMcp,
     setMcpServers,
     saveMcpServers,
   };

--- a/packages/desktop/src/renderer/pages/settings/components/SettingsSider.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/SettingsSider.tsx
@@ -33,21 +33,104 @@ export type SettingsRegistryEntry = Readonly<{
   id: string;
   path: string;
   productOnly?: boolean;
+  routePaths: readonly string[];
 }>;
 
 /** Stable settings order shared by navigation and route registration. */
 export const SETTINGS_REGISTRY = [
-  { id: 'account', path: 'account', featureId: 'account', productOnly: true, desktopOnly: false },
-  { id: 'agent', path: 'agent', featureId: 'agents', productOnly: false, desktopOnly: false },
-  { id: 'model', path: 'model', featureId: 'models', productOnly: false, desktopOnly: false },
-  { id: 'skills', path: 'skills', featureId: 'skills', productOnly: false, desktopOnly: false },
-  { id: 'tools', path: 'tools', featureId: 'tools', productOnly: false, desktopOnly: false },
-  { id: 'appearance', path: 'appearance', featureId: 'appearance', productOnly: false, desktopOnly: false },
-  { id: 'webui', path: 'webui', featureId: 'webUi', productOnly: false, desktopOnly: false },
-  { id: 'pet', path: 'pet', featureId: 'desktopPet', productOnly: false, desktopOnly: true },
-  { id: 'system', path: 'system', featureId: 'system', productOnly: false, desktopOnly: false },
-  { id: 'about', path: 'about', featureId: 'system', productOnly: false, desktopOnly: false },
+  {
+    id: 'account',
+    path: 'account',
+    featureId: 'account',
+    productOnly: true,
+    desktopOnly: false,
+    routePaths: ['/settings/account'],
+  },
+  {
+    id: 'agent',
+    path: 'agent',
+    featureId: 'agents',
+    productOnly: false,
+    desktopOnly: false,
+    routePaths: ['/settings/agent', '/settings/agent/:id/repair'],
+  },
+  {
+    id: 'model',
+    path: 'model',
+    featureId: 'models',
+    productOnly: false,
+    desktopOnly: false,
+    routePaths: ['/settings/model'],
+  },
+  {
+    id: 'skills',
+    path: 'skills',
+    featureId: 'skills',
+    productOnly: false,
+    desktopOnly: false,
+    routePaths: [
+      '/settings/skills',
+      '/settings/skills/import-history',
+      '/settings/skills/detail/:skillName',
+      '/settings/capabilities',
+      '/settings/capabilities/skills/import-history',
+      '/settings/skills-hub',
+    ],
+  },
+  {
+    id: 'tools',
+    path: 'tools',
+    featureId: 'tools',
+    productOnly: false,
+    desktopOnly: false,
+    routePaths: ['/settings/tools'],
+  },
+  {
+    id: 'appearance',
+    path: 'appearance',
+    featureId: 'appearance',
+    productOnly: false,
+    desktopOnly: false,
+    routePaths: ['/settings/appearance', '/settings/display'],
+  },
+  {
+    id: 'webui',
+    path: 'webui',
+    featureId: 'webUi',
+    productOnly: false,
+    desktopOnly: false,
+    routePaths: ['/settings/webui'],
+  },
+  {
+    id: 'pet',
+    path: 'pet',
+    featureId: 'desktopPet',
+    productOnly: false,
+    desktopOnly: true,
+    routePaths: ['/settings/pet'],
+  },
+  {
+    id: 'system',
+    path: 'system',
+    featureId: 'system',
+    productOnly: false,
+    desktopOnly: false,
+    routePaths: ['/settings/system'],
+  },
+  {
+    id: 'about',
+    path: 'about',
+    featureId: 'system',
+    productOnly: false,
+    desktopOnly: false,
+    routePaths: ['/settings/about'],
+  },
 ] as const satisfies readonly SettingsRegistryEntry[];
+
+export const EXTENSION_SETTINGS_ROUTE_REGISTRY = {
+  featureId: 'extensionSettings',
+  path: '/settings/ext/:tabId',
+} as const satisfies Readonly<{ featureId: ProductFeatureId; path: string }>;
 
 export type BuiltinSettingsId = (typeof SETTINGS_REGISTRY)[number]['id'];
 

--- a/packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyAssistantCatalog.ts
+++ b/packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyAssistantCatalog.ts
@@ -19,9 +19,9 @@ const KI_CLI_ASSISTANT_IDENTITY = KI_BUDDY_ASSISTANT_IDENTITIES.kiCli;
 
 const PRODUCT_BUILTIN_ASSISTANT_REQUIREMENTS: readonly ProductBuiltinResourceRequirement[] = Object.values(
   KI_BUDDY_ASSISTANT_IDENTITIES
-).map(({ assistantId, resourceName }) => ({
-  featureId: 'assistants',
-  resourceId: assistantId,
+).map(({ id, resourceName, featureId }) => ({
+  featureId,
+  resourceId: id,
   resourceName,
 }));
 
@@ -44,8 +44,8 @@ export type ProductAssistantCatalog = Readonly<{
 }>;
 
 const isKiCliAssistant = (assistant: Assistant): boolean =>
-  assistant.id === KI_CLI_ASSISTANT_IDENTITY.assistantId &&
-  assistant.source === KI_CLI_ASSISTANT_IDENTITY.assistantSource &&
+  assistant.id === KI_CLI_ASSISTANT_IDENTITY.id &&
+  assistant.source === KI_CLI_ASSISTANT_IDENTITY.source &&
   assistant.agent_id === KI_CLI_ASSISTANT_IDENTITY.agentId &&
   assistant.agent?.type === KI_CLI_ASSISTANT_IDENTITY.agentType &&
   assistant.agent.source === KI_CLI_ASSISTANT_IDENTITY.agentSource;

--- a/packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyAssistantIdentity.ts
+++ b/packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyAssistantIdentity.ts
@@ -1,6 +1,13 @@
 import type { TChatConversation, TConversationAssistantIdentity } from '@/common/config/storage';
 import type { ProductExperience, ProductResourceOrigin } from '@/common/platform/ki-buddy';
 import type { Assistant } from '@/common/types/agent/assistantTypes';
+import {
+  KI_BUDDY_ASSISTANT_IDENTITIES,
+  KI_BUDDY_PRODUCT_ASSISTANT_IDS,
+  KI_CLI_PRODUCT_RESOURCE_ID,
+} from './kiBuddyResourceRegistry';
+
+export { KI_BUDDY_ASSISTANT_IDENTITIES, KI_BUDDY_PRODUCT_ASSISTANT_IDS, KI_CLI_PRODUCT_RESOURCE_ID };
 
 type AssistantOriginIdentity = Readonly<{
   id: string;
@@ -18,44 +25,12 @@ export type KiBuddyConversationRuntimeAccessInput = Readonly<{
   conversation: TChatConversation | undefined;
 }>;
 
-export const KI_CLI_PRODUCT_RESOURCE_ID = '632f31d2';
-
-export const KI_BUDDY_ASSISTANT_IDENTITIES = {
-  word: {
-    assistantId: 'word-creator',
-    assistantSource: 'builtin',
-    resourceName: 'Word Creator',
-  },
-  presentation: {
-    assistantId: 'ppt-creator',
-    assistantSource: 'builtin',
-    resourceName: 'PPT Creator',
-  },
-  spreadsheet: {
-    assistantId: 'excel-creator',
-    assistantSource: 'builtin',
-    resourceName: 'Excel Creator',
-  },
-  kiCli: {
-    assistantId: `bare:${KI_CLI_PRODUCT_RESOURCE_ID}`,
-    assistantSource: 'generated',
-    resourceName: 'Ki CLI',
-    agentId: KI_CLI_PRODUCT_RESOURCE_ID,
-    agentType: 'aionrs',
-    agentSource: 'internal',
-  },
-} as const;
-
-export const KI_BUDDY_PRODUCT_ASSISTANT_IDS = Object.values(KI_BUDDY_ASSISTANT_IDENTITIES).map(
-  ({ assistantId }) => assistantId
-);
-
 /** Identifies the product-owned internal CLI across current and historical snapshot IDs. */
 export function isKiCliConversationAssistant(assistant: TConversationAssistantIdentity): boolean {
   return (
     assistant.backend === 'aionrs' &&
     assistant.source === 'generated' &&
-    (assistant.id === KI_BUDDY_ASSISTANT_IDENTITIES.kiCli.assistantId ||
+    (assistant.id === KI_BUDDY_ASSISTANT_IDENTITIES.kiCli.id ||
       assistant.id === 'bare-aionrs' ||
       assistant.id === 'aionrs')
   );
@@ -67,7 +42,7 @@ export function resolveKiBuddyAssistantOrigin(assistant: AssistantOriginIdentity
   if (assistant.source === 'user') return 'custom';
   if (
     Object.values(KI_BUDDY_ASSISTANT_IDENTITIES).some(
-      (identity) => assistant.id === identity.assistantId && assistant.source === identity.assistantSource
+      (identity) => assistant.id === identity.id && assistant.source === identity.source
     )
   ) {
     return 'productBuiltin';

--- a/packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyResourceRegistry.ts
+++ b/packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyResourceRegistry.ts
@@ -1,0 +1,76 @@
+import type { ProductFeatureId } from '@/common/platform/ki-buddy';
+
+type ProductResourceDefinition = Readonly<{
+  featureId: ProductFeatureId;
+  id: string;
+  resourceName?: string;
+}>;
+
+const KI_CLI_AGENT = {
+  id: '632f31d2',
+  featureId: 'agents',
+  resourceName: 'Ki CLI',
+  agentSource: 'internal',
+  agentType: 'aionrs',
+} as const satisfies ProductResourceDefinition & { agentSource: string; agentType: string };
+
+/** Stable product-owned identities used by every Agent, Assistant, Skill, and MCP catalog projection. */
+export const KI_BUDDY_PRODUCT_RESOURCE_REGISTRY = {
+  agent: {
+    kiCli: KI_CLI_AGENT,
+  },
+  assistant: {
+    word: {
+      id: 'word-creator',
+      featureId: 'assistants',
+      resourceName: 'Word Creator',
+      source: 'builtin',
+    },
+    presentation: {
+      id: 'ppt-creator',
+      featureId: 'assistants',
+      resourceName: 'PPT Creator',
+      source: 'builtin',
+    },
+    spreadsheet: {
+      id: 'excel-creator',
+      featureId: 'assistants',
+      resourceName: 'Excel Creator',
+      source: 'builtin',
+    },
+    kiCli: {
+      id: `bare:${KI_CLI_AGENT.id}`,
+      featureId: 'assistants',
+      resourceName: KI_CLI_AGENT.resourceName,
+      source: 'generated',
+      agentId: KI_CLI_AGENT.id,
+      agentSource: KI_CLI_AGENT.agentSource,
+      agentType: KI_CLI_AGENT.agentType,
+    },
+  },
+  skill: {
+    word: {
+      id: 'builtin:officecli-docx',
+      featureId: 'skills',
+      backendName: 'officecli-docx',
+    },
+    presentation: {
+      id: 'builtin:officecli-pptx',
+      featureId: 'skills',
+      backendName: 'officecli-pptx',
+    },
+    spreadsheet: {
+      id: 'builtin:officecli-xlsx',
+      featureId: 'skills',
+      backendName: 'officecli-xlsx',
+    },
+  },
+  mcp: {},
+} as const;
+
+export const KI_CLI_PRODUCT_RESOURCE_ID = KI_BUDDY_PRODUCT_RESOURCE_REGISTRY.agent.kiCli.id;
+export const KI_BUDDY_ASSISTANT_IDENTITIES = KI_BUDDY_PRODUCT_RESOURCE_REGISTRY.assistant;
+export const KI_BUDDY_PRODUCT_ASSISTANT_IDS = Object.values(KI_BUDDY_ASSISTANT_IDENTITIES).map(({ id }) => id);
+export const KI_BUDDY_PRODUCT_SKILL_NAMES = new Set<string>(
+  Object.values(KI_BUDDY_PRODUCT_RESOURCE_REGISTRY.skill).map(({ backendName }) => backendName)
+);

--- a/packages/desktop/src/renderer/services/runtime/kiBuddyAgentCatalog.ts
+++ b/packages/desktop/src/renderer/services/runtime/kiBuddyAgentCatalog.ts
@@ -10,7 +10,7 @@ import {
 } from '@/common/platform/ki-buddy';
 import { requestManagedAgents, type ManagedAgent } from '@/renderer/utils/model/agentTypes';
 import { getKiBuddyProductRuntime, getProductExperience } from './kiBuddyRuntime';
-import { KI_CLI_PRODUCT_RESOURCE_ID } from './catalogs/kiBuddyAssistantIdentity';
+import { KI_BUDDY_PRODUCT_RESOURCE_REGISTRY, KI_CLI_PRODUCT_RESOURCE_ID } from './catalogs/kiBuddyResourceRegistry';
 import { reportHiddenProductResources } from './catalogs/kiBuddyProductResourceDiagnostics';
 
 export { KI_CLI_PRODUCT_RESOURCE_ID } from './catalogs/kiBuddyAssistantIdentity';
@@ -19,7 +19,7 @@ const getProductBuiltinAgentRequirements = (): readonly ProductBuiltinResourceRe
   const resourceName = getKiBuddyProductRuntime()?.brand.cliName;
   return [
     {
-      featureId: 'agents',
+      featureId: KI_BUDDY_PRODUCT_RESOURCE_REGISTRY.agent.kiCli.featureId,
       resourceId: KI_CLI_PRODUCT_RESOURCE_ID,
       ...(resourceName ? { resourceName } : {}),
     },

--- a/packages/desktop/src/renderer/services/runtime/kiBuddySkillCatalog.ts
+++ b/packages/desktop/src/renderer/services/runtime/kiBuddySkillCatalog.ts
@@ -8,6 +8,7 @@ import {
 } from '@/common/platform/ki-buddy';
 import { reportHiddenProductResources } from './catalogs/kiBuddyProductResourceDiagnostics';
 import { getProductExperience } from './kiBuddyRuntime';
+import { KI_BUDDY_PRODUCT_SKILL_NAMES } from './catalogs/kiBuddyResourceRegistry';
 
 export type AvailableSkill = Awaited<ReturnType<typeof ipcBridge.fs.listAvailableSkills.invoke>>[number];
 
@@ -24,12 +25,6 @@ export type ProductSkillCatalog = Readonly<{
   visibleSkills: readonly AvailableSkill[];
 }>;
 
-const PRODUCT_OFFICE_SKILL_RELATIVE_LOCATIONS = new Set([
-  'officecli-docx/SKILL.md',
-  'officecli-pptx/SKILL.md',
-  'officecli-xlsx/SKILL.md',
-]);
-
 const resolveSkillIdentity = (
   skill: AvailableSkill
 ): Readonly<{ id: string; name: string; origin: ProductResourceOrigin; skill: AvailableSkill }> => {
@@ -39,11 +34,9 @@ const resolveSkillIdentity = (
   if (skill.source === 'extension') {
     return { id: `extension:${skill.name}`, name: skill.name, origin: 'extension', skill };
   }
-  if (skill.source === 'builtin' && skill.relative_location) {
-    const origin = PRODUCT_OFFICE_SKILL_RELATIVE_LOCATIONS.has(skill.relative_location)
-      ? 'productBuiltin'
-      : 'upstreamBuiltin';
-    return { id: `builtin:${skill.relative_location}`, name: skill.name, origin, skill };
+  if (skill.source === 'builtin') {
+    const origin = KI_BUDDY_PRODUCT_SKILL_NAMES.has(skill.name) ? 'productBuiltin' : 'upstreamBuiltin';
+    return { id: `builtin:${skill.name}`, name: skill.name, origin, skill };
   }
   return { id: `unclassified:${skill.name}`, name: skill.name, origin: 'unclassified', skill };
 };

--- a/packages/shared-scripts/src/kiBuddyProductExperienceConsistency.ts
+++ b/packages/shared-scripts/src/kiBuddyProductExperienceConsistency.ts
@@ -1,0 +1,269 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import ts from 'typescript';
+
+export type ProductExperienceSource = Readonly<{ content: string; path: string }>;
+
+export type ProductExperienceViolation = Readonly<{
+  code:
+    | 'brand_feature_decision'
+    | 'direct_resource_policy_read'
+    | 'duplicate_product_decision_list'
+    | 'raw_product_capability_read'
+    | 'unregistered_main_lifecycle';
+  detail: string;
+  line: number;
+  path: string;
+}>;
+
+export type ProductExperienceInspectionOptions = Readonly<{
+  featureIds?: readonly string[];
+}>;
+
+type ProductExperienceRegistry = Readonly<{
+  features: Readonly<Record<string, unknown>>;
+  resourceKinds: Readonly<Record<string, unknown>>;
+  resourceOrigins: Readonly<Record<string, unknown>>;
+}>;
+
+const RAW_CAPABILITY_ALLOWED_FILES = new Set([
+  'packages/desktop/src/common/types/platform/electron.ts',
+  'packages/desktop/src/renderer/services/runtime/kiBuddyRuntime.ts',
+]);
+const MAIN_LIFECYCLE_POLICY_FILE = 'packages/desktop/src/process/ki-buddy/index.ts';
+const DIRECT_RESOURCE_POLICY_ALLOWED_FILES = new Set([
+  'packages/desktop/src/common/platform/ki-buddy/experience/index.ts',
+  'packages/desktop/src/renderer/hooks/mcp/catalog.ts',
+  'packages/desktop/src/renderer/services/runtime/kiBuddyModelCatalog.ts',
+  'packages/desktop/src/renderer/services/runtime/kiBuddySkillCatalog.ts',
+]);
+const PRODUCT_DECISION_REGISTRY_FILES = new Set([
+  'packages/desktop/src/common/platform/ki-buddy/experience/index.ts',
+  MAIN_LIFECYCLE_POLICY_FILE,
+  'packages/desktop/src/renderer/components/layout/Sider/SiderNav/workspaceRegistry.ts',
+  'packages/desktop/src/renderer/pages/settings/components/SettingsSider.tsx',
+  'packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyResourceRegistry.ts',
+]);
+
+function normalizePath(filePath: string): string {
+  return filePath.split(path.sep).join('/');
+}
+
+function sourceKind(filePath: string): ts.ScriptKind {
+  return filePath.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+}
+
+function violation(
+  code: ProductExperienceViolation['code'],
+  file: ProductExperienceSource,
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+  detail: string
+): ProductExperienceViolation {
+  return {
+    code,
+    path: file.path,
+    line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
+    detail,
+  };
+}
+
+function productDecisionText(node: ts.Node, sourceFile: ts.SourceFile): string | null {
+  if (ts.isIfStatement(node)) return node.expression.getText(sourceFile);
+  if (ts.isConditionalExpression(node)) return node.condition.getText(sourceFile);
+  if (ts.isBinaryExpression(node)) return node.getText(sourceFile);
+  return null;
+}
+
+function isBrandFeatureDecision(node: ts.Node, sourceFile: ts.SourceFile): boolean {
+  const text = productDecisionText(node, sourceFile);
+  return Boolean(text && /(?:brand|productName|shortName)/.test(text) && /['"](?:Ki-Buddy|ki-buddy)['"]/.test(text));
+}
+
+function propertyNameText(name: ts.PropertyName, sourceFile: ts.SourceFile): string {
+  return ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)
+    ? name.text
+    : name.getText(sourceFile);
+}
+
+function stringValue(node: ts.Expression): string | null {
+  return ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node) ? node.text : null;
+}
+
+function collectKnownStringLiterals(node: ts.Node, knownValues: ReadonlySet<string>): ReadonlySet<string> {
+  const values = new Set<string>();
+  function visit(current: ts.Node): void {
+    if (ts.isStringLiteral(current) && knownValues.has(current.text)) values.add(current.text);
+    ts.forEachChild(current, visit);
+  }
+  visit(node);
+  return values;
+}
+
+function isNamedProductDecisionArray(node: ts.ArrayLiteralExpression): boolean {
+  let current: ts.Node = node;
+  while (
+    current.parent &&
+    (ts.isAsExpression(current.parent) ||
+      ts.isSatisfiesExpression(current.parent) ||
+      ts.isParenthesizedExpression(current.parent) ||
+      ts.isCallExpression(current.parent) ||
+      ts.isNewExpression(current.parent))
+  ) {
+    current = current.parent;
+  }
+  const declaration = current.parent;
+  return Boolean(
+    declaration &&
+    ts.isVariableDeclaration(declaration) &&
+    ts.isIdentifier(declaration.name) &&
+    /(?:PRODUCT|FEATURE|NAVIGATION|ROUTE|RESOURCE|LIFECYCLE)/.test(declaration.name.text)
+  );
+}
+
+/** Inspects stable ProductExperience ownership boundaries; behavior belongs to integration and packaged E2E tests. */
+export function inspectProductExperienceSources(
+  files: readonly ProductExperienceSource[],
+  options: ProductExperienceInspectionOptions = {}
+): ProductExperienceViolation[] {
+  const knownFeatureIds = new Set(options.featureIds ?? []);
+  const violations: ProductExperienceViolation[] = [];
+
+  for (const file of files) {
+    const normalizedPath = normalizePath(file.path);
+    const sourceFile = ts.createSourceFile(
+      file.path,
+      file.content,
+      ts.ScriptTarget.Latest,
+      true,
+      sourceKind(file.path)
+    );
+
+    function visit(node: ts.Node): void {
+      if (isBrandFeatureDecision(node, sourceFile)) {
+        violations.push(violation('brand_feature_decision', file, sourceFile, node, node.getText(sourceFile)));
+      }
+      if (
+        !PRODUCT_DECISION_REGISTRY_FILES.has(normalizedPath) &&
+        ts.isPropertyAssignment(node) &&
+        propertyNameText(node.name, sourceFile) === 'featureId'
+      ) {
+        const featureId = stringValue(node.initializer);
+        if (featureId && knownFeatureIds.has(featureId)) {
+          violations.push(
+            violation('duplicate_product_decision_list', file, sourceFile, node, node.getText(sourceFile))
+          );
+        }
+      }
+      if (
+        !PRODUCT_DECISION_REGISTRY_FILES.has(normalizedPath) &&
+        ts.isArrayLiteralExpression(node) &&
+        isNamedProductDecisionArray(node) &&
+        collectKnownStringLiterals(node, knownFeatureIds).size >= 2
+      ) {
+        violations.push(violation('duplicate_product_decision_list', file, sourceFile, node, node.getText(sourceFile)));
+      }
+      ts.forEachChild(node, visit);
+    }
+    visit(sourceFile);
+
+    if (file.content.includes('__kiBuddyProductPresentation') && !RAW_CAPABILITY_ALLOWED_FILES.has(normalizedPath)) {
+      violations.push(
+        violation('raw_product_capability_read', file, sourceFile, sourceFile, '__kiBuddyProductPresentation')
+      );
+    }
+    if (
+      normalizedPath.startsWith('packages/desktop/src/process/') &&
+      normalizedPath !== MAIN_LIFECYCLE_POLICY_FILE &&
+      file.content.includes('.featureState(')
+    ) {
+      violations.push(violation('unregistered_main_lifecycle', file, sourceFile, sourceFile, '.featureState('));
+    }
+    if (file.content.includes('.resourceAccess(') && !DIRECT_RESOURCE_POLICY_ALLOWED_FILES.has(normalizedPath)) {
+      violations.push(violation('direct_resource_policy_read', file, sourceFile, sourceFile, '.resourceAccess('));
+    }
+  }
+
+  return violations.filter(
+    (current, index, all) =>
+      all.findIndex(
+        (candidate) =>
+          candidate.code === current.code && candidate.path === current.path && candidate.line === current.line
+      ) === index
+  );
+}
+
+function readSourceFiles(directory: string, projectRoot: string): ProductExperienceSource[] {
+  const files: ProductExperienceSource[] = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...readSourceFiles(absolutePath, projectRoot));
+    else if (/\.tsx?$/.test(entry.name)) {
+      files.push({
+        path: normalizePath(path.relative(projectRoot, absolutePath)),
+        content: fs.readFileSync(absolutePath, 'utf8'),
+      });
+    }
+  }
+  return files;
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireSameKeys(actual: Record<string, unknown>, expected: Record<string, unknown>, label: string): void {
+  const actualKeys = Object.keys(actual).toSorted();
+  const expectedKeys = Object.keys(expected).toSorted();
+  if (JSON.stringify(actualKeys) !== JSON.stringify(expectedKeys)) {
+    throw new Error(`${label} must match the stable ProductExperience registry`);
+  }
+}
+
+/** Runs the lightweight repository check used by lint and CI. */
+export function verifyProductExperienceConsistency(projectRoot: string): void {
+  const registry = JSON.parse(
+    fs.readFileSync(
+      path.join(projectRoot, 'packages/desktop/src/common/platform/ki-buddy/experience/registry.json'),
+      'utf8'
+    )
+  ) as ProductExperienceRegistry;
+  const productConfig = requireRecord(
+    JSON.parse(fs.readFileSync(path.join(projectRoot, 'ki-buddy-product.json'), 'utf8')),
+    'Ki-Buddy product config'
+  );
+  const experience = requireRecord(productConfig.experience, 'Product experience');
+  const features = requireRecord(experience.features, 'Product feature policy');
+  const resources = requireRecord(experience.resources, 'Product resource policy');
+  requireSameKeys(features, registry.features, 'Product feature policy');
+  requireSameKeys(resources, registry.resourceKinds, 'Product resource policy');
+  for (const access of Object.values(resources)) {
+    requireSameKeys(
+      requireRecord(access, 'Product resource origin policy'),
+      registry.resourceOrigins,
+      'Product resource origin policy'
+    );
+  }
+
+  const files = readSourceFiles(path.join(projectRoot, 'packages/desktop/src'), projectRoot);
+  const violations = inspectProductExperienceSources(files, { featureIds: Object.keys(registry.features) });
+  if (violations.length > 0) {
+    const details = violations
+      .map(({ code, path: filePath, line, detail }) => `${filePath}:${line} [${code}] ${detail}`)
+      .join('\n');
+    throw new Error(`ProductExperience consistency check failed:\n${details}`);
+  }
+}
+
+if (import.meta.main) {
+  try {
+    verifyProductExperienceConsistency(path.resolve(import.meta.dir, '../../..'));
+    console.log('ProductExperience consistency check passed.');
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/packages/shared-scripts/src/kiBuddyRelease.js
+++ b/packages/shared-scripts/src/kiBuddyRelease.js
@@ -4,6 +4,7 @@ const { execFileSync } = require('node:child_process');
 const { isDeepStrictEqual } = require('node:util');
 const yaml = require('js-yaml');
 const { readKiCorePin } = require('./kiCoreRelease');
+const productExperienceRegistry = require('../../desktop/src/common/platform/ki-buddy/experience/registry.json');
 
 const KI_BUDDY_PRODUCT = 'Ki-Buddy';
 const KI_BUDDY_REPOSITORY = 'xlihub/Ki-Buddy';
@@ -13,46 +14,12 @@ const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const PACKAGE_VERSION_PATTERN =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const SHA40_PATTERN = /^[0-9a-f]{40}$/;
-const PRODUCT_FEATURE_IDS = [
-  'account',
-  'agents',
-  'appearance',
-  'assistants',
-  'channels',
-  'componentShowcase',
-  'conversation',
-  'desktopPet',
-  'extensionMarketplace',
-  'extensionRuntime',
-  'extensionSettings',
-  'guid',
-  'guidFeedback',
-  'guidGithubStar',
-  'guidWebUi',
-  'models',
-  'scheduledTasks',
-  'skills',
-  'system',
-  'team',
-  'themeCustomEditor',
-  'themeMarketplace',
-  'themePresets',
-  'tools',
-  'webUi',
-];
-const PRODUCT_RESOURCE_KINDS = ['agent', 'assistant', 'model', 'skill', 'mcp'];
-const PRODUCT_RESOURCE_ORIGINS = ['productBuiltin', 'upstreamBuiltin', 'custom', 'extension', 'unclassified'];
-const PRODUCT_FEATURE_DEPENDENCIES = [
-  ['extensionMarketplace', 'extensionRuntime'],
-  ['extensionSettings', 'extensionRuntime'],
-  ['guidFeedback', 'guid'],
-  ['guidGithubStar', 'guid'],
-  ['guidWebUi', 'guid'],
-  ['guidWebUi', 'webUi'],
-  ['themeCustomEditor', 'appearance'],
-  ['themeMarketplace', 'appearance'],
-  ['themePresets', 'appearance'],
-];
+const PRODUCT_FEATURE_IDS = Object.keys(productExperienceRegistry.features);
+const PRODUCT_RESOURCE_KINDS = Object.keys(productExperienceRegistry.resourceKinds);
+const PRODUCT_RESOURCE_ORIGINS = Object.keys(productExperienceRegistry.resourceOrigins);
+const PRODUCT_FEATURE_DEPENDENCIES = Object.entries(productExperienceRegistry.features).flatMap(
+  ([featureId, definition]) => definition.dependsOn.map((parentId) => [featureId, parentId])
+);
 
 function requireExactKeys(value, keys, label) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -82,6 +49,11 @@ function validateProductExperiencePolicy(policy) {
   for (const [child, parent] of PRODUCT_FEATURE_DEPENDENCIES) {
     if (policy.features[child] === 'enabled' && policy.features[parent] !== 'enabled') {
       throw new Error(`Product feature ${child} requires enabled parent ${parent}`);
+    }
+  }
+  for (const [featureId, definition] of Object.entries(productExperienceRegistry.features)) {
+    if (definition.requiredState && policy.features[featureId] !== definition.requiredState) {
+      throw new Error(`Product feature ${featureId} must be ${definition.requiredState}`);
     }
   }
 

--- a/tests/integration/ProductExperienceSiderHost.dom.test.tsx
+++ b/tests/integration/ProductExperienceSiderHost.dom.test.tsx
@@ -56,6 +56,7 @@ vi.mock('@renderer/components/layout/Sider/TeamSiderSection', () => ({
 }));
 
 import Sider from '@/renderer/components/layout/Sider';
+import { getWorkspaceExperienceProjection } from '@/renderer/components/layout/Sider/SiderNav/workspaceRegistry';
 
 function workspaceNavigationIds(container: HTMLElement): Array<string | null> {
   return Array.from(container.querySelectorAll('[data-workspace-nav-id]')).map((item) =>
@@ -70,6 +71,18 @@ describe('Product experience Sider host', () => {
     window.__kiBuddyProductBootstrapError = null;
     window.__kiBuddyProductPresentation = null;
   });
+
+  it.each(['conversation', 'assistants', 'scheduledTasks', 'team'] as const)(
+    'projects %s routes and navigation from one workspace registry',
+    (featureId) => {
+      activateKiBuddyProduct({ [featureId]: 'disabled' });
+
+      const projection = getWorkspaceExperienceProjection();
+
+      expect(projection.routes.some((route) => route.featureId === featureId)).toBe(false);
+      expect(projection.navigation.some((item) => item.featureId === featureId)).toBe(false);
+    }
+  );
 
   it('does not mount Team navigation or its subscriptions in Ki-Buddy', async () => {
     activateKiBuddyProduct();

--- a/tests/unit/assets/kiBuddyProductExperienceConsistency.test.ts
+++ b/tests/unit/assets/kiBuddyProductExperienceConsistency.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  inspectProductExperienceSources,
+  verifyProductExperienceConsistency,
+} from '../../../packages/shared-scripts/src/kiBuddyProductExperienceConsistency';
+
+describe('ProductExperience consistency check', () => {
+  it('accepts the current stable product boundaries', () => {
+    expect(() => verifyProductExperienceConsistency(process.cwd())).not.toThrow();
+  });
+
+  it('detects brand-driven feature decisions and raw capability reads', () => {
+    const violations = inspectProductExperienceSources([
+      {
+        path: 'packages/desktop/src/renderer/pages/example.tsx',
+        content: `
+          if (brand.productName === 'Ki-Buddy') enableFeature();
+          const policy = window.__kiBuddyProductPresentation?.experience;
+        `,
+      },
+    ]);
+
+    expect(violations.map(({ code }) => code)).toEqual(['brand_feature_decision', 'raw_product_capability_read']);
+  });
+
+  it('does not treat product copy as a feature decision', () => {
+    const violations = inspectProductExperienceSources([
+      {
+        path: 'packages/desktop/src/renderer/pages/example.tsx',
+        content: `const productDescription = 'Ki-Buddy';`,
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
+  it('detects main lifecycle policy reads outside the central registry', () => {
+    const violations = inspectProductExperienceSources([
+      {
+        path: 'packages/desktop/src/process/example.ts',
+        content: `if (productExperience.featureState('desktopPet') === 'enabled') startPet();`,
+      },
+    ]);
+
+    expect(violations).toEqual([
+      expect.objectContaining({ code: 'unregistered_main_lifecycle', path: 'packages/desktop/src/process/example.ts' }),
+    ]);
+  });
+
+  it('detects copied feature registrations outside stable registries', () => {
+    const violations = inspectProductExperienceSources(
+      [
+        {
+          path: 'packages/desktop/src/renderer/pages/example.tsx',
+          content: `const copy = { featureId: 'guid' };`,
+        },
+      ],
+      { featureIds: ['guid'] }
+    );
+
+    expect(violations).toEqual([expect.objectContaining({ code: 'duplicate_product_decision_list' })]);
+  });
+
+  it('detects copied feature lists outside stable registries', () => {
+    const violations = inspectProductExperienceSources(
+      [
+        {
+          path: 'packages/desktop/src/renderer/pages/example.tsx',
+          content: `const PRODUCT_FEATURE_IDS = new Set(['guid', 'team']);`,
+        },
+      ],
+      { featureIds: ['guid', 'team'] }
+    );
+
+    expect(violations).toEqual([expect.objectContaining({ code: 'duplicate_product_decision_list' })]);
+  });
+
+  it('detects resource access decisions outside catalog projections', () => {
+    const violations = inspectProductExperienceSources([
+      {
+        path: 'packages/desktop/src/renderer/pages/example.tsx',
+        content: `const visible = productExperience.resourceAccess('skill', 'custom') !== 'hidden';`,
+      },
+    ]);
+
+    expect(violations).toEqual([expect.objectContaining({ code: 'direct_resource_policy_read' })]);
+  });
+
+  it('allows policy access in its owning adapters and catalogs', () => {
+    const violations = inspectProductExperienceSources([
+      {
+        path: 'packages/desktop/src/renderer/services/runtime/kiBuddyRuntime.ts',
+        content: `const policy = window.__kiBuddyProductPresentation?.experience;`,
+      },
+      {
+        path: 'packages/desktop/src/renderer/hooks/mcp/catalog.ts',
+        content: `const access = productExperience.resourceAccess('mcp', 'custom');`,
+      },
+      {
+        path: 'packages/desktop/src/process/ki-buddy/index.ts',
+        content: `const state = productExperience.featureState('desktopPet');`,
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/unit/common-platform/productExperience.test.ts
+++ b/tests/unit/common-platform/productExperience.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
+  PRODUCT_FEATURE_DEPENDENCIES,
+  PRODUCT_FEATURE_IDS,
+  PRODUCT_RESOURCE_KINDS,
   PRODUCT_RESOURCE_ORIGINS,
   createAionUiProductExperience,
   createKiBuddyProductExperience,
   evaluateProductBuiltinResourceState,
   parseProductExperiencePolicy,
   projectProductResources,
-} from '@/common/platform/ki-buddy/productExperience';
+} from '@/common/platform/ki-buddy/experience';
+import productExperienceRegistry from '../../../packages/desktop/src/common/platform/ki-buddy/experience/registry.json';
 
 const validPolicy = {
   schemaVersion: 1,
@@ -81,6 +85,17 @@ const validPolicy = {
 } as const;
 
 describe('ProductExperience interface', () => {
+  it('uses the shared registry as the single feature and resource contract', () => {
+    expect(PRODUCT_FEATURE_IDS).toEqual(Object.keys(productExperienceRegistry.features));
+    expect(PRODUCT_FEATURE_DEPENDENCIES).toEqual(
+      Object.entries(productExperienceRegistry.features).flatMap(([featureId, definition]) =>
+        definition.dependsOn.map((parentId) => [featureId, parentId])
+      )
+    );
+    expect(PRODUCT_RESOURCE_KINDS).toEqual(Object.keys(productExperienceRegistry.resourceKinds));
+    expect(PRODUCT_RESOURCE_ORIGINS).toEqual(Object.keys(productExperienceRegistry.resourceOrigins));
+  });
+
   it('projects visible MCP resources and records hidden resources without exposing their configuration', () => {
     const experience = createKiBuddyProductExperience(validPolicy);
     const projection = projectProductResources(experience, 'mcp', [

--- a/tests/unit/process/ki-buddy/runtimeFacade.test.ts
+++ b/tests/unit/process/ki-buddy/runtimeFacade.test.ts
@@ -32,6 +32,7 @@ vi.mock('@/process/utils/runBackendMigrations', () => ({
 }));
 
 const {
+  MAIN_PRODUCT_LIFECYCLE_REGISTRY,
   createKiBuddyProductBootstrap,
   createKiBuddyProductIntegrityWindow,
   createKiBuddyRuntime,
@@ -62,6 +63,16 @@ describe('Ki-Buddy main-process runtime facade', () => {
     installTransportMock.mockReset();
     vi.mocked(BrowserWindow).mockReset();
     for (const appPath of appPaths.splice(0)) rmSync(appPath, { recursive: true, force: true });
+  });
+
+  it('keeps product-specific main lifecycles in one stable registry', () => {
+    expect(MAIN_PRODUCT_LIFECYCLE_REGISTRY).toEqual({
+      accountCoreTransport: { featureId: 'account' },
+      channelsMigration: { featureId: 'channels' },
+      desktopPet: { featureId: 'desktopPet' },
+      scheduledTasks: { featureId: 'scheduledTasks' },
+      webUi: { featureId: 'webUi' },
+    });
   });
 
   it('runs Channels migration only for product adapters that enable its lifecycle', async () => {

--- a/tests/unit/renderer/services/runtime/kiBuddyAssistantCatalog.dom.test.ts
+++ b/tests/unit/renderer/services/runtime/kiBuddyAssistantCatalog.dom.test.ts
@@ -2,6 +2,7 @@ import type { ProductExperience } from '@/common/platform/ki-buddy';
 import type { Assistant } from '@/common/types/agent/assistantTypes';
 import { createAionUiProductExperience, createKiBuddyProductExperience } from '@/common/platform/ki-buddy';
 import { projectProductAssistantCatalog } from '@/renderer/services/runtime/catalogs/kiBuddyAssistantCatalog';
+import { KI_BUDDY_PRODUCT_RESOURCE_REGISTRY } from '@/renderer/services/runtime/catalogs/kiBuddyResourceRegistry';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import productConfig from '../../../../../ki-buddy-product.json';
 
@@ -43,6 +44,28 @@ const kiBuddyExperience = (): ProductExperience => createKiBuddyProductExperienc
 describe('projectProductAssistantCatalog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('uses one stable registry for product Agent, Assistant, Skill, and MCP identities', () => {
+    expect(
+      Object.values(KI_BUDDY_PRODUCT_RESOURCE_REGISTRY.agent).map(({ id, featureId }) => ({ id, featureId }))
+    ).toEqual([{ id: '632f31d2', featureId: 'agents' }]);
+    expect(
+      Object.values(KI_BUDDY_PRODUCT_RESOURCE_REGISTRY.assistant).map(({ id, featureId }) => ({ id, featureId }))
+    ).toEqual([
+      { id: 'word-creator', featureId: 'assistants' },
+      { id: 'ppt-creator', featureId: 'assistants' },
+      { id: 'excel-creator', featureId: 'assistants' },
+      { id: 'bare:632f31d2', featureId: 'assistants' },
+    ]);
+    expect(
+      Object.values(KI_BUDDY_PRODUCT_RESOURCE_REGISTRY.skill).map(({ id, backendName }) => ({ id, backendName }))
+    ).toEqual([
+      { id: 'builtin:officecli-docx', backendName: 'officecli-docx' },
+      { id: 'builtin:officecli-pptx', backendName: 'officecli-pptx' },
+      { id: 'builtin:officecli-xlsx', backendName: 'officecli-xlsx' },
+    ]);
+    expect(KI_BUDDY_PRODUCT_RESOURCE_REGISTRY.mcp).toEqual({});
   });
 
   it('shows stable product and Custom Assistants with manage access', () => {

--- a/tests/unit/renderer/services/runtime/kiBuddySkillCatalog.dom.test.ts
+++ b/tests/unit/renderer/services/runtime/kiBuddySkillCatalog.dom.test.ts
@@ -185,9 +185,9 @@ describe('projectProductSkillCatalog', () => {
       { name: 'skill-creator', origin: 'upstreamBuiltin', access: 'use' },
     ]);
     expect(result.hiddenResources).toEqual([
-      expect.objectContaining({ resourceId: 'builtin:mermaid/SKILL.md', origin: 'upstreamBuiltin' }),
+      expect.objectContaining({ resourceId: 'builtin:mermaid', origin: 'upstreamBuiltin' }),
       expect.objectContaining({
-        resourceId: 'builtin:auto-inject/aionui-config/SKILL.md',
+        resourceId: 'builtin:aionui-config',
         origin: 'upstreamBuiltin',
       }),
       expect.objectContaining({ resourceId: 'extension:extension-skill', origin: 'extension' }),
@@ -197,7 +197,7 @@ describe('projectProductSkillCatalog', () => {
     expect(result.hiddenResources[0]).not.toHaveProperty('description');
   });
 
-  it('does not identify a renamed built-in as an Office product resource by display name alone', () => {
+  it('identifies an Office product Skill by stable backend name instead of installation path', () => {
     const result = projectProductSkillCatalog(
       [
         {
@@ -213,10 +213,10 @@ describe('projectProductSkillCatalog', () => {
       createKiBuddyProductExperience(productConfig.experience)
     );
 
-    expect(result.entries).toEqual([]);
-    expect(result.hiddenResources).toEqual([
-      expect.objectContaining({ resourceId: 'builtin:other/SKILL.md', origin: 'upstreamBuiltin' }),
+    expect(result.entries).toEqual([
+      expect.objectContaining({ resourceId: 'builtin:officecli-docx', origin: 'productBuiltin' }),
     ]);
+    expect(result.hiddenResources).toEqual([]);
   });
 
   it('keeps the complete Skill catalog manageable when the Ki-Buddy capability is absent', () => {


### PR DESCRIPTION
# Pull Request

## Description

本 PR 完成 Ki-Buddy #51 的产品 seam 一致性整理：

- 将 feature、resource 与 lifecycle 的产品决策统一到 `ProductExperience` 及稳定 registry。
- 删除过渡期的重复导航、资源身份和 lifecycle 函数名名单。
- 将产品体验 contract 移入 Ki-Buddy runtime common 模块，runtime 与发布校验读取同一份 registry。
- 增加轻量一致性检查，验证 policy/contract 字段、稳定身份和 adapter/catalog 访问边界。
- 保留 AionUi capability 缺失路径与 Ki-Buddy 无效策略的安装完整性错误边界。
- 更新 ADR，明确 route/navigation/resource/lifecycle 行为由 unit/integration 验证，packaged 客户端矩阵由 #52 验收。

对开发者的影响：后续新增或开放产品能力时，需要先登记稳定 feature/resource 身份，再由对应 registry 投影；不再通过品牌文本、组件名或路径表达产品状态。

## Related Issues

- Closes #51
- Follow-up: #52

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 480 test files / 4149 tests passed; 1 file / 5 tests skipped by project configuration
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (本 PR 未新增用户可见硬编码文本)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

不适用。本 PR 不引入新的视觉界面。

## Additional Context

- `bun run package` 已通过；存在项目既有的 dynamic import、circular chunk 和 chunk size warning，没有构建错误。
- lint 输出 866 条项目既有 warning，0 error。
- 测试输出一次既有 `MaxListenersExceededWarning`，测试结果通过。
- 未执行 packaged Electron E2E；按 ADR 和更新后的 issue 职责，该验收属于 #52。
