### PR TITLE
test(ki-buddy): add packaged release matrix

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -287,7 +287,7 @@ jobs:
     name: Build Test (${{ matrix.platform }})
     if: github.event.action != 'closed' && github.event.pull_request.draft == false && inputs.skip_build_test != true
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -341,7 +341,7 @@ jobs:
         if: matrix.platform == 'linux-x64'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential python3 python3-pip pkg-config libsqlite3-dev fakeroot dpkg-dev rpm libnss3-dev libatk-bridge2.0-dev libdrm2 libxkbcommon-dev libxss1 libatspi2.0-dev libgtk-3-dev libxrandr2 libasound2-dev
+          sudo apt-get install -y build-essential python3 python3-pip pkg-config libsqlite3-dev fakeroot dpkg-dev rpm xvfb lsof dbus-x11 gnome-keyring libsecret-1-0 libnss3-dev libatk-bridge2.0-dev libdrm2 libxkbcommon-dev libxss1 libatspi2.0-dev libgtk-3-dev libxrandr2 libasound2-dev
 
       - name: Get Electron version
         id: electron-version
@@ -406,6 +406,7 @@ jobs:
           WindowsTargetPlatformVersion: 10.0.19041.0
           CI: true
           GH_TOKEN: ${{ github.token }}
+          AIONUI_BACKEND_SOURCE_POLICY: release-pinned
 
       - name: Build test (non-Windows)
         if: "!startsWith(matrix.platform, 'windows')"
@@ -425,6 +426,7 @@ jobs:
           npm_config_disturl: https://electronjs.org/headers
           CI: true
           GH_TOKEN: ${{ github.token }}
+          AIONUI_BACKEND_SOURCE_POLICY: release-pinned
 
       - name: Verify build artifacts exist
         shell: bash
@@ -457,6 +459,43 @@ jobs:
           node packages/shared-scripts/src/kiBuddyUnpacked.js \
             --platform "$PRODUCT_PLATFORM" \
             --path "out/${{ matrix.unpacked_dir }}"
+
+      - name: Build AionUi capability-absent E2E package
+        shell: bash
+        run: |
+          bunx electron-builder \
+            --config packages/desktop/electron-builder.yml \
+            --dir \
+            "${{ matrix.target }}" \
+            "--${{ matrix.arch }}" \
+            --publish=never \
+            --config.directories.output=out/aionui-e2e
+        env:
+          CI: true
+          ELECTRON_CACHE: ${{ runner.temp }}/.cache/electron
+          ELECTRON_BUILDER_CACHE: ${{ runner.temp }}/.cache/electron-builder
+
+      - name: Run packaged Ki-Buddy first-release matrix
+        shell: bash
+        run: |
+          if [ "${{ matrix.platform }}" = "linux-x64" ]; then
+            dbus-run-session -- bash -euo pipefail -c '
+              eval "$(printf "%s" "ki-buddy-e2e" | gnome-keyring-daemon --unlock --components=secrets)"
+              xvfb-run --auto-servernum bunx cross-env E2E_PACKAGED=1 playwright test --config playwright.config.ts tests/e2e/features/remote/ki-buddy/productMatrix.e2e.ts
+            '
+          else
+            bunx cross-env E2E_PACKAGED=1 playwright test --config playwright.config.ts tests/e2e/features/remote/ki-buddy/productMatrix.e2e.ts
+          fi
+
+      - name: Upload packaged E2E failure evidence
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ki-buddy-packaged-e2e-${{ matrix.platform }}
+          path: |
+            tests/e2e/report/
+            tests/e2e/results/
+          if-no-files-found: warn
 
       - name: Silent install smoke test (Windows x64)
         if: matrix.platform == 'windows-x64'

--- a/packages/desktop/src/common/types/platform/electron.ts
+++ b/packages/desktop/src/common/types/platform/electron.ts
@@ -85,6 +85,10 @@ declare global {
   interface Window {
     electronAPI?: ElectronBridgeAPI;
     __getKiBuddyProductBootstrap?: () => import('./kiBuddyProduct').KiBuddyProductBootstrap;
+    __getE2EUiObserverState?: () => {
+      selectors: string[];
+      violations: Array<{ html: string; selector: string }>;
+    };
     __kiBuddyProductBootstrapError?: string | null;
     __kiBuddyProductPresentation?: KiBuddyProductCapability | null;
     __initialLanguage?: string | null;

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -38,6 +38,7 @@ import { setupApplicationMenu } from './process/utils/appMenu';
 import { startWebHost } from '@aionui/web-host';
 import { initializeZoomFactor, setupZoomForWindow } from './process/utils/zoom';
 import { hydrateWindowsProcessPath } from './process/startup/windowsPath';
+import { appendRendererQuery, resolveE2ERendererQuery } from './process/startup/rendererLoadTarget';
 import {
   MIN_WINDOW_WIDTH,
   MIN_WINDOW_HEIGHT,
@@ -99,6 +100,17 @@ import electronSquirrelStartup from 'electron-squirrel-startup';
 // When a second instance starts (e.g. from protocol URL), it sends its data
 // to the first instance via second-instance event, then quits.
 const isE2ETestMode = process.env.AIONUI_E2E_TEST === '1';
+const e2eStartedMainProductLifecycles: string[] = [];
+if (isE2ETestMode) {
+  const e2eGlobal = globalThis as typeof globalThis & {
+    __aionuiE2EStartedMainProductLifecycles?: () => string[];
+  };
+  e2eGlobal.__aionuiE2EStartedMainProductLifecycles = () => [...e2eStartedMainProductLifecycles];
+}
+
+const recordE2EStartedMainProductLifecycle = (lifecycleId: string): void => {
+  if (isE2ETestMode) e2eStartedMainProductLifecycles.push(lifecycleId);
+};
 const skipSingleInstanceLock = isE2ETestMode || process.env.AIONUI_MULTI_INSTANCE === '1';
 const packagedKiBuddyRuntime = readKiBuddyRuntimeIdentity(app.getAppPath());
 const selectedProtocolScheme = packagedKiBuddyRuntime
@@ -624,18 +636,25 @@ const createWindow = ({ showOnReady = true }: { showOnReady?: boolean } = {}): v
   // Load the renderer: dev server URL in development, built HTML file in production
   const rendererUrl = process.env['ELECTRON_RENDERER_URL'];
   const fallbackFile = path.join(__dirname, '../renderer/index.html');
+  const rendererQuery = resolveE2ERendererQuery(process.env);
+  const loadRendererFile = () =>
+    mainWindow.loadFile(fallbackFile, rendererQuery ? { query: rendererQuery } : undefined);
+  const loadRenderer = () =>
+    !app.isPackaged && rendererUrl
+      ? mainWindow.loadURL(appendRendererQuery(rendererUrl, rendererQuery))
+      : loadRendererFile();
 
   if (!app.isPackaged && rendererUrl) {
     console.log(`[AionUi] Loading renderer URL: ${rendererUrl}`);
-    mainWindow.loadURL(rendererUrl).catch((error) => {
+    loadRenderer().catch((error) => {
       console.error('[AionUi] loadURL failed, falling back to file:', error.message || error);
-      mainWindow.loadFile(fallbackFile).catch((e2) => {
+      loadRendererFile().catch((e2) => {
         console.error('[AionUi] loadFile fallback also failed:', e2.message || e2);
       });
     });
   } else {
     console.log(`[AionUi] Loading renderer file: ${fallbackFile}`);
-    mainWindow.loadFile(fallbackFile).catch((error) => {
+    loadRenderer().catch((error) => {
       console.error('[AionUi] loadFile failed:', error.message || error);
     });
   }
@@ -653,15 +672,9 @@ const createWindow = ({ showOnReady = true }: { showOnReady?: boolean } = {}): v
     if (!mainWindow.isDestroyed()) {
       console.log('[AionUi] Attempting to recover from renderer crash by reloading...');
 
-      if (!app.isPackaged && rendererUrl) {
-        mainWindow.loadURL(rendererUrl).catch((error) => {
-          console.error('[AionUi] Recovery loadURL failed:', error.message || error);
-        });
-      } else {
-        mainWindow.loadFile(fallbackFile).catch((error) => {
-          console.error('[AionUi] Recovery loadFile failed:', error.message || error);
-        });
-      }
+      loadRenderer().catch((error) => {
+        console.error('[AionUi] Recovery renderer load failed:', error.message || error);
+      });
     }
   });
 
@@ -1058,6 +1071,7 @@ const handleAppReady = async (): Promise<void> => {
     if (productExperience) {
       startMainProductLifecyclePhase(productExperience, 'desktopReady', {
         desktopPet: () => {
+          recordE2EStartedMainProductLifecycle('desktopPet');
           setTimeout(() => {
             void (async () => {
               try {
@@ -1077,6 +1091,7 @@ const handleAppReady = async (): Promise<void> => {
           }, 3000);
         },
         webUi: () => {
+          recordE2EStartedMainProductLifecycle('webUi');
           if (isE2ETestMode) return;
           // 窗口创建后异步恢复 WebUI，不阻塞 UI / Restore WebUI async after window creation, non-blocking
           restoreDesktopWebUIFromPreferences().catch((error) => {

--- a/packages/desktop/src/process/startup/rendererLoadTarget.ts
+++ b/packages/desktop/src/process/startup/rendererLoadTarget.ts
@@ -1,0 +1,28 @@
+export const E2E_FORBIDDEN_SELECTORS_QUERY_KEY = 'aionui-e2e-forbidden-selectors';
+
+type E2ERendererEnvironment = Readonly<{
+  AIONUI_E2E_FORBIDDEN_SELECTORS?: string;
+  AIONUI_E2E_TEST?: string;
+}>;
+
+/** Builds the test-only renderer query after validating the selector contract in the main process. */
+export function resolveE2ERendererQuery(environment: E2ERendererEnvironment): Record<string, string> | undefined {
+  const serializedSelectors = environment.AIONUI_E2E_FORBIDDEN_SELECTORS;
+  if (environment.AIONUI_E2E_TEST !== '1' || !serializedSelectors) return undefined;
+
+  const parsedSelectors: unknown = JSON.parse(serializedSelectors);
+  if (!Array.isArray(parsedSelectors) || !parsedSelectors.every((selector) => typeof selector === 'string')) {
+    throw new Error('AIONUI_E2E_FORBIDDEN_SELECTORS must be a JSON string array');
+  }
+
+  return { [E2E_FORBIDDEN_SELECTORS_QUERY_KEY]: JSON.stringify(parsedSelectors) };
+}
+
+/** Adds renderer query values without replacing an existing development-server query string. */
+export function appendRendererQuery(rendererUrl: string, query: Readonly<Record<string, string>> | undefined): string {
+  if (!query) return rendererUrl;
+
+  const target = new URL(rendererUrl);
+  for (const [key, value] of Object.entries(query)) target.searchParams.set(key, value);
+  return target.toString();
+}

--- a/packages/desktop/src/process/utils/tray.ts
+++ b/packages/desktop/src/process/utils/tray.ts
@@ -25,6 +25,21 @@ let cachedActiveCount = 0;
 let trayBrand = { iconPath: 'app.png', productName: 'AionUi' };
 let desktopPetTrayEnabled = true;
 
+export type TrayMenuSnapshotItem = Readonly<{
+  label?: string;
+  submenu?: Readonly<{ items: readonly TrayMenuSnapshotItem[] }> | null;
+}>;
+
+/** Flattens tray labels into paths so packaged tests can attest optional contributions. */
+export function collectTrayMenuLabels(items: readonly TrayMenuSnapshotItem[], parentLabel = ''): string[] {
+  return items.flatMap((item) => {
+    const label = item.label?.trim() ?? '';
+    const pathLabel = label ? (parentLabel ? `${parentLabel} > ${label}` : label) : parentLabel;
+    const nestedLabels = item.submenu ? collectTrayMenuLabels(item.submenu.items, pathLabel) : [];
+    return [...(label ? [pathLabel] : []), ...nestedLabels];
+  });
+}
+
 /** Replaces the upstream product name in tray locale text with the selected product name. */
 export function formatTrayBrandText(text: string, productName: string): string {
   return text.replaceAll('AionUi', productName);
@@ -273,6 +288,13 @@ export const buildTrayContextMenu = async (): Promise<Electron.Menu> => {
 
   return Menu.buildFromTemplate(template);
 };
+
+if (process.env.AIONUI_E2E_TEST === '1') {
+  const e2eGlobal = globalThis as typeof globalThis & {
+    __aionuiE2ETrayMenuLabels?: () => Promise<string[]>;
+  };
+  e2eGlobal.__aionuiE2ETrayMenuLabels = async () => collectTrayMenuLabels((await buildTrayContextMenu()).items);
+}
 
 /**
  * Create system tray (idempotent — no-op if already exists).

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/AppearanceModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/AppearanceModalContent.tsx
@@ -67,7 +67,10 @@ const AppearanceModalContent: React.FC = () => {
         <div className='space-y-16px'>
           {/* 主题画廊 / Theme Gallery */}
           {showThemeSettings && (
-            <div className='px-16px md:px-24px lg:px-28px py-14px md:py-16px bg-2 rd-16px'>
+            <div
+              data-product-features='themeCustomEditor themeMarketplace themePresets'
+              className='px-16px md:px-24px lg:px-28px py-14px md:py-16px bg-2 rd-16px'
+            >
               <div className='text-14px text-t-primary leading-22px mb-12px'>{t('settings.theme')}</div>
               <CssThemeSettings capabilities={themeCapabilities} />
             </div>

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
@@ -346,6 +346,7 @@ const ModelModalContent: React.FC = () => {
         {t('settings.clearStatus')}
       </Button>
       <TalkToButlerButton
+        data-testid='model-add'
         label={t('settings.addModel')}
         chatLabel={t('settings.talkToButler.addViaChat', { defaultValue: 'Add via chat' })}
         onManual={() => addPlatformModalCtrl.open()}
@@ -429,6 +430,10 @@ const ModelModalContent: React.FC = () => {
               const isExpanded = collapseKey[platform.id] ?? false;
               return (
                 <Collapse
+                  data-testid={`model-provider-${platform.id}`}
+                  data-product-resource-id={platform.id}
+                  data-product-resource-origin='custom'
+                  data-product-resource-access='manage'
                   activeKey={isExpanded ? ['image-generation'] : []}
                   onChange={(_, activeKeys) => {
                     const expanded = activeKeys.includes('image-generation');
@@ -488,6 +493,7 @@ const ModelModalContent: React.FC = () => {
                           />
                           <div className='flex items-center gap-4px'>
                             <Button
+                              data-testid={`model-provider-add-${platform.id}`}
                               size='mini'
                               className='model-provider-action-btn !w-28px !h-28px !min-w-28px text-t-secondary hover:text-t-primary'
                               icon={<Plus size='14' />}
@@ -498,12 +504,14 @@ const ModelModalContent: React.FC = () => {
                               onOk={() => removePlatform(platform.id)}
                             >
                               <Button
+                                data-testid={`model-provider-delete-${platform.id}`}
                                 size='mini'
                                 className='model-provider-action-btn !w-28px !h-28px !min-w-28px text-t-secondary hover:text-t-primary'
                                 icon={<Minus size='14' />}
                               />
                             </Popconfirm>
                             <Button
+                              data-testid={`model-provider-edit-${platform.id}`}
                               size='mini'
                               className='model-provider-action-btn !w-28px !h-28px !min-w-28px text-t-secondary hover:text-t-primary'
                               icon={<Write size='14' />}
@@ -525,7 +533,12 @@ const ModelModalContent: React.FC = () => {
 
                       return (
                         <div key={model}>
-                          <div className='flex items-center justify-between gap-8px px-8px py-12px transition-colors hover:bg-[var(--fill-0)]'>
+                          <div
+                            data-product-resource-id={`provider:${platform.id}/model:${model}`}
+                            data-product-resource-origin='custom'
+                            data-product-resource-access='manage'
+                            className='flex items-center justify-between gap-8px px-8px py-12px transition-colors hover:bg-[var(--fill-0)]'
+                          >
                             <div className='flex min-w-0 flex-1 items-center gap-8px'>
                               {/* 健康状态指示器 / Health status indicator */}
                               {healthStatus !== 'unknown' && (

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
@@ -172,6 +172,7 @@ const ModalMcpManagementSection: React.FC<{
   const renderAddButton = () => {
     return (
       <TalkToButlerButton
+        data-testid='mcp-add'
         label={t('settings.mcpAddServer')}
         chatLabel={t('settings.talkToButler.addViaChat', { defaultValue: 'Add via chat' })}
         prompt={t('settings.talkToButler.prompt.addMcp', { defaultValue: 'Help me set up an MCP server.' })}
@@ -215,11 +216,12 @@ const ModalMcpManagementSection: React.FC<{
             disableOverflow={isPageMode}
           >
             <div className='space-y-12px'>
-              {visibleMcpEntries.map(({ server, access }) => (
+              {visibleMcpEntries.map(({ server, access, origin }) => (
                 <McpServerItem
                   key={server.id}
                   server={server}
                   access={access}
+                  origin={origin}
                   isCollapsed={mcpCollapseKey[server.id] || false}
                   isTestingConnection={testingServers[server.id] || false}
                   oauthStatus={oauthStatus[server.id]}
@@ -231,11 +233,12 @@ const ModalMcpManagementSection: React.FC<{
                   onOAuthLogin={handleOAuthLogin}
                 />
               ))}
-              {extensionMcpCatalogEntries.map(({ server, access }) => (
+              {extensionMcpCatalogEntries.map(({ server, access, origin }) => (
                 <McpServerItem
                   key={server.id}
                   server={server}
                   access={access}
+                  origin={origin}
                   isCollapsed={mcpCollapseKey[server.id] || false}
                   isTestingConnection={false}
                   onToggleCollapse={() => toggleServerCollapse(server.id)}

--- a/packages/desktop/src/renderer/index.html
+++ b/packages/desktop/src/renderer/index.html
@@ -14,6 +14,50 @@
     <link rel="apple-touch-icon" href="./pwa/icon-180.png" />
     <title>AionUi</title>
     <script>
+      // Test-only first-frame observer. The main process supplies selectors in the renderer URL;
+      // this runs before React and keeps DOM access inside the renderer process.
+      (function () {
+        var serializedSelectors = new URLSearchParams(window.location.search).get('aionui-e2e-forbidden-selectors');
+        if (!serializedSelectors) return;
+
+        var selectors = JSON.parse(serializedSelectors);
+        if (
+          !Array.isArray(selectors) ||
+          !selectors.every(function (selector) {
+            return typeof selector === 'string';
+          })
+        ) {
+          throw new Error('aionui-e2e-forbidden-selectors must contain a JSON string array');
+        }
+
+        var violations = [];
+        var inspect = function (root) {
+          selectors.forEach(function (selector) {
+            var matches = [];
+            if (root instanceof Element && root.matches(selector)) matches.push(root);
+            root.querySelectorAll(selector).forEach(function (match) {
+              matches.push(match);
+            });
+            matches.forEach(function (match) {
+              violations.push({ selector: selector, html: match.outerHTML.slice(0, 500) });
+            });
+          });
+        };
+
+        window.__getE2EUiObserverState = function () {
+          return { selectors: selectors.slice(), violations: violations.slice() };
+        };
+        inspect(document);
+        new MutationObserver(function (records) {
+          records.forEach(function (record) {
+            record.addedNodes.forEach(function (node) {
+              if (node instanceof Element) inspect(node);
+            });
+          });
+        }).observe(document, { childList: true, subtree: true });
+      })();
+    </script>
+    <script>
       // Restore appearance and explicit product presentation before the first business frame.
       (function () {
         try {

--- a/packages/desktop/src/renderer/pages/guid/components/QuickActionButtons.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/QuickActionButtons.tsx
@@ -98,6 +98,7 @@ const WebuiQuickAction: React.FC<WebuiQuickActionProps> = ({ onHoverChange, styl
 
   return (
     <div
+      data-product-feature='guidWebUi'
       className='group inline-flex items-center justify-center h-36px min-w-36px max-w-36px px-0 rd-999px bg-fill-0 cursor-pointer overflow-hidden whitespace-nowrap hover:max-w-200px hover:px-14px hover:justify-start hover:gap-8px transition-[max-width,padding,border-radius,box-shadow] duration-420 ease-in-out'
       style={style}
       onMouseEnter={() => onHoverChange(true)}
@@ -154,6 +155,7 @@ const QuickActionButtons: React.FC<QuickActionButtonsProps> = ({
       <div className='flex justify-center items-center gap-24px'>
         {feedbackEnabled && (
           <div
+            data-product-feature='guidFeedback'
             className='group inline-flex items-center justify-center h-36px min-w-36px max-w-36px px-0 rd-999px bg-fill-0 cursor-pointer overflow-hidden whitespace-nowrap hover:max-w-170px hover:px-14px hover:justify-start hover:gap-8px transition-[max-width,padding,border-radius,box-shadow] duration-420 ease-in-out'
             style={quickActionStyle(hoveredQuickAction === 'bugReport')}
             onMouseEnter={() => setHoveredQuickAction('bugReport')}
@@ -183,6 +185,7 @@ const QuickActionButtons: React.FC<QuickActionButtonsProps> = ({
         )}
         {githubStarEnabled && (
           <div
+            data-product-feature='guidGithubStar'
             className='group inline-flex items-center justify-center h-36px min-w-36px max-w-36px px-0 rd-999px bg-fill-0 cursor-pointer overflow-hidden whitespace-nowrap hover:max-w-150px hover:px-14px hover:justify-start hover:gap-8px transition-[max-width,padding,border-radius,box-shadow] duration-420 ease-in-out'
             style={quickActionStyle(hoveredQuickAction === 'repo')}
             onMouseEnter={() => setHoveredQuickAction('repo')}

--- a/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpManagement.tsx
+++ b/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpManagement.tsx
@@ -173,11 +173,12 @@ const McpManagement: React.FC<McpManagementProps> = ({ message }) => {
           {visibleMcpEntries.length === 0 && extensionMcpCatalogEntries.length === 0 ? (
             <div className='py-8 text-center text-t-secondary'>{t('settings.mcpNoServersFound')}</div>
           ) : (
-            visibleMcpEntries.map(({ server, access }) => (
+            visibleMcpEntries.map(({ server, access, origin }) => (
               <McpServerItem
                 key={server.id}
                 server={server}
                 access={access}
+                origin={origin}
                 isCollapsed={mcpCollapseKey[server.id] || false}
                 isTestingConnection={testingServers[server.id] || false}
                 oauthStatus={oauthStatus[server.id]}
@@ -190,11 +191,12 @@ const McpManagement: React.FC<McpManagementProps> = ({ message }) => {
               />
             ))
           )}
-          {extensionMcpCatalogEntries.map(({ server, access }) => (
+          {extensionMcpCatalogEntries.map(({ server, access, origin }) => (
             <McpServerItem
               key={server.id}
               server={server}
               access={access}
+              origin={origin}
               isCollapsed={mcpCollapseKey[server.id] || false}
               isTestingConnection={false}
               onToggleCollapse={() => toggleServerCollapse(server.id)}

--- a/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpServerHeader.tsx
+++ b/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpServerHeader.tsx
@@ -196,6 +196,7 @@ const McpServerHeader: React.FC<McpServerHeaderProps> = ({
         )}
         {canTest && (!needsLogin || access === 'use') && (
           <Button
+            data-testid={`mcp-test-${server.id}`}
             size='mini'
             icon={<Refresh size={'14'} />}
             title={t('settings.mcpTestConnection')}
@@ -211,13 +212,17 @@ const McpServerHeader: React.FC<McpServerHeaderProps> = ({
               trigger='hover'
               droplist={
                 <Menu>
-                  <Menu.Item key='edit' onClick={() => onEditServer(server)}>
+                  <Menu.Item data-testid={`mcp-edit-${server.id}`} key='edit' onClick={() => onEditServer(server)}>
                     <div className='flex items-center gap-2'>
                       <Write size={'14'} />
                       {t('settings.mcpEditServer')}
                     </div>
                   </Menu.Item>
-                  <Menu.Item key='delete' onClick={() => onDeleteServer(server.id)}>
+                  <Menu.Item
+                    data-testid={`mcp-delete-${server.id}`}
+                    key='delete'
+                    onClick={() => onDeleteServer(server.id)}
+                  >
                     <div className='flex items-center gap-2 text-red-500'>
                       <DeleteFour size={'14'} />
                       {t('settings.mcpDeleteServer')}
@@ -226,7 +231,7 @@ const McpServerHeader: React.FC<McpServerHeaderProps> = ({
                 </Menu>
               }
             >
-              <Button size='mini' icon={<SettingOne size={'14'} />} />
+              <Button data-testid={`mcp-manage-${server.id}`} size='mini' icon={<SettingOne size={'14'} />} />
             </Dropdown>
           )}
         </div>

--- a/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpServerItem.tsx
+++ b/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpServerItem.tsx
@@ -4,11 +4,12 @@ import type { IMcpServer } from '@/common/config/storage';
 import McpServerHeader from './McpServerHeader';
 import McpServerToolsList from './McpServerToolsList';
 import type { McpOAuthStatus } from '@/renderer/hooks/mcp/useMcpOAuth';
-import type { ProductResourceAccess } from '@/common/platform/ki-buddy';
+import type { ProductResourceAccess, ProductResourceOrigin } from '@/common/platform/ki-buddy';
 
 interface McpServerItemProps {
   server: IMcpServer;
   access?: ProductResourceAccess;
+  origin?: ProductResourceOrigin;
   isCollapsed: boolean;
   isTestingConnection: boolean;
   oauthStatus?: McpOAuthStatus;
@@ -25,6 +26,7 @@ interface McpServerItemProps {
 const McpServerItem: React.FC<McpServerItemProps> = ({
   server,
   access,
+  origin,
   isCollapsed,
   isTestingConnection,
   oauthStatus,
@@ -39,6 +41,9 @@ const McpServerItem: React.FC<McpServerItemProps> = ({
   return (
     <Collapse
       key={server.id}
+      data-product-resource-id={server.id}
+      data-product-resource-origin={origin}
+      data-product-resource-access={access}
       activeKey={isCollapsed ? ['1'] : []}
       onChange={onToggleCollapse}
       className='mb-4 [&_div.arco-collapse-item-header-title]:flex-1'

--- a/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
@@ -425,7 +425,12 @@ const AddPlatformModal = ModalHOC<{
     >
       {messageContext}
       <div>
-        <Form form={form} layout='vertical' className='[&_.arco-form-item]:mb-12px [&_.arco-form-item:last-child]:mb-0'>
+        <Form
+          data-testid='model-provider-create-form'
+          form={form}
+          layout='vertical'
+          className='[&_.arco-form-item]:mb-12px [&_.arco-form-item:last-child]:mb-0'
+        >
           {/* 模型平台选择（第一层）/ Model Platform Selection (first level) */}
           <Form.Item
             initialValue={DEFAULT_PLATFORM_VALUE}
@@ -435,6 +440,7 @@ const AddPlatformModal = ModalHOC<{
             rules={[{ required: true }]}
           >
             <Select
+              data-testid='model-provider-platform'
               showSearch
               filterOption={(inputValue, option) => {
                 const optionValue = (option as React.ReactElement<{ value?: string }>)?.props?.value;
@@ -497,6 +503,7 @@ const AddPlatformModal = ModalHOC<{
             rules={[{ required: isCustom || isNewApi }]}
           >
             <Input
+              data-testid='model-provider-base-url'
               placeholder={
                 isFullUrl
                   ? 'https://your-api-endpoint.com/v1/chat/completions'
@@ -551,6 +558,7 @@ const AddPlatformModal = ModalHOC<{
             }
           >
             <Input
+              data-testid='model-provider-api-key'
               onBlur={() => {
                 void modelListState.mutate();
               }}
@@ -644,6 +652,7 @@ const AddPlatformModal = ModalHOC<{
             }
           >
             <Select
+              data-testid='model-provider-models'
               mode='multiple'
               loading={!isFullUrl && modelListState.isLoading}
               showSearch

--- a/packages/desktop/src/renderer/pages/settings/components/EditModeModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/EditModeModal.tsx
@@ -184,7 +184,7 @@ const EditModeModal = ModalHOC<{ data?: IProvider; onChange(data: IProvider): vo
       >
         {messageContext}
         <div>
-          <Form form={form} layout='vertical'>
+          <Form data-testid='model-provider-edit-form' form={form} layout='vertical'>
             {/* 模型供应商名称（可编辑，带 Logo）/ Model Provider name (editable, with Logo) */}
             <Form.Item
               label={
@@ -197,7 +197,7 @@ const EditModeModal = ModalHOC<{ data?: IProvider; onChange(data: IProvider): vo
               required
               rules={[{ required: true }]}
             >
-              <Input placeholder={t('settings.modelProvider')} />
+              <Input data-testid='model-provider-name' placeholder={t('settings.modelProvider')} />
             </Form.Item>
 
             {/* Base URL */}

--- a/packages/desktop/src/renderer/pages/settings/components/JsonImportModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/JsonImportModal.tsx
@@ -343,7 +343,7 @@ const JsonImportModal: React.FC<JsonImportModalProps> = ({ visible, server, onCa
               content={validation.errorMessage || t('settings.mcpJsonFormatError') || 'JSON format error'}
             />
           )}
-          <div className='relative'>
+          <div data-testid='mcp-json-editor' className='relative'>
             <CodeMirror
               value={jsonInput}
               height='300px'

--- a/packages/shared-scripts/src/kiBuddyRelease.js
+++ b/packages/shared-scripts/src/kiBuddyRelease.js
@@ -1,3 +1,4 @@
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
@@ -10,6 +11,7 @@ const KI_BUDDY_PRODUCT = 'Ki-Buddy';
 const KI_BUDDY_REPOSITORY = 'xlihub/Ki-Buddy';
 const AION_UI_REPOSITORY = 'iOfficeAI/AionUi';
 const PRODUCT_CONFIG_FILE = 'ki-buddy-product.json';
+const PRODUCT_EXPERIENCE_REGISTRY_FILE = 'packages/desktop/src/common/platform/ki-buddy/experience/registry.json';
 const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const PACKAGE_VERSION_PATTERN =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
@@ -324,6 +326,92 @@ function readProductConfig(projectRoot) {
   return config;
 }
 
+function sha256File(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function createSourceStateSha256(projectRoot) {
+  const hash = crypto.createHash('sha256');
+  hash.update(
+    execFileSync('git', ['diff', '--binary', 'HEAD', '--'], {
+      cwd: projectRoot,
+      encoding: 'buffer',
+      maxBuffer: 100 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  );
+  const untrackedFiles = execFileSync('git', ['ls-files', '--others', '--exclude-standard', '-z'], {
+    cwd: projectRoot,
+    encoding: 'buffer',
+    maxBuffer: 100 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+    .toString('utf8')
+    .split('\0')
+    .filter(Boolean)
+    .toSorted();
+  for (const relativePath of untrackedFiles) {
+    hash.update(`untracked\0${relativePath}\0`);
+    const filePath = path.join(projectRoot, relativePath);
+    const stats = fs.lstatSync(filePath);
+    hash.update(stats.isSymbolicLink() ? fs.readlinkSync(filePath) : fs.readFileSync(filePath));
+    hash.update('\0');
+  }
+  return hash.digest('hex');
+}
+
+/** Writes immutable evidence tying one packaged client to its product policy sources and source commit. */
+function createKiBuddyBuildEvidence(projectRoot, outputPath, options = {}) {
+  const productConfig = readProductConfig(projectRoot);
+  const sourceCommit = String(
+    options.commit ||
+      execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: projectRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+  ).trim();
+  if (!SHA40_PATTERN.test(sourceCommit)) {
+    throw new Error('Ki-Buddy build evidence requires a full lowercase source commit SHA');
+  }
+  const sourceTreeDirty =
+    options.dirty ??
+    Boolean(
+      execFileSync('git', ['status', '--porcelain', '--untracked-files=all'], {
+        cwd: projectRoot,
+        encoding: 'utf8',
+        maxBuffer: 100 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).trim()
+    );
+  const sourceStateSha256 = options.sourceStateSha256 || createSourceStateSha256(projectRoot);
+
+  const evidence = {
+    schemaVersion: 1,
+    product: {
+      runtimeIdentity: productConfig.runtimeIdentity,
+      productName: productConfig.brand.productName,
+    },
+    sourceCommit,
+    sourceTreeDirty,
+    sourceStateSha256,
+    policySources: {
+      productConfig: {
+        path: PRODUCT_CONFIG_FILE,
+        sha256: sha256File(path.join(projectRoot, PRODUCT_CONFIG_FILE)),
+      },
+      experienceRegistry: {
+        path: PRODUCT_EXPERIENCE_REGISTRY_FILE,
+        sha256: sha256File(path.join(projectRoot, PRODUCT_EXPERIENCE_REGISTRY_FILE)),
+      },
+    },
+  };
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+  return evidence;
+}
+
 function createEffectivePackageJson(projectRoot, options = {}) {
   const upstreamPackage = readJson(path.join(projectRoot, 'package.json'), 'AionUi package.json');
   const productConfig = readProductConfig(projectRoot);
@@ -364,6 +452,12 @@ function createElectronBuilderConfig(projectRoot, outputPath, options = {}) {
       to: productConfig.assets.packaged.icon,
     });
   }
+  const buildEvidencePath = path.join(path.dirname(outputPath), 'ki-buddy-build-evidence.json');
+  createKiBuddyBuildEvidence(projectRoot, buildEvidencePath, { commit: options.commit });
+  productExtraResources.push({
+    from: buildEvidencePath,
+    to: 'ki-buddy-build-evidence.json',
+  });
   const config = {
     ...upstreamBuilderConfig,
     ...productConfig.electronBuilder,
@@ -656,6 +750,8 @@ if (require.main === module) {
 }
 
 module.exports = {
+  createSourceStateSha256,
+  createKiBuddyBuildEvidence,
   createEffectivePackageJson,
   createElectronBuilderConfig,
   extractReleaseNotes,

--- a/tests/e2e/features/remote/ki-buddy/fakeAgentsServer.ts
+++ b/tests/e2e/features/remote/ki-buddy/fakeAgentsServer.ts
@@ -1,0 +1,55 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+export const MATRIX_TEST_USER = {
+  email: 'ki-buddy-matrix@example.com',
+  name: 'Ki-Buddy Matrix User',
+  orgName: 'Ki-Buddy E2E',
+  phone: '10086',
+  roles: [{ name: 'member' }],
+  token: 'ki-buddy-matrix-token',
+  userName: 'ki-buddy-matrix',
+  uuid: 'ki-buddy-matrix-user',
+} as const;
+
+export async function startMatrixAgentsServer(): Promise<{
+  baseUrl: string;
+  close: () => Promise<void>;
+}> {
+  const server = http.createServer((request, response) => {
+    const isLogin = request.method === 'POST' && request.url === '/kagent/login';
+    const isValidation = request.method === 'POST' && request.url === '/kagent/system/user/validateToken';
+    const authenticated = request.headers.authorization === `Bearer ${MATRIX_TEST_USER.token}`;
+
+    if (!isLogin && !isValidation) {
+      response.writeHead(404).end();
+      return;
+    }
+    if (isValidation && !authenticated) {
+      response.writeHead(401).end();
+      return;
+    }
+
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.end(
+      JSON.stringify({
+        errorCode: 0,
+        responseBody: {
+          ...MATRIX_TEST_USER,
+          ...(isValidation ? { token: undefined } : {}),
+        },
+      })
+    );
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve()))),
+  };
+}

--- a/tests/e2e/features/remote/ki-buddy/firstReleaseMatrix.ts
+++ b/tests/e2e/features/remote/ki-buddy/firstReleaseMatrix.ts
@@ -1,0 +1,114 @@
+/**
+ * Approved Ki-Buddy v1 launch matrix.
+ *
+ * This file is deliberately independent from ki-buddy-product.json and the
+ * runtime registry. Those files are test inputs; importing either here would
+ * let a bad policy change its own expected result.
+ */
+export const FIRST_RELEASE_MATRIX = {
+  backend: {
+    repository: 'xlihub/Ki-Core',
+    tag: 'ki-core-v0.1.0',
+    commit: '209e6844d39bac0762c61e198c1ba3a007f9dd2e',
+  },
+  features: {
+    account: 'enabled',
+    agents: 'enabled',
+    appearance: 'enabled',
+    assistants: 'enabled',
+    channels: 'disabled',
+    componentShowcase: 'disabled',
+    conversation: 'enabled',
+    desktopPet: 'disabled',
+    extensionMarketplace: 'disabled',
+    extensionRuntime: 'disabled',
+    extensionSettings: 'disabled',
+    guid: 'enabled',
+    guidFeedback: 'disabled',
+    guidGithubStar: 'disabled',
+    guidWebUi: 'disabled',
+    models: 'enabled',
+    scheduledTasks: 'enabled',
+    skills: 'enabled',
+    system: 'enabled',
+    team: 'disabled',
+    themeCustomEditor: 'disabled',
+    themeMarketplace: 'disabled',
+    themePresets: 'disabled',
+    tools: 'enabled',
+    webUi: 'disabled',
+  },
+  resources: {
+    agent: {
+      productBuiltin: 'use',
+      upstreamBuiltin: 'hidden',
+      custom: 'manage',
+      extension: 'hidden',
+      unclassified: 'hidden',
+    },
+    assistant: {
+      productBuiltin: 'manage',
+      upstreamBuiltin: 'hidden',
+      custom: 'manage',
+      extension: 'hidden',
+      unclassified: 'hidden',
+    },
+    model: {
+      productBuiltin: 'manage',
+      upstreamBuiltin: 'manage',
+      custom: 'manage',
+      extension: 'hidden',
+      unclassified: 'hidden',
+    },
+    skill: {
+      productBuiltin: 'use',
+      upstreamBuiltin: 'hidden',
+      custom: 'manage',
+      extension: 'hidden',
+      unclassified: 'hidden',
+    },
+    mcp: {
+      productBuiltin: 'use',
+      upstreamBuiltin: 'hidden',
+      custom: 'manage',
+      extension: 'hidden',
+      unclassified: 'hidden',
+    },
+  },
+  behaviorDefaults: {
+    scheduledTaskExecutor: 'assistant',
+    autoInjectedSkillExclusions: ['aionui-config'],
+  },
+  workspaceEntries: ['newConversation', 'assistants', 'scheduledTasks'],
+  settingsEntries: ['account', 'agent', 'model', 'skills', 'tools', 'appearance', 'system', 'about'],
+  disabledWorkspaceRoutes: ['/team/e2e-disabled', '/test/components'],
+  disabledSettingsRoutes: ['/settings/webui', '/settings/pet', '/settings/ext/e2e-disabled'],
+  disabledFeatureEvidence: {
+    flashObserved: {
+      channels: ['[data-webui-tab="channels"]'],
+      desktopPet: ['[data-settings-id="pet"]'],
+      extensionRuntime: ['[data-testid="extension-skills-section"]'],
+      extensionSettings: ['[data-settings-path^="ext/"]'],
+      guidFeedback: ['[data-product-feature="guidFeedback"]'],
+      guidGithubStar: ['[data-product-feature="guidGithubStar"]'],
+      guidWebUi: ['[data-product-feature="guidWebUi"]'],
+      team: ['[data-testid="team-section-toggle"]', '[data-testid="team-create-btn"]'],
+      themeCustomEditor: ['[data-product-features~="themeCustomEditor"]'],
+      themeMarketplace: ['[data-product-features~="themeMarketplace"]'],
+      themePresets: ['[data-product-features~="themePresets"]'],
+      webUi: ['[data-settings-id="webui"]'],
+    },
+    routeOnly: {
+      componentShowcase: ['/test/components'],
+    },
+    runtimeOnly: {
+      extensionMarketplace: ['extensions.get-loaded-extensions'],
+    },
+  },
+  productResources: {
+    agents: ['632f31d2'],
+    assistants: ['word-creator', 'ppt-creator', 'excel-creator', 'bare:632f31d2'],
+    skills: ['officecli-docx', 'officecli-pptx', 'officecli-xlsx'],
+    mcp: [],
+  },
+} as const;

--- a/tests/e2e/features/remote/ki-buddy/packagedApp.ts
+++ b/tests/e2e/features/remote/ki-buddy/packagedApp.ts
@@ -1,0 +1,141 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { _electron as electron } from 'playwright';
+import { createE2EEnvironment, resolveMainWindow, resolvePackagedApp, type PackagedApp } from '../../../fixtures';
+import { FIRST_RELEASE_MATRIX } from './firstReleaseMatrix';
+
+const { createSourceStateSha256 } = require('../../../../../packages/shared-scripts/src/kiBuddyRelease.js') as {
+  createSourceStateSha256: (root: string) => string;
+};
+
+export type ProductBuildEvidence = Readonly<{
+  schemaVersion: 1;
+  product: Readonly<{
+    productName: string;
+    runtimeIdentity: string;
+  }>;
+  sourceCommit: string;
+  sourceStateSha256: string;
+  sourceTreeDirty: boolean;
+  policySources: Readonly<{
+    experienceRegistry: Readonly<{ path: string; sha256: string }>;
+    productConfig: Readonly<{ path: string; sha256: string }>;
+  }>;
+}>;
+
+export type BackendBundleEvidence = Readonly<{
+  kiCore: Readonly<{ releaseCommit: string; tag: string }>;
+  source: Readonly<{ policy: string; repository: string; tag: string; type: string }>;
+}>;
+
+export type LaunchedPackagedApp = Readonly<{
+  electronApp: ElectronApplication;
+  logs: string[];
+  package: PackagedApp;
+  page: Page;
+  processId: number;
+  sandboxDir: string;
+}>;
+
+const KI_BUDDY_FORBIDDEN_UI_SELECTORS = [
+  ...new Set(Object.values(FIRST_RELEASE_MATRIX.disabledFeatureEvidence.flashObserved).flat()),
+];
+
+export const projectRoot = path.resolve(__dirname, '../../../../..');
+
+function packageRoot(kind: 'aionui' | 'ki-buddy'): string {
+  return kind === 'ki-buddy' ? path.join(projectRoot, 'out') : path.join(projectRoot, 'out', 'aionui-e2e');
+}
+
+export async function launchPackagedApp(
+  kind: 'aionui' | 'ki-buddy',
+  existingSandboxDir?: string
+): Promise<LaunchedPackagedApp> {
+  const packaged = resolvePackagedApp(packageRoot(kind));
+  if (!packaged) {
+    throw new Error(
+      `${kind} packaged E2E artifact is missing under ${packageRoot(kind)}. Build both unpacked applications first.`
+    );
+  }
+
+  const sandboxDir = existingSandboxDir ?? fs.mkdtempSync(path.join(os.tmpdir(), `${kind}-matrix-e2e-`));
+  const launchArgs = process.platform === 'linux' && process.env.CI ? ['--no-sandbox'] : [];
+  const electronApp = await electron.launch({
+    executablePath: packaged.executablePath,
+    args: launchArgs,
+    cwd: packaged.cwd,
+    env: {
+      ...createE2EEnvironment(sandboxDir, path.join(sandboxDir, 'extension-states.json')),
+      AIONUI_CDP_PORT: '0',
+      ...(kind === 'ki-buddy'
+        ? { AIONUI_E2E_FORBIDDEN_SELECTORS: JSON.stringify(KI_BUDDY_FORBIDDEN_UI_SELECTORS) }
+        : {}),
+      AIONUI_EXTENSIONS_PATH: path.join(projectRoot, 'examples'),
+      NODE_ENV: 'production',
+    },
+    timeout: 60_000,
+  });
+  const processId = electronApp.process().pid;
+  if (typeof processId !== 'number') {
+    await electronApp.close().catch(() => undefined);
+    throw new Error(`Unable to resolve the ${kind} packaged application process ID.`);
+  }
+  const logs: string[] = [];
+  electronApp.process().stdout?.on('data', (chunk) => logs.push(`[main:stdout] ${String(chunk).trimEnd()}`));
+  electronApp.process().stderr?.on('data', (chunk) => logs.push(`[main:stderr] ${String(chunk).trimEnd()}`));
+  const page = await resolveMainWindow(electronApp);
+  page.on('console', (message) => logs.push(`[renderer:${message.type()}] ${message.text()}`));
+  page.on('pageerror', (error) => logs.push(`[renderer:pageerror] ${error.message}`));
+
+  return {
+    electronApp,
+    logs,
+    package: packaged,
+    page,
+    processId,
+    sandboxDir,
+  };
+}
+
+export async function closePackagedApp(app: LaunchedPackagedApp, removeSandbox = true): Promise<void> {
+  await app.electronApp.close().catch(() => undefined);
+  if (removeSandbox) fs.rmSync(app.sandboxDir, { recursive: true, force: true });
+}
+
+export function readProductBuildEvidence(packaged: PackagedApp): ProductBuildEvidence {
+  const evidencePath = path.join(packaged.resourcesPath, 'ki-buddy-build-evidence.json');
+  return JSON.parse(fs.readFileSync(evidencePath, 'utf8')) as ProductBuildEvidence;
+}
+
+export function readBackendBundleEvidence(packaged: PackagedApp): BackendBundleEvidence {
+  const runtimeKey = `${process.platform}-${process.arch}`;
+  const evidencePath = path.join(packaged.resourcesPath, 'bundled-aioncore', runtimeKey, 'manifest.json');
+  return JSON.parse(fs.readFileSync(evidencePath, 'utf8')) as BackendBundleEvidence;
+}
+
+export function currentSourceCommit(): string {
+  return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: projectRoot, encoding: 'utf8' }).trim();
+}
+
+export function currentSourceStateSha256(): string {
+  return createSourceStateSha256(projectRoot);
+}
+
+export function isSourceTreeDirty(): boolean {
+  return Boolean(
+    execFileSync('git', ['status', '--porcelain', '--untracked-files=all'], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+    }).trim()
+  );
+}
+
+export function sha256Source(relativePath: string): string {
+  return createHash('sha256')
+    .update(fs.readFileSync(path.join(projectRoot, relativePath)))
+    .digest('hex');
+}

--- a/tests/e2e/features/remote/ki-buddy/processTreeNetworkState.ts
+++ b/tests/e2e/features/remote/ki-buddy/processTreeNetworkState.ts
@@ -1,0 +1,211 @@
+import { execFileSync } from 'node:child_process';
+
+export type ProcessTreeRecord = Readonly<{
+  command: string;
+  pid: number;
+  ppid: number;
+}>;
+
+export type ProcessTreeListener = Readonly<{
+  address: string;
+  command: string;
+  pid: number;
+  port: number;
+  protocol: 'tcp';
+}>;
+
+export type ProcessTreeNetworkState = Readonly<{
+  listeners: readonly ProcessTreeListener[];
+  processes: readonly ProcessTreeRecord[];
+  rootPid: number;
+}>;
+
+type WindowsProcessRecord = Readonly<{
+  CommandLine?: unknown;
+  Name?: unknown;
+  ParentProcessId?: unknown;
+  ProcessId?: unknown;
+}>;
+
+type WindowsListenerRecord = Readonly<{
+  LocalAddress?: unknown;
+  LocalPort?: unknown;
+  OwningProcess?: unknown;
+}>;
+
+const normalizeJsonArray = (value: unknown): unknown[] => {
+  if (value === null || value === undefined || value === '') return [];
+  return Array.isArray(value) ? value : [value];
+};
+
+export function parsePsProcessTable(output: string): ProcessTreeRecord[] {
+  return output.split(/\r?\n/).flatMap((line): ProcessTreeRecord[] => {
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.+?)\s*$/);
+    if (!match) return [];
+    return [{ pid: Number(match[1]), ppid: Number(match[2]), command: match[3] }];
+  });
+}
+
+export function parseLsofListeners(output: string): ProcessTreeListener[] {
+  const listeners: ProcessTreeListener[] = [];
+  let pid: number | undefined;
+  let command = '';
+
+  for (const line of output.split(/\r?\n/)) {
+    const field = line[0];
+    const value = line.slice(1);
+    if (field === 'p') {
+      pid = /^\d+$/.test(value) ? Number(value) : undefined;
+      command = '';
+      continue;
+    }
+    if (field === 'c') {
+      command = value;
+      continue;
+    }
+    if (field !== 'n' || pid === undefined) continue;
+
+    const portMatch = value.match(/:(\d+)(?:\s+\(LISTEN\))?$/);
+    if (!portMatch) continue;
+    listeners.push({
+      pid,
+      command,
+      address: value,
+      port: Number(portMatch[1]),
+      protocol: 'tcp',
+    });
+  }
+
+  return listeners;
+}
+
+export function parseWindowsProcesses(output: string): ProcessTreeRecord[] {
+  if (!output.trim()) return [];
+  const records = normalizeJsonArray(JSON.parse(output) as unknown) as WindowsProcessRecord[];
+  return records.flatMap((record): ProcessTreeRecord[] => {
+    if (
+      typeof record.ProcessId !== 'number' ||
+      typeof record.ParentProcessId !== 'number' ||
+      typeof record.Name !== 'string'
+    ) {
+      return [];
+    }
+    return [
+      {
+        pid: record.ProcessId,
+        ppid: record.ParentProcessId,
+        command: typeof record.CommandLine === 'string' ? record.CommandLine : record.Name,
+      },
+    ];
+  });
+}
+
+export function parseWindowsListeners(output: string, processes: readonly ProcessTreeRecord[]): ProcessTreeListener[] {
+  if (!output.trim()) return [];
+  const commands = new Map(processes.map(({ command, pid }) => [pid, command]));
+  const records = normalizeJsonArray(JSON.parse(output) as unknown) as WindowsListenerRecord[];
+  return records.flatMap((record): ProcessTreeListener[] => {
+    if (
+      typeof record.OwningProcess !== 'number' ||
+      typeof record.LocalAddress !== 'string' ||
+      typeof record.LocalPort !== 'number'
+    ) {
+      return [];
+    }
+    return [
+      {
+        pid: record.OwningProcess,
+        command: commands.get(record.OwningProcess) ?? '',
+        address: record.LocalAddress,
+        port: record.LocalPort,
+        protocol: 'tcp',
+      },
+    ];
+  });
+}
+
+export function collectProcessTreePids(processes: readonly ProcessTreeRecord[], rootPid: number): Set<number> {
+  const treePids = new Set([rootPid]);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const processRecord of processes) {
+      if (!treePids.has(processRecord.ppid) || treePids.has(processRecord.pid)) continue;
+      treePids.add(processRecord.pid);
+      changed = true;
+    }
+  }
+  return treePids;
+}
+
+export function partitionExpectedPlaywrightElectronListeners(
+  state: ProcessTreeNetworkState,
+  backendPort: number
+): Readonly<{
+  applicationListeners: readonly ProcessTreeListener[];
+  playwrightHarnessListeners: readonly ProcessTreeListener[];
+}> {
+  const hasPlaywrightDebugFlags = (command: string): boolean =>
+    /(?:^|[\s"])--inspect=0(?=[\s"]|$)/.test(command) &&
+    /(?:^|[\s"])--remote-debugging-port=0(?=[\s"]|$)/.test(command);
+  const harnessProcessIds = new Set(
+    state.processes.filter(({ command }) => hasPlaywrightDebugFlags(command)).map(({ pid }) => pid)
+  );
+  const candidates = state.listeners.filter(({ pid, port }) => harnessProcessIds.has(pid) && port !== backendPort);
+  const candidateProcessIds = new Set(candidates.map(({ pid }) => pid));
+  const playwrightHarnessListeners = candidates.length === 2 && candidateProcessIds.size === 1 ? candidates : [];
+
+  return {
+    playwrightHarnessListeners,
+    applicationListeners: state.listeners.filter((listener) => !playwrightHarnessListeners.includes(listener)),
+  };
+}
+
+const run = (command: string, args: string[]): string =>
+  execFileSync(command, args, { encoding: 'utf8', timeout: 10_000 });
+
+/** Captures all TCP listeners owned by the packaged Electron process and its descendants. */
+export function captureProcessTreeNetworkState(rootPid: number): ProcessTreeNetworkState {
+  let processes: ProcessTreeRecord[];
+  let listeners: ProcessTreeListener[];
+
+  if (process.platform === 'win32') {
+    processes = parseWindowsProcesses(
+      run('powershell.exe', [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine | ConvertTo-Json -Compress',
+      ])
+    );
+    listeners = parseWindowsListeners(
+      run('powershell.exe', [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        'Get-NetTCPConnection -State Listen | Select-Object OwningProcess,LocalAddress,LocalPort | ConvertTo-Json -Compress',
+      ]),
+      processes
+    );
+  } else {
+    processes = parsePsProcessTable(run('ps', ['-axo', 'pid=,ppid=,command=']));
+    listeners = parseLsofListeners(run('lsof', ['-nP', '-a', '-iTCP', '-sTCP:LISTEN', '-Fpcn']));
+  }
+
+  const processTreePids = collectProcessTreePids(processes, rootPid);
+  const processCommands = new Map(processes.map(({ command, pid }) => [pid, command]));
+  return {
+    rootPid,
+    processes: processes.filter(({ pid }) => processTreePids.has(pid)).toSorted((left, right) => left.pid - right.pid),
+    listeners: listeners
+      .filter(({ pid }) => processTreePids.has(pid))
+      .map(({ address, command, pid, port, protocol }) => ({
+        address,
+        command: processCommands.get(pid) ?? command,
+        pid,
+        port,
+        protocol,
+      }))
+      .toSorted((left, right) => left.pid - right.pid || left.port - right.port),
+  };
+}

--- a/tests/e2e/features/remote/ki-buddy/productMatrix.e2e.ts
+++ b/tests/e2e/features/remote/ki-buddy/productMatrix.e2e.ts
@@ -1,0 +1,975 @@
+import type { ElectronApplication, Locator, Page, TestInfo } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+import { httpDelete, httpInvoke, invokeBridge } from '../../../helpers';
+import { FIRST_RELEASE_MATRIX } from './firstReleaseMatrix';
+import { MATRIX_TEST_USER, startMatrixAgentsServer } from './fakeAgentsServer';
+import {
+  captureProcessTreeNetworkState,
+  partitionExpectedPlaywrightElectronListeners,
+} from './processTreeNetworkState';
+import {
+  closePackagedApp,
+  currentSourceCommit,
+  currentSourceStateSha256,
+  isSourceTreeDirty,
+  launchPackagedApp,
+  readBackendBundleEvidence,
+  readProductBuildEvidence,
+  sha256Source,
+  type LaunchedPackagedApp,
+} from './packagedApp';
+
+type ProductBootstrap = Readonly<{
+  capability: null | {
+    experience: {
+      behaviorDefaults: unknown;
+      features: unknown;
+      resources: unknown;
+      schemaVersion: number;
+    };
+    id: string;
+    schemaVersion: number;
+  };
+  error: string | null;
+  productIdentity: string | null;
+  status: 'absent' | 'invalid' | 'ready';
+}>;
+
+type FirstFrameViolation = Readonly<{ html: string; selector: string }>;
+
+const EXTENSION_CONTRIBUTION_QUERIES = [
+  'extensions.get-loaded-extensions',
+  'extensions.get-acp-adapters',
+  'extensions.get-mcp-servers',
+  'extensions.get-assistants',
+  'extensions.get-agents',
+  'extensions.get-skills',
+  'extensions.get-themes',
+  'extensions.get-settings-tabs',
+  'extensions.get-webui-contributions',
+] as const;
+
+async function readOptionalRuntimeState(page: Page): Promise<{
+  channels: { available: boolean; error?: string; value?: unknown };
+  extensionContributions: Record<string, { available: boolean; error?: string; value?: unknown }>;
+}> {
+  const probe = async (key: string): Promise<{ available: boolean; error?: string; value?: unknown }> => {
+    try {
+      return { available: true, value: await invokeBridge(page, key, undefined, 1_500) };
+    } catch (error) {
+      return { available: false, error: String(error) };
+    }
+  };
+  const [channels, ...extensionStates] = await Promise.all([
+    probe('channel.get-plugin-status'),
+    ...EXTENSION_CONTRIBUTION_QUERIES.map(probe),
+  ]);
+  return {
+    channels,
+    extensionContributions: Object.fromEntries(
+      EXTENSION_CONTRIBUTION_QUERIES.map((key, index) => [key, extensionStates[index]])
+    ),
+  };
+}
+
+async function readFirstFrameViolations(page: Page): Promise<FirstFrameViolation[]> {
+  const observerState = await page.evaluate(() => window.__getE2EUiObserverState?.());
+  if (!observerState) throw new Error('The first-frame observer was not installed before renderer startup.');
+  expect(observerState.selectors).toEqual([
+    ...new Set(Object.values(FIRST_RELEASE_MATRIX.disabledFeatureEvidence.flashObserved).flat()),
+  ]);
+  return observerState.violations;
+}
+
+async function confirmVisibleAionModal(page: Page): Promise<void> {
+  await page.locator('.aionui-modal-wrapper:visible .aionui-modal-std-footer button.arco-btn-primary').click();
+}
+
+async function revealHoverMenu(row: Locator, trigger: Locator, menuItem: Locator): Promise<void> {
+  await expect(async () => {
+    await row.hover();
+    await trigger.hover();
+    await expect(menuItem).toBeVisible({ timeout: 1_000 });
+  }).toPass({ timeout: 10_000 });
+}
+
+async function attachClientState(testInfo: TestInfo, app: LaunchedPackagedApp, name: string): Promise<void> {
+  const [snapshot, mainProcessState, optionalRuntimeState, processTreeNetworkState] = await Promise.all([
+    app.page.evaluate(() => ({
+      bodyText: document.body.innerText.slice(0, 6_000),
+      hash: window.location.hash,
+      title: document.title,
+      bootstrap: window.__getKiBuddyProductBootstrap?.() ?? null,
+    })),
+    readMainProcessState(app.electronApp).catch((error: unknown) => ({ error: String(error) })),
+    readOptionalRuntimeState(app.page).catch((error: unknown) => ({ error: String(error) })),
+    Promise.resolve()
+      .then(() => captureProcessTreeNetworkState(app.processId))
+      .catch((error: unknown) => ({ error: String(error) })),
+  ]);
+  await testInfo.attach(`${name}.json`, {
+    body: Buffer.from(
+      JSON.stringify(
+        { ...snapshot, mainProcessState, optionalRuntimeState, processTreeNetworkState, logs: app.logs.slice(-2_000) },
+        null,
+        2
+      )
+    ),
+    contentType: 'application/json',
+  });
+  await testInfo.attach(`${name}.png`, {
+    body: await app.page.screenshot(),
+    contentType: 'image/png',
+  });
+}
+
+async function skipOpeningGuide(page: Page): Promise<void> {
+  const guideOrLogin = page.locator('#ki-buddy-opening-guide-title, input[autocomplete="username"]').first();
+  await guideOrLogin.waitFor({ state: 'visible', timeout: 45_000 });
+  const skip = page.getByRole('button', { name: /^(跳过|Skip)$/i });
+  if (await skip.isVisible().catch(() => false)) await skip.click();
+  await page.locator('input[autocomplete="username"]').waitFor({ state: 'visible', timeout: 15_000 });
+}
+
+async function login(page: Page, baseUrl: string): Promise<void> {
+  await skipOpeningGuide(page);
+  await page.locator('input[autocomplete="url"]').fill(baseUrl);
+  await page.locator('input[autocomplete="username"]').fill(MATRIX_TEST_USER.userName);
+  await page.locator('input[autocomplete="current-password"]').fill('matrix-password');
+  await page.getByRole('button', { name: /^(登录|Sign In)$/i }).click();
+  await expect(page).toHaveURL(/#\/guid$/, { timeout: 45_000 });
+}
+
+async function readMainProcessState(electronApp: ElectronApplication): Promise<{
+  startedProductLifecycles: string[];
+  trayMenuLabels: string[];
+  windows: Array<{ title: string; url: string; visible: boolean }>;
+}> {
+  return electronApp.evaluate(async ({ BrowserWindow }) => {
+    const e2eGlobal = globalThis as typeof globalThis & {
+      __aionuiE2EStartedMainProductLifecycles?: () => string[];
+      __aionuiE2ETrayMenuLabels?: () => Promise<string[]>;
+    };
+    const windows = BrowserWindow.getAllWindows().map((window) => ({
+      title: window.getTitle(),
+      url: window.webContents.getURL(),
+      visible: window.isVisible(),
+    }));
+    const trayMenuLabels = (await e2eGlobal.__aionuiE2ETrayMenuLabels?.()) ?? [];
+    const startedProductLifecycles = e2eGlobal.__aionuiE2EStartedMainProductLifecycles?.() ?? [];
+    return { startedProductLifecycles, trayMenuLabels, windows };
+  });
+}
+
+test.describe.serial('Ki-Buddy packaged first-release product matrix', () => {
+  test.skip(process.env.E2E_PACKAGED !== '1', 'This acceptance suite requires packaged Electron applications.');
+  test.setTimeout(240_000);
+
+  let productApp: LaunchedPackagedApp;
+  let agents: Awaited<ReturnType<typeof startMatrixAgentsServer>>;
+
+  test.beforeAll(async () => {
+    agents = await startMatrixAgentsServer();
+    productApp = await launchPackagedApp('ki-buddy');
+  });
+
+  test.afterAll(async () => {
+    if (productApp) await closePackagedApp(productApp).catch(() => undefined);
+    if (agents) await agents.close().catch(() => undefined);
+  });
+
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status !== testInfo.expectedStatus && productApp?.page && !productApp.page.isClosed()) {
+      await attachClientState(testInfo, productApp, 'failure-state').catch(() => undefined);
+    }
+    if (productApp?.page && !productApp.page.isClosed()) {
+      await productApp.page.unrouteAll({ behavior: 'ignoreErrors' }).catch(() => undefined);
+    }
+  });
+
+  test('attests product identity, policy sources, tested commit, and the independent oracle', async ({}, testInfo) => {
+    const evidence = readProductBuildEvidence(productApp.package);
+    const backendEvidence = readBackendBundleEvidence(productApp.package);
+    const bootstrap = await productApp.page.evaluate(
+      () => window.__getKiBuddyProductBootstrap?.() as ProductBootstrap | undefined
+    );
+    const appIdentity = await productApp.electronApp.evaluate(({ app }) => ({
+      isPackaged: app.isPackaged,
+      name: app.getName(),
+      version: app.getVersion(),
+    }));
+
+    expect(appIdentity).toMatchObject({ isPackaged: true, name: 'Ki-Buddy' });
+    expect(evidence).toMatchObject({
+      schemaVersion: 1,
+      product: { runtimeIdentity: 'ki-buddy', productName: 'Ki-Buddy' },
+      sourceCommit: currentSourceCommit(),
+      sourceStateSha256: currentSourceStateSha256(),
+      sourceTreeDirty: isSourceTreeDirty(),
+    });
+    for (const source of Object.values(evidence.policySources)) {
+      expect(source.sha256).toBe(sha256Source(source.path));
+    }
+    expect(backendEvidence).toMatchObject({
+      kiCore: {
+        releaseCommit: FIRST_RELEASE_MATRIX.backend.commit,
+        tag: FIRST_RELEASE_MATRIX.backend.tag,
+      },
+      source: {
+        policy: 'release-pinned',
+        repository: FIRST_RELEASE_MATRIX.backend.repository,
+        tag: FIRST_RELEASE_MATRIX.backend.tag,
+        type: 'github-release',
+      },
+    });
+    expect(bootstrap).toMatchObject({
+      status: 'ready',
+      productIdentity: 'ki-buddy',
+      error: null,
+      capability: {
+        id: 'ki-buddy',
+        schemaVersion: 3,
+        experience: {
+          schemaVersion: 1,
+          features: FIRST_RELEASE_MATRIX.features,
+          resources: FIRST_RELEASE_MATRIX.resources,
+          behaviorDefaults: FIRST_RELEASE_MATRIX.behaviorDefaults,
+        },
+      },
+    });
+    expect(await readFirstFrameViolations(productApp.page)).toEqual([]);
+    await testInfo.attach('packaged-build-evidence.json', {
+      body: Buffer.from(JSON.stringify({ appIdentity, evidence, backendEvidence, bootstrap }, null, 2)),
+      contentType: 'application/json',
+    });
+    await attachClientState(testInfo, productApp, 'first-visible-frame');
+  });
+
+  test('keeps the product entry stable before login, after login, refresh, and restart', async ({}, testInfo) => {
+    await skipOpeningGuide(productApp.page);
+    await expect(productApp.page.locator('[data-settings-id="webui"], [data-settings-id="pet"]')).toHaveCount(0);
+    expect(await readFirstFrameViolations(productApp.page)).toEqual([]);
+
+    await login(productApp.page, agents.baseUrl);
+    await expect(productApp.page.getByTestId('guid-input')).toBeVisible({ timeout: 30_000 });
+    await expect(productApp.page.locator('[class*="guidQuickActions"]')).toHaveCount(0);
+    expect(await readFirstFrameViolations(productApp.page)).toEqual([]);
+
+    await productApp.page.reload();
+    await expect(productApp.page).toHaveURL(/#\/guid$/, { timeout: 45_000 });
+    await expect(productApp.page.getByTestId('guid-input')).toBeVisible({ timeout: 30_000 });
+    expect(await readFirstFrameViolations(productApp.page)).toEqual([]);
+
+    const sandboxDir = productApp.sandboxDir;
+    await closePackagedApp(productApp, false);
+    productApp = await launchPackagedApp('ki-buddy', sandboxDir);
+    await expect(productApp.page).toHaveURL(/#\/guid$/, { timeout: 45_000 });
+    await expect(productApp.page.getByTestId('guid-input')).toBeVisible({ timeout: 30_000 });
+    expect(await readFirstFrameViolations(productApp.page)).toEqual([]);
+    await attachClientState(testInfo, productApp, 'after-restart');
+  });
+
+  test('projects navigation, Appearance capabilities, and disabled-route replace redirects', async () => {
+    await productApp.page.evaluate(() => {
+      window.location.hash = '#/guid';
+    });
+    await expect(productApp.page.getByText(/^(新会话|New Chat)$/i)).toBeVisible({ timeout: 20_000 });
+    await expect(productApp.page.getByText(/^(助手|Assistants)$/i)).toBeVisible();
+    await expect(productApp.page.getByText(/^(定时任务|Scheduled Tasks)$/i)).toBeVisible();
+
+    await productApp.page.evaluate(() => {
+      window.location.hash = '#/settings/account';
+    });
+    await expect(productApp.page.locator('[data-settings-id="account"]')).toBeVisible({ timeout: 20_000 });
+    const settingsIds = await productApp.page
+      .locator('[data-settings-id]')
+      .evaluateAll((nodes) =>
+        nodes.map((node) => node.getAttribute('data-settings-id')).filter((value): value is string => Boolean(value))
+      );
+    expect(settingsIds).toEqual(FIRST_RELEASE_MATRIX.settingsEntries);
+    await expect(productApp.page.locator('[data-settings-path^="ext/"]')).toHaveCount(0);
+
+    await productApp.page.evaluate(() => {
+      window.location.hash = '#/settings/appearance';
+    });
+    await expect(productApp.page).toHaveURL(/#\/settings\/appearance$/);
+    await expect(productApp.page.getByText(/^(缩放|Scale)$/i)).toBeVisible({ timeout: 20_000 });
+    await expect(productApp.page.getByText(/聊天字号|Chat text size/i)).toBeVisible();
+    await expect(productApp.page.getByText(/^(主题|Theme)$/i)).toHaveCount(0);
+
+    for (const route of [
+      ...FIRST_RELEASE_MATRIX.disabledWorkspaceRoutes,
+      ...FIRST_RELEASE_MATRIX.disabledSettingsRoutes,
+    ]) {
+      const historyLength = await productApp.page.evaluate(() => history.length);
+      await productApp.page.evaluate((disabledRoute) => {
+        window.location.hash = `#${disabledRoute}`;
+      }, route);
+      await expect
+        .poll(() => productApp.page.evaluate(() => window.location.hash), { timeout: 15_000 })
+        .not.toBe(`#${route}`);
+      expect(await productApp.page.evaluate(() => history.length)).toBe(historyLength + 1);
+    }
+  });
+
+  test('enforces Agent product-use, hidden-upstream, and Custom-management access', async () => {
+    const baselineAgents = await httpInvoke<Array<Record<string, unknown> & { id: string; name: string }>>(
+      productApp.page,
+      'GET',
+      '/api/agents/management'
+    );
+    const productAgent = baselineAgents.find(({ id }) => id === FIRST_RELEASE_MATRIX.productResources.agents[0]);
+    if (!productAgent) throw new Error('The packaged Agent catalog is missing the product Agent fixture source.');
+    const agentFixtures = [
+      { ...productAgent, id: 'matrix-custom-agent', name: 'Matrix Custom Agent', agent_source: 'custom' },
+      { ...productAgent, id: 'matrix-upstream-agent', name: 'Matrix Upstream Agent', agent_source: 'builtin' },
+      {
+        ...productAgent,
+        id: 'matrix-extension-agent',
+        name: 'Matrix Extension Agent',
+        agent_source: 'extension',
+        isExtension: true,
+      },
+      { ...productAgent, id: 'matrix-unclassified-agent', name: 'Matrix Unclassified Agent', agent_source: 'future' },
+    ];
+    const agentListPattern = '**/api/agents/management';
+    await productApp.page.route(agentListPattern, async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: [...baselineAgents, ...agentFixtures] }),
+      });
+    });
+    await productApp.page.reload();
+    await productApp.page.evaluate(() => {
+      window.location.hash = '#/settings/agent';
+    });
+    await expect(productApp.page.getByTestId('agent-management-page')).toBeVisible({ timeout: 30_000 });
+    await expect(productApp.page.getByTestId('btn-add-custom-agent')).toBeVisible();
+    await expect(productApp.page.getByTestId('agent-row-632f31d2')).toBeVisible({ timeout: 30_000 });
+    await expect(productApp.page.getByTestId('agent-row-edit-632f31d2')).toHaveCount(0);
+    await expect(productApp.page.getByTestId('agent-row-matrix-custom-agent')).toBeVisible();
+    await expect(productApp.page.getByTestId('agent-row-edit-matrix-custom-agent')).toBeVisible();
+    for (const hiddenAgentId of ['matrix-upstream-agent', 'matrix-extension-agent', 'matrix-unclassified-agent']) {
+      await expect(productApp.page.getByTestId(`agent-row-${hiddenAgentId}`)).toHaveCount(0);
+    }
+    await productApp.page.unroute(agentListPattern);
+  });
+
+  test('creates, edits, and deletes a real Custom Model without inventing unavailable origins', async () => {
+    const modelName = `ki-buddy-custom-model-${Date.now()}`;
+    const providerBaseUrl = `${agents.baseUrl}/v1`;
+    const fetchModelsPattern = '**/api/providers/fetch-models';
+    const detectProtocolPattern = '**/api/providers/detect-protocol';
+    const fetchModelRequests: unknown[] = [];
+    const detectProtocolRequests: unknown[] = [];
+
+    await productApp.page.route(fetchModelsPattern, async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      fetchModelRequests.push(route.request().postDataJSON());
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: { models: [modelName] } }),
+      });
+    });
+    await productApp.page.route(detectProtocolPattern, async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      detectProtocolRequests.push(route.request().postDataJSON());
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: { success: true, protocol: 'openai', confidence: 100 } }),
+      });
+    });
+
+    try {
+      await productApp.page.evaluate(() => {
+        window.location.hash = '#/settings/model';
+      });
+      await expect(productApp.page.getByTestId('model-header')).toBeVisible({ timeout: 20_000 });
+      await productApp.page.getByTestId('model-add').click();
+      await productApp.page.getByTestId('model-add-manual').click();
+
+      const createForm = productApp.page.getByTestId('model-provider-create-form');
+      await expect(createForm).toBeVisible();
+      await createForm.getByTestId('model-provider-base-url').fill(providerBaseUrl);
+      await createForm.getByTestId('model-provider-api-key').fill('sk-ki-buddy-matrix');
+      await expect.poll(() => fetchModelRequests.length).toBeGreaterThan(0);
+      await expect.poll(() => detectProtocolRequests.length).toBeGreaterThan(0);
+      expect(fetchModelRequests[0]).toMatchObject({
+        api_key: 'sk-ki-buddy-matrix',
+        base_url: providerBaseUrl,
+        platform: 'custom',
+      });
+      expect(detectProtocolRequests[0]).toMatchObject({
+        api_key: 'sk-ki-buddy-matrix',
+        base_url: providerBaseUrl,
+      });
+
+      const modelSelect = createForm.getByTestId('model-provider-models');
+      await modelSelect.click();
+      await modelSelect.locator('input').fill(modelName);
+      await modelSelect.locator('input').press('Enter');
+      await confirmVisibleAionModal(productApp.page);
+
+      const providerEntry = productApp.page
+        .locator(
+          '[data-testid^="model-provider-"][data-product-resource-origin="custom"][data-product-resource-access="manage"]'
+        )
+        .filter({ hasText: modelName });
+      await expect(providerEntry).toBeVisible({ timeout: 20_000 });
+      await expect(productApp.page.locator('[data-product-resource-origin="productBuiltin"]')).toHaveCount(0);
+      await expect(productApp.page.locator('[data-product-resource-origin="upstreamBuiltin"]')).toHaveCount(0);
+      const createdProviders = await httpInvoke<
+        Array<{ base_url: string; id: string; models: string[]; name: string; platform: string }>
+      >(productApp.page, 'GET', '/api/providers');
+      const createdProvider = createdProviders.find(({ models }) => models.includes(modelName));
+      expect(createdProvider).toMatchObject({
+        base_url: providerBaseUrl,
+        models: expect.arrayContaining([modelName]),
+        platform: 'custom',
+      });
+      if (!createdProvider) throw new Error('Custom Model was not persisted by the packaged backend.');
+
+      await providerEntry.hover();
+      await providerEntry.locator('[data-testid^="model-provider-edit-"]').click();
+      const editForm = productApp.page.getByTestId('model-provider-edit-form');
+      await expect(editForm).toBeVisible();
+      const editedProviderName = `Ki-Buddy Custom Provider ${Date.now()}`;
+      await editForm.getByTestId('model-provider-name').fill(editedProviderName);
+      await confirmVisibleAionModal(productApp.page);
+      await expect(providerEntry).toContainText(editedProviderName, { timeout: 20_000 });
+      await expect
+        .poll(
+          async () => {
+            const providers = await httpInvoke<Array<{ id: string; name: string }>>(
+              productApp.page,
+              'GET',
+              '/api/providers'
+            );
+            return providers.find(({ id }) => id === createdProvider.id)?.name;
+          },
+          { timeout: 20_000 }
+        )
+        .toBe(editedProviderName);
+
+      await providerEntry.hover();
+      await providerEntry.locator('[data-testid^="model-provider-delete-"]').click();
+      await productApp.page.locator('.arco-popconfirm:visible button.arco-btn-primary').click();
+      await expect(providerEntry).toHaveCount(0, { timeout: 20_000 });
+      await expect
+        .poll(
+          async () => {
+            const providers = await httpInvoke<Array<{ id: string }>>(productApp.page, 'GET', '/api/providers');
+            return providers.some(({ id }) => id === createdProvider.id);
+          },
+          { timeout: 20_000 }
+        )
+        .toBe(false);
+      const remainingProviders = await httpInvoke<Array<{ id: string; models?: string[] }>>(
+        productApp.page,
+        'GET',
+        '/api/providers'
+      );
+      expect(remainingProviders.map(({ id }) => id)).not.toContain(createdProvider.id);
+      expect(remainingProviders.flatMap(({ models = [] }) => models)).not.toContain(modelName);
+    } finally {
+      await productApp.page.unroute(fetchModelsPattern);
+      await productApp.page.unroute(detectProtocolPattern);
+    }
+  });
+
+  test('enforces Assistant product-management, hidden-upstream, and Custom-management access', async () => {
+    const baselineAssistants = await httpInvoke<Array<Record<string, unknown> & { id: string; name: string }>>(
+      productApp.page,
+      'GET',
+      '/api/assistants'
+    );
+    const productAssistant = baselineAssistants.find(({ id }) => id === 'word-creator');
+    if (!productAssistant) throw new Error('The packaged Assistant catalog is missing the product fixture source.');
+    const productAssistantAgent =
+      productAssistant.agent && typeof productAssistant.agent === 'object' ? productAssistant.agent : {};
+    const assistantFixtures = [
+      {
+        ...productAssistant,
+        id: 'matrix-custom-assistant',
+        name: 'Matrix Custom Assistant',
+        source: 'user',
+        deletable: true,
+      },
+      { ...productAssistant, id: 'matrix-upstream-assistant', name: 'Matrix Upstream Assistant', source: 'builtin' },
+      {
+        ...productAssistant,
+        id: 'matrix-extension-assistant',
+        name: 'Matrix Extension Assistant',
+        source: 'generated',
+        agent: { ...productAssistantAgent, type: 'acp', source: 'extension' },
+      },
+      {
+        ...productAssistant,
+        id: 'matrix-unclassified-assistant',
+        name: 'Matrix Unclassified Assistant',
+        source: 'future',
+      },
+    ];
+    const assistantListPattern = '**/api/assistants';
+    await productApp.page.route(assistantListPattern, async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: [...baselineAssistants, ...assistantFixtures] }),
+      });
+    });
+    await productApp.page.reload();
+    await productApp.page.evaluate(() => {
+      window.location.hash = '#/assistants';
+    });
+    await expect(productApp.page.getByTestId('assistants-header')).toBeVisible({ timeout: 30_000 });
+    await expect(productApp.page.getByTestId('btn-create-assistant')).toBeVisible();
+    await productApp.page.getByTestId('settings-tab-official').click();
+    for (const assistantId of FIRST_RELEASE_MATRIX.productResources.assistants.filter(
+      (resourceId) => !resourceId.startsWith('bare:')
+    )) {
+      await expect(productApp.page.getByTestId(`official-card-${assistantId}`)).toBeVisible({ timeout: 30_000 });
+      await expect(productApp.page.getByTestId(`switch-enabled-${assistantId}`)).toBeVisible();
+    }
+    await expect(productApp.page.getByTestId('official-card-cowork')).toHaveCount(0);
+    await productApp.page.getByTestId('settings-tab-mine').click();
+    const bareAssistantId = FIRST_RELEASE_MATRIX.productResources.assistants.find((resourceId) =>
+      resourceId.startsWith('bare:')
+    );
+    expect(bareAssistantId).toBeTruthy();
+    await expect(productApp.page.getByTestId(`assistant-card-${bareAssistantId}`)).toBeVisible({ timeout: 30_000 });
+    await expect(productApp.page.getByTestId('assistant-card-matrix-custom-assistant')).toBeVisible();
+    await expect(productApp.page.getByTestId('switch-enabled-matrix-custom-assistant')).toBeVisible();
+    for (const hiddenAssistantId of [
+      'matrix-upstream-assistant',
+      'matrix-extension-assistant',
+      'matrix-unclassified-assistant',
+    ]) {
+      await expect(productApp.page.getByTestId(`official-card-${hiddenAssistantId}`)).toHaveCount(0);
+      await expect(productApp.page.getByTestId(`assistant-card-${hiddenAssistantId}`)).toHaveCount(0);
+    }
+    await productApp.page.unroute(assistantListPattern);
+  });
+
+  test('enforces Skill product-use, hidden-upstream, and Custom-management access', async () => {
+    const baselineSkills = await httpInvoke<Array<Record<string, unknown> & { name: string }>>(
+      productApp.page,
+      'GET',
+      '/api/skills'
+    );
+    const productSkill = baselineSkills.find(({ name }) => name === FIRST_RELEASE_MATRIX.productResources.skills[0]);
+    if (!productSkill) throw new Error('The packaged Skill catalog is missing the product fixture source.');
+    const skillFixtures = [
+      {
+        ...productSkill,
+        name: 'matrix-custom-skill',
+        description: 'Matrix Custom Skill',
+        source: 'custom',
+        is_custom: true,
+        is_auto_inject: false,
+      },
+      {
+        ...productSkill,
+        name: 'matrix-upstream-skill',
+        description: 'Matrix Upstream Skill',
+        source: 'builtin',
+        is_custom: false,
+        is_auto_inject: false,
+      },
+      {
+        ...productSkill,
+        name: 'matrix-extension-skill',
+        description: 'Matrix Extension Skill',
+        source: 'extension',
+        is_custom: false,
+        is_auto_inject: false,
+      },
+      {
+        ...productSkill,
+        name: 'matrix-unclassified-skill',
+        description: 'Matrix Unclassified Skill',
+        source: 'future',
+        is_custom: false,
+        is_auto_inject: false,
+      },
+    ];
+    const skillListPattern = '**/api/skills';
+    await productApp.page.route(skillListPattern, async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: [...baselineSkills, ...skillFixtures] }),
+      });
+    });
+    await productApp.page.reload();
+    await productApp.page.evaluate(() => {
+      window.location.hash = '#/settings/skills';
+    });
+    await expect(productApp.page.getByTestId('skills-header')).toBeVisible({ timeout: 30_000 });
+    await expect(productApp.page.getByTestId('btn-add-skill')).toBeVisible();
+    await productApp.page.getByTestId('settings-tab-official').click();
+    await expect(productApp.page.locator('[data-testid="extension-skills-section"]')).toHaveCount(0);
+    await Promise.all(
+      FIRST_RELEASE_MATRIX.productResources.skills.flatMap((skillName) => [
+        expect(productApp.page.getByTestId(`official-skill-card-${skillName}`)).toBeVisible({ timeout: 30_000 }),
+        expect(productApp.page.getByTestId(`btn-delete-${skillName}`)).toHaveCount(0),
+      ])
+    );
+    await expect(productApp.page.getByTestId('official-skill-card-cron')).toHaveCount(0);
+    await expect(productApp.page.getByTestId('official-skill-card-aionui-config')).toHaveCount(0);
+    for (const hiddenSkillName of ['matrix-upstream-skill', 'matrix-extension-skill', 'matrix-unclassified-skill']) {
+      await expect(productApp.page.getByText(hiddenSkillName, { exact: true })).toHaveCount(0);
+    }
+    await productApp.page.getByTestId('settings-tab-custom').click();
+    await expect(productApp.page.getByTestId('my-skill-card-matrix-custom-skill')).toBeVisible();
+    await expect(productApp.page.getByTestId('btn-delete-matrix-custom-skill')).toBeVisible();
+    await productApp.page.unroute(skillListPattern);
+  });
+
+  test('enforces the MCP origin matrix and completes Custom MCP CRUD through the UI', async () => {
+    const now = Date.now();
+    const visibleProductMcp = {
+      id: `matrix-product-mcp-${now}`,
+      name: `Matrix Product MCP ${now}`,
+      enabled: true,
+      builtin: false,
+      product_origin: 'productBuiltin',
+      transport: { type: 'stdio', command: 'node', args: ['--version'] },
+      original_json: '{}',
+      created_at: now,
+      updated_at: now,
+    };
+    const hiddenMcps = [
+      {
+        ...visibleProductMcp,
+        id: `matrix-upstream-mcp-${now}`,
+        name: `Matrix Upstream MCP ${now}`,
+        builtin: true,
+        product_origin: undefined,
+      },
+      {
+        ...visibleProductMcp,
+        id: `matrix-extension-mcp-${now}`,
+        name: `Matrix Extension MCP ${now}`,
+        product_origin: 'extension',
+      },
+      {
+        ...visibleProductMcp,
+        id: `matrix-unclassified-mcp-${now}`,
+        name: `Matrix Unclassified MCP ${now}`,
+        product_origin: 'unexpected-origin',
+      },
+    ];
+    const mcpListPattern = '**/api/mcp/servers';
+    await productApp.page.route(mcpListPattern, async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: [visibleProductMcp, ...hiddenMcps] }),
+      });
+    });
+
+    await productApp.page.evaluate(() => {
+      window.location.hash = '#/settings/tools';
+    });
+    await expect(productApp.page.getByTestId('tools-header')).toBeVisible({ timeout: 20_000 });
+    const productEntry = productApp.page.locator(
+      `[data-product-resource-id="${visibleProductMcp.id}"][data-product-resource-origin="productBuiltin"][data-product-resource-access="use"]`
+    );
+    await expect(productEntry).toBeVisible({ timeout: 20_000 });
+    await expect(productEntry.getByTestId(`mcp-test-${visibleProductMcp.id}`)).toBeVisible();
+    await expect(productEntry.getByTestId(`mcp-manage-${visibleProductMcp.id}`)).toHaveCount(0);
+    for (const hiddenMcp of hiddenMcps) {
+      await expect(productApp.page.getByText(hiddenMcp.name, { exact: true })).toHaveCount(0);
+    }
+
+    const customMcpName = `Matrix Custom MCP ${now}`;
+    const customMcpJson = JSON.stringify({
+      mcpServers: {
+        [customMcpName]: { command: 'node', args: ['--version'], description: 'created by packaged matrix' },
+      },
+    });
+    await productApp.page.getByTestId('mcp-add').click();
+    await productApp.page.getByTestId('mcp-add-json').click();
+    const editor = productApp.page.getByTestId('mcp-json-editor').locator('.cm-content');
+    await editor.fill(customMcpJson);
+    await confirmVisibleAionModal(productApp.page);
+
+    const customEntry = productApp.page
+      .locator('[data-product-resource-origin="custom"][data-product-resource-access="manage"]')
+      .filter({ hasText: customMcpName });
+    await expect(customEntry).toBeVisible({ timeout: 20_000 });
+    const customMcpId = await customEntry.getAttribute('data-product-resource-id');
+    if (!customMcpId) throw new Error('Custom MCP entry did not expose its persisted resource ID.');
+    const manageCustomMcp = customEntry.getByTestId(`mcp-manage-${customMcpId}`);
+    const editCustomMcp = productApp.page.getByTestId(`mcp-edit-${customMcpId}`);
+    await revealHoverMenu(customEntry, manageCustomMcp, editCustomMcp);
+    await editCustomMcp.click();
+    const editedMcpJson = JSON.stringify({
+      mcpServers: {
+        [customMcpName]: { command: 'node', args: ['--help'], description: 'edited by packaged matrix' },
+      },
+    });
+    await productApp.page.getByTestId('mcp-json-editor').locator('.cm-content').fill(editedMcpJson);
+    await confirmVisibleAionModal(productApp.page);
+    await expect(customEntry).toBeVisible();
+
+    await productApp.page.unroute(mcpListPattern);
+    const editedBackendMcps = await httpInvoke<
+      Array<{ id: string; original_json?: string; transport?: { args?: string[] } }>
+    >(productApp.page, 'GET', '/api/mcp/servers');
+    const editedBackendMcp = editedBackendMcps.find(({ id }) => id === customMcpId);
+    expect(editedBackendMcp).toBeTruthy();
+    expect(editedBackendMcp?.transport?.args).toContain('--help');
+    expect(editedBackendMcp?.original_json).toContain('--help');
+
+    const deleteCustomMcp = productApp.page.getByTestId(`mcp-delete-${customMcpId}`);
+    await revealHoverMenu(customEntry, manageCustomMcp, deleteCustomMcp);
+    await deleteCustomMcp.click();
+    await productApp.page.locator('.arco-modal:visible .arco-modal-footer button.arco-btn-primary').click();
+    await expect(customEntry).toHaveCount(0, { timeout: 20_000 });
+
+    const backendMcps = await httpInvoke<Array<{ id: string }>>(productApp.page, 'GET', '/api/mcp/servers');
+    expect(backendMcps.map(({ id }) => id)).not.toContain(customMcpId);
+  });
+
+  test('creates and edits Scheduled Tasks with Assistant-only selection', async () => {
+    const provider = await httpInvoke<{ id: string }>(productApp.page, 'POST', '/api/providers', {
+      id: `ki-buddy-matrix-provider-${Date.now()}`,
+      platform: 'new-api',
+      name: 'Ki-Buddy Matrix Provider',
+      base_url: 'https://api.example.com/v1',
+      api_key: 'sk-ki-buddy-matrix',
+      models: ['matrix-model'],
+      enabled: true,
+    });
+    await productApp.page.reload();
+    await expect(productApp.page.getByTestId('tools-header')).toBeVisible({ timeout: 30_000 });
+    await productApp.page.evaluate(() => {
+      window.location.hash = '#/scheduled';
+    });
+    await expect(productApp.page.getByTestId('scheduled-tasks-header')).toBeVisible({ timeout: 20_000 });
+    await productApp.page
+      .getByText(/新建任务|New Task/i)
+      .first()
+      .click();
+    await productApp.page.getByText(/手动创建|Create manually/i).click();
+    const createDialog = productApp.page.locator('.arco-modal:visible').last();
+    await expect(createDialog).toBeVisible();
+    const taskName = `Ki-Buddy Matrix ${Date.now()}`;
+    await createDialog.locator('#name input').fill(taskName);
+    const assistantSelect = createDialog.getByTestId('cron-assistant-select');
+    await expect(assistantSelect).toBeVisible();
+    await assistantSelect.click();
+    const optionsText = await productApp.page.locator('.arco-select-option').allTextContents();
+    expect(optionsText.length).toBeGreaterThan(0);
+    expect(optionsText.join('\n')).not.toMatch(/\bTeam\b|团队/);
+    await productApp.page.locator('.arco-select-option:not(.arco-select-option-disabled)').first().click();
+    await createDialog.locator('#prompt textarea').fill('Verify the Ki-Buddy packaged task matrix.');
+    await createDialog.getByRole('button', { name: /^(保存|Save)$/i }).click();
+    await expect(createDialog).toBeHidden({ timeout: 30_000 });
+
+    const taskEntry = productApp.page.getByText(taskName, { exact: true });
+    await expect(taskEntry).toBeVisible({ timeout: 20_000 });
+    await taskEntry.click();
+    await expect(productApp.page).toHaveURL(/#\/scheduled\/[^/]+$/, { timeout: 20_000 });
+    const jobId = productApp.page.url().split('/').at(-1);
+    expect(jobId).toBeTruthy();
+
+    const detailHeading = productApp.page.locator('h1').filter({ hasText: taskName });
+    const detailActions = detailHeading.locator('..').locator('button');
+    await detailActions.first().click();
+    const editDialog = productApp.page.locator('.arco-modal:visible').last();
+    await expect(editDialog).toBeVisible();
+    const editedTaskName = `${taskName} Edited`;
+    await editDialog.locator('#name input').fill(editedTaskName);
+    await editDialog.getByRole('button', { name: /^(保存|Save)$/i }).click();
+    await expect(editDialog).toBeHidden({ timeout: 30_000 });
+    await expect(productApp.page.locator('h1').filter({ hasText: editedTaskName })).toBeVisible({ timeout: 20_000 });
+
+    const updated = (await invokeBridge(productApp.page, 'cron.get-job', { job_id: jobId })) as {
+      name: string;
+      metadata?: { agent_config?: { assistant_id?: string; team_id?: string } };
+    };
+    expect(updated.name).toBe(editedTaskName);
+    expect(updated.metadata?.agent_config?.assistant_id).toBeTruthy();
+    expect(updated.metadata?.agent_config?.team_id).toBeUndefined();
+    await invokeBridge(productApp.page, 'cron.remove-job', { job_id: jobId });
+    await httpDelete(productApp.page, `/api/providers/${provider.id}`);
+  });
+
+  test('keeps Pet, WebUI, Channels, and Extension runtime inactive with state evidence', async ({}, testInfo) => {
+    const backendPort = await productApp.page.evaluate(() => window.__backendPort ?? 0);
+    const [state, optionalRuntimeState, processTreeNetworkState] = await Promise.all([
+      readMainProcessState(productApp.electronApp),
+      readOptionalRuntimeState(productApp.page),
+      Promise.resolve().then(() => captureProcessTreeNetworkState(productApp.processId)),
+    ]);
+    const { applicationListeners, playwrightHarnessListeners } = partitionExpectedPlaywrightElectronListeners(
+      processTreeNetworkState,
+      backendPort
+    );
+    await testInfo.attach('disabled-runtime-state.json', {
+      body: Buffer.from(
+        JSON.stringify(
+          {
+            backendPort,
+            state,
+            optionalRuntimeState,
+            processTreeNetworkState,
+            playwrightHarnessListeners,
+            applicationListeners,
+          },
+          null,
+          2
+        )
+      ),
+      contentType: 'application/json',
+    });
+
+    expect(state.windows).toHaveLength(1);
+    expect(state.windows[0]).toMatchObject({ visible: true });
+    expect(processTreeNetworkState.processes.some(({ command }) => /aioncore/i.test(command))).toBe(true);
+    expect(processTreeNetworkState.listeners.some(({ port }) => port === backendPort)).toBe(true);
+    expect(playwrightHarnessListeners).toHaveLength(2);
+    expect(applicationListeners.filter(({ command }) => !/aioncore/i.test(command))).toEqual([]);
+    expect(state.startedProductLifecycles).not.toContain('desktopPet');
+    expect(state.startedProductLifecycles).not.toContain('webUi');
+    expect(state.trayMenuLabels.length).toBeGreaterThan(0);
+    expect(state.trayMenuLabels.join('\n')).not.toMatch(/Desktop Pet|桌面宠物|宠物/);
+    expect(Object.values(optionalRuntimeState.extensionContributions)).toEqual(
+      EXTENSION_CONTRIBUTION_QUERIES.map(() => expect.objectContaining({ available: false }))
+    );
+    expect(optionalRuntimeState.channels).toMatchObject({ available: false });
+
+    await productApp.page.evaluate(() => {
+      window.location.hash = '#/settings/account';
+    });
+    await expect(productApp.page.locator('[data-settings-id="webui"], [data-settings-id="pet"]')).toHaveCount(0);
+    await expect(productApp.page.locator('[data-settings-path^="ext/"]')).toHaveCount(0);
+    await expect(productApp.page.getByText(/Channels|渠道|频道/i)).toHaveCount(0);
+  });
+
+  test('reports missing required product resources while Account and diagnostics remain usable', async ({}, testInfo) => {
+    await productApp.page.route('**/api/agents/management**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: [] }),
+      });
+    });
+    await productApp.page.reload();
+    await expect(productApp.page.getByTestId('installation-integrity-dialog')).toBeVisible({ timeout: 30_000 });
+    const reportButton = productApp.page.getByTestId('installation-integrity-report');
+    await expect(reportButton).toBeVisible();
+    await reportButton.click();
+    await expect(reportButton).toBeDisabled();
+    await expect.poll(() => productApp.page.evaluate(() => window.__installationIntegrityReportCount ?? 0)).toBe(1);
+    await attachClientState(testInfo, productApp, 'missing-product-resource');
+    const integrityModal = productApp.page.locator('.arco-modal').filter({
+      has: productApp.page.getByTestId('installation-integrity-dialog'),
+    });
+    await integrityModal.locator('.arco-modal-close-icon').click();
+    await expect(productApp.page.getByTestId('installation-integrity-dialog')).toBeHidden({ timeout: 10_000 });
+    await productApp.page.locator('[data-settings-id="account"]').click();
+    await expect(productApp.page).toHaveURL(/#\/settings\/account$/);
+    await expect(productApp.page.getByTestId('ki-buddy-account-card')).toBeVisible();
+    await productApp.page.getByTestId('ki-buddy-account-menu-button').click();
+    await expect(productApp.page.getByTestId('ki-buddy-account-logout-menu-item')).toBeVisible();
+    await productApp.page.unroute('**/api/agents/management**');
+  });
+
+  test('preserves full packaged AionUi behavior when the Ki-Buddy capability is absent', async ({}, testInfo) => {
+    const aionUiApp = await launchPackagedApp('aionui');
+    try {
+      const bootstrap = await aionUiApp.page.evaluate(
+        () => window.__getKiBuddyProductBootstrap?.() as ProductBootstrap | undefined
+      );
+      expect(bootstrap).toEqual({
+        status: 'absent',
+        productIdentity: null,
+        capability: null,
+        error: null,
+      });
+      expect(await aionUiApp.electronApp.evaluate(({ app }) => app.getName())).toBe('AionUi');
+
+      await aionUiApp.page.evaluate(() => {
+        window.location.hash = '#/settings/system';
+      });
+      await expect(aionUiApp.page.locator('[data-settings-id="webui"]')).toBeVisible({ timeout: 30_000 });
+      await expect(aionUiApp.page.locator('[data-settings-id="pet"]')).toBeVisible();
+      const settingsIds = await aionUiApp.page
+        .locator('[data-settings-id]')
+        .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-settings-id')));
+      expect(settingsIds).toEqual(
+        expect.arrayContaining(['agent', 'model', 'skills', 'tools', 'webui', 'pet', 'appearance', 'system', 'about'])
+      );
+
+      await aionUiApp.page.evaluate(() => {
+        window.location.hash = '#/settings/webui';
+      });
+      await expect(aionUiApp.page.locator('[data-webui-tab="channels"]')).toBeVisible({ timeout: 30_000 });
+      await aionUiApp.page.evaluate(() => {
+        window.location.hash = '#/settings/appearance';
+      });
+      await expect(
+        aionUiApp.page.locator(
+          '[data-product-features~="themeCustomEditor"][data-product-features~="themeMarketplace"]'
+        )
+      ).toBeVisible({ timeout: 30_000 });
+
+      await aionUiApp.page.evaluate(() => {
+        window.location.hash = '#/guid';
+      });
+      await expect(aionUiApp.page.getByTestId('guid-input')).toBeVisible({ timeout: 30_000 });
+      await expect(aionUiApp.page.getByTestId('team-section-toggle')).toBeVisible();
+      await expect(aionUiApp.page.locator('[data-product-feature="guidWebUi"]')).toBeVisible();
+      await expect(aionUiApp.page.locator('[data-product-feature="guidFeedback"]')).toBeVisible();
+      await expect(aionUiApp.page.locator('[data-product-feature="guidGithubStar"]')).toBeVisible();
+
+      await aionUiApp.page.evaluate(() => {
+        window.location.hash = '#/assistants';
+      });
+      await expect(aionUiApp.page.getByTestId('assistants-header')).toBeVisible({ timeout: 30_000 });
+      await aionUiApp.page.evaluate(() => {
+        window.location.hash = '#/scheduled';
+      });
+      await expect(aionUiApp.page.getByTestId('scheduled-tasks-header')).toBeVisible({ timeout: 30_000 });
+      await aionUiApp.page.evaluate(() => {
+        window.location.hash = '#/test/components';
+      });
+      await expect(aionUiApp.page).toHaveURL(/#\/test\/components$/);
+      await attachClientState(testInfo, aionUiApp, 'aionui-capability-absent');
+    } catch (error) {
+      await attachClientState(testInfo, aionUiApp, 'aionui-failure-state').catch(() => undefined);
+      throw error;
+    } finally {
+      await closePackagedApp(aionUiApp);
+    }
+  });
+});

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -124,7 +124,7 @@ async function ensureRendererAppMounted(page: Page): Promise<void> {
   }
 }
 
-async function resolveMainWindow(electronApp: ElectronApplication): Promise<Page> {
+export async function resolveMainWindow(electronApp: ElectronApplication): Promise<Page> {
   const existingMainWindow = electronApp.windows().find((win) => !isDevToolsWindow(win));
   if (existingMainWindow) {
     await ensureRendererAppMounted(existingMainWindow);
@@ -152,9 +152,16 @@ async function resolveMainWindow(electronApp: ElectronApplication): Promise<Page
  * Resolve the path to the packaged Electron executable under out/.
  * Returns { executablePath, cwd } or null if not found.
  */
-function resolvePackagedApp(): { executablePath: string; cwd: string } | null {
+export type PackagedApp = Readonly<{
+  applicationRoot: string;
+  cwd: string;
+  executablePath: string;
+  resourcesPath: string;
+}>;
+
+export function resolvePackagedApp(rootDirectory?: string): PackagedApp | null {
   const projectRoot = path.resolve(__dirname, '../..');
-  const outDir = path.join(projectRoot, 'out');
+  const outDir = rootDirectory ? path.resolve(rootDirectory) : path.join(projectRoot, 'out');
   if (!fs.existsSync(outDir)) return null;
 
   const platform = process.platform;
@@ -167,7 +174,14 @@ function resolvePackagedApp(): { executablePath: string; cwd: string } | null {
       const executable = ['Ki-Buddy.exe', 'AionUi.exe']
         .map((name) => path.join(dirPath, name))
         .find((candidate) => fs.existsSync(candidate));
-      if (executable) return { executablePath: executable, cwd: dirPath };
+      if (executable) {
+        return {
+          applicationRoot: dirPath,
+          executablePath: executable,
+          cwd: dirPath,
+          resourcesPath: path.join(dirPath, 'resources'),
+        };
+      }
     }
   } else if (platform === 'darwin') {
     // Resolve the executable declared by either the Ki-Buddy or AionUi bundle.
@@ -183,7 +197,15 @@ function resolvePackagedApp(): { executablePath: string; cwd: string } | null {
               .map((name) => path.join(executableDir, name))
               .find((candidate) => fs.statSync(candidate).isFile())
           : undefined;
-        if (executable) return { executablePath: executable, cwd: macDir };
+        if (executable) {
+          const applicationRoot = path.join(macDir, appBundle);
+          return {
+            applicationRoot,
+            executablePath: executable,
+            cwd: macDir,
+            resourcesPath: path.join(applicationRoot, 'Contents', 'Resources'),
+          };
+        }
       }
     }
   } else {
@@ -193,7 +215,14 @@ function resolvePackagedApp(): { executablePath: string; cwd: string } | null {
       if (!fs.existsSync(dirPath)) continue;
       for (const name of ['Ki-Buddy', 'ki-buddy', 'aionui', 'AionUi']) {
         const exe = path.join(dirPath, name);
-        if (fs.existsSync(exe)) return { executablePath: exe, cwd: dirPath };
+        if (fs.existsSync(exe)) {
+          return {
+            applicationRoot: dirPath,
+            executablePath: exe,
+            cwd: dirPath,
+            resourcesPath: path.join(dirPath, 'resources'),
+          };
+        }
       }
     }
   }
@@ -208,7 +237,7 @@ function shouldUsePackagedMode(): boolean {
   return !!process.env.CI;
 }
 
-function createE2EEnvironment(userDataDir: string, stateFile: string): NodeJS.ProcessEnv {
+export function createE2EEnvironment(userDataDir: string, stateFile: string): NodeJS.ProcessEnv {
   return {
     ...process.env,
     AIONUI_EXTENSIONS_PATH:

--- a/tests/e2e/helpers/bridge/invoke.ts
+++ b/tests/e2e/helpers/bridge/invoke.ts
@@ -1,6 +1,7 @@
 import type { Page } from '@playwright/test';
 import { RESPONSE_MAPPERS } from './mappers';
 import { HTTP_ROUTES } from './routes';
+import { fetchBackendFromRenderer } from '../httpBridge';
 
 type ElectronApi = {
   emit?: (name: string, data: unknown) => Promise<unknown>;
@@ -30,62 +31,12 @@ export async function invokeBridge<T = unknown>(
     const body =
       route.method === 'GET' || route.method === 'DELETE' ? undefined : route.mapBody ? route.mapBody(params) : data;
 
-    const raw = await page.evaluate(
-      async ({ method, path, requestBody, requestTimeoutMs }) => {
-        const port = (window as unknown as { __backendPort?: number }).__backendPort;
-        if (!port) {
-          throw new Error('window.__backendPort is not available in renderer context');
-        }
-
-        const controller = new AbortController();
-        const timer = setTimeout(() => controller.abort(), requestTimeoutMs);
-
-        try {
-          const headers: Record<string, string> = {};
-          if (requestBody !== undefined) headers['Content-Type'] = 'application/json';
-
-          const requestInit: RequestInit = {
-            method,
-            headers,
-            signal: controller.signal,
-          };
-          if (requestBody !== undefined && method !== 'GET') {
-            requestInit.body = JSON.stringify(requestBody);
-          }
-
-          const response = await fetch(`http://127.0.0.1:${port}${path}`, requestInit);
-
-          if (!response.ok) {
-            let errBody: unknown;
-            try {
-              errBody = await response.json();
-            } catch {
-              errBody = await response.text();
-            }
-            throw new Error(`Backend ${method} ${path} failed (${response.status}): ${JSON.stringify(errBody)}`);
-          }
-
-          const contentType = response.headers.get('Content-Type');
-          if (!contentType?.includes('application/json')) {
-            return undefined;
-          }
-
-          const json = (await response.json()) as { success?: boolean; data?: unknown };
-          if (json && typeof json === 'object' && 'data' in json) {
-            return json.data;
-          }
-          return json;
-        } finally {
-          clearTimeout(timer);
-        }
-      },
-      {
-        method: route.method,
-        path: resolvedPath,
-        requestBody: body,
-        requestTimeoutMs: timeoutMs,
-      }
-    );
+    const raw = await page.evaluate(fetchBackendFromRenderer, {
+      method: route.method,
+      path: resolvedPath,
+      body,
+      timeoutMs,
+    });
 
     return (route.mapResponse ? RESPONSE_MAPPERS[route.mapResponse](raw) : raw) as T;
   }

--- a/tests/e2e/helpers/httpBridge.ts
+++ b/tests/e2e/helpers/httpBridge.ts
@@ -16,7 +16,59 @@ import type { Page } from '@playwright/test';
  * `data` when present, matching `httpBridge.ts:76` in the renderer adapter.
  */
 
-type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+type RendererBackendRequest = Readonly<{
+  body?: unknown;
+  method: HttpMethod;
+  path: string;
+  timeoutMs?: number;
+}>;
+
+/** Executes one authenticated backend request from the renderer network context. */
+export async function fetchBackendFromRenderer({
+  body,
+  method,
+  path,
+  timeoutMs,
+}: RendererBackendRequest): Promise<unknown> {
+  const port = window.__backendPort;
+  if (!port) throw new Error('window.__backendPort is not available in renderer context');
+
+  const effectiveBody = body !== undefined ? body : method === 'DELETE' ? {} : undefined;
+  const headers: Record<string, string> = {};
+  if (effectiveBody !== undefined) headers['Content-Type'] = 'application/json';
+  const csrfToken = window.electronAPI?.kiBuddyCoreTransport?.csrfToken;
+  if (csrfToken && !['GET', 'HEAD', 'OPTIONS'].includes(method)) headers['x-csrf-token'] = csrfToken;
+
+  const controller = timeoutMs ? new AbortController() : undefined;
+  const timer = timeoutMs ? window.setTimeout(() => controller?.abort(), timeoutMs) : undefined;
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+      method,
+      headers,
+      credentials: 'include',
+      signal: controller?.signal,
+      ...(effectiveBody !== undefined && method !== 'GET' ? { body: JSON.stringify(effectiveBody) } : {}),
+    });
+
+    if (!response.ok) {
+      let errorBody: unknown;
+      try {
+        errorBody = await response.json();
+      } catch {
+        errorBody = await response.text();
+      }
+      throw new Error(`Backend ${method} ${path} failed (${response.status}): ${JSON.stringify(errorBody)}`);
+    }
+
+    if (!response.headers.get('Content-Type')?.includes('application/json')) return undefined;
+    const json = (await response.json()) as unknown;
+    return json && typeof json === 'object' && 'data' in json ? (json as { data: unknown }).data : json;
+  } finally {
+    if (timer !== undefined) window.clearTimeout(timer);
+  }
+}
 
 export async function httpInvoke<T = unknown>(
   page: Page,
@@ -24,50 +76,7 @@ export async function httpInvoke<T = unknown>(
   path: string,
   body?: unknown
 ): Promise<T> {
-  return page.evaluate(
-    async ({ method: m, path: p, body: b }) => {
-      const port = (window as unknown as { __backendPort?: number }).__backendPort ?? 13400;
-      const url = `http://127.0.0.1:${port}${p}`;
-      // DELETE routes require Content-Type: application/json AND a JSON-parseable
-      // body even when the operation takes no body (e.g. DELETE /api/skills/external-paths
-      // where the path is in the query string). Send `{}` as default body for DELETE.
-      const effectiveBody = b !== undefined ? b : m === 'DELETE' ? {} : undefined;
-      const headers: Record<string, string> = {};
-      if (effectiveBody !== undefined) headers['Content-Type'] = 'application/json';
-
-      const requestInit: RequestInit = {
-        method: m,
-        headers,
-      };
-      if (effectiveBody !== undefined && m !== 'GET') {
-        requestInit.body = JSON.stringify(effectiveBody);
-      }
-
-      const res = await fetch(url, requestInit);
-
-      if (!res.ok) {
-        let errText: string;
-        try {
-          errText = JSON.stringify(await res.json());
-        } catch {
-          errText = await res.text();
-        }
-        throw new Error(`Backend ${m} ${p} failed (${res.status}): ${errText}`);
-      }
-
-      const contentType = res.headers.get('Content-Type');
-      if (!contentType?.includes('application/json')) {
-        return undefined;
-      }
-
-      const json = await res.json();
-      if (json && typeof json === 'object' && 'data' in json) {
-        return (json as { data: unknown }).data;
-      }
-      return json;
-    },
-    { method, path, body }
-  ) as Promise<T>;
+  return page.evaluate(fetchBackendFromRenderer, { method, path, body }) as Promise<T>;
 }
 
 export const httpGet = <T = unknown>(page: Page, path: string) => httpInvoke<T>(page, 'GET', path);

--- a/tests/unit/assets/kiBuddyRelease.test.ts
+++ b/tests/unit/assets/kiBuddyRelease.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { copyFileSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { load as loadYaml } from 'js-yaml';
 
 const {
+  createKiBuddyBuildEvidence,
+  createSourceStateSha256,
   createEffectivePackageJson,
   createElectronBuilderConfig,
   readKiBuddyRelease,
@@ -20,6 +24,12 @@ function readPngDimensions(relativePath: string): { height: number; width: numbe
   const data = readFileSync(join(projectRoot, relativePath));
   expect(data.subarray(0, 8).toString('hex')).toBe('89504e470d0a1a0a');
   return { width: data.readUInt32BE(16), height: data.readUInt32BE(20) };
+}
+
+function sha256(relativePath: string): string {
+  return createHash('sha256')
+    .update(readFileSync(join(projectRoot, relativePath)))
+    .digest('hex');
 }
 
 describe('Ki-Buddy product release identity', () => {
@@ -268,9 +278,114 @@ describe('Ki-Buddy product release identity', () => {
         resource.to === 'app.png' ? Object.assign({}, resource, { from: productConfig.assets.platform.png }) : resource
       );
       expectedResources.push({ from: productConfig.assets.platform.png, to: productConfig.assets.packaged.icon });
+      const evidencePath = join(tempDir, 'ki-buddy-build-evidence.json');
+      expectedResources.push({ from: evidencePath, to: 'ki-buddy-build-evidence.json' });
       expect(config.extraResources).toEqual(expectedResources);
+      expect(JSON.parse(readFileSync(evidencePath, 'utf8'))).toMatchObject({
+        product: { runtimeIdentity: 'ki-buddy', productName: 'Ki-Buddy' },
+        sourceCommit: expect.stringMatching(/^[0-9a-f]{40}$/),
+      });
       expect(JSON.parse(readFileSync(outputPath, 'utf8'))).toEqual(config);
       expect(readFileSync(join(projectRoot, 'package.json'), 'utf8')).toBe(originalPackage);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('records the exact product policy sources, tested commit, and source-tree state in packaged build evidence', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'ki-buddy-build-evidence-'));
+    const outputPath = join(tempDir, 'ki-buddy-build-evidence.json');
+    const testedCommit = 'a'.repeat(40);
+    try {
+      const sourceStateSha256 = 'c'.repeat(64);
+      const evidence = createKiBuddyBuildEvidence(projectRoot, outputPath, {
+        commit: testedCommit,
+        dirty: false,
+        sourceStateSha256,
+      });
+
+      expect(evidence).toEqual({
+        schemaVersion: 1,
+        product: {
+          runtimeIdentity: 'ki-buddy',
+          productName: 'Ki-Buddy',
+        },
+        sourceCommit: testedCommit,
+        sourceTreeDirty: false,
+        sourceStateSha256,
+        policySources: {
+          productConfig: {
+            path: 'ki-buddy-product.json',
+            sha256: sha256('ki-buddy-product.json'),
+          },
+          experienceRegistry: {
+            path: 'packages/desktop/src/common/platform/ki-buddy/experience/registry.json',
+            sha256: sha256('packages/desktop/src/common/platform/ki-buddy/experience/registry.json'),
+          },
+        },
+      });
+      expect(JSON.parse(readFileSync(outputPath, 'utf8'))).toEqual(evidence);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('marks build evidence when the packaged source tree contains uncommitted changes', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'ki-buddy-dirty-build-evidence-'));
+    try {
+      expect(
+        createKiBuddyBuildEvidence(projectRoot, join(tempDir, 'evidence.json'), {
+          commit: 'b'.repeat(40),
+          dirty: true,
+          sourceStateSha256: 'd'.repeat(64),
+        })
+      ).toMatchObject({
+        sourceCommit: 'b'.repeat(40),
+        sourceTreeDirty: true,
+        sourceStateSha256: 'd'.repeat(64),
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('changes source-state evidence for package.json, other tracked files, and untracked files', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'ki-buddy-source-state-'));
+    const packagePath = join(tempDir, 'package.json');
+    const trackedPath = join(tempDir, 'tracked.txt');
+    const packageContents = '{"name":"upstream"}\n';
+    const trackedContents = 'tracked baseline\n';
+    try {
+      execFileSync('git', ['init', '--quiet'], { cwd: tempDir });
+      writeFileSync(packagePath, packageContents);
+      writeFileSync(trackedPath, trackedContents);
+      execFileSync('git', ['add', 'package.json', 'tracked.txt'], { cwd: tempDir });
+      execFileSync(
+        'git',
+        [
+          '-c',
+          'user.name=Ki-Buddy Test',
+          '-c',
+          'user.email=ki-buddy-test@example.com',
+          'commit',
+          '--quiet',
+          '-m',
+          'base',
+        ],
+        { cwd: tempDir }
+      );
+
+      const baseline = createSourceStateSha256(tempDir);
+      writeFileSync(packagePath, '{"name":"modified-product"}\n');
+      expect(createSourceStateSha256(tempDir)).not.toBe(baseline);
+
+      writeFileSync(packagePath, packageContents);
+      writeFileSync(trackedPath, 'tracked modification\n');
+      expect(createSourceStateSha256(tempDir)).not.toBe(baseline);
+
+      writeFileSync(trackedPath, trackedContents);
+      writeFileSync(join(tempDir, 'untracked.txt'), 'untracked evidence\n');
+      expect(createSourceStateSha256(tempDir)).not.toBe(baseline);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/tests/unit/e2e/firstReleaseMatrix.test.ts
+++ b/tests/unit/e2e/firstReleaseMatrix.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { FIRST_RELEASE_MATRIX } from '../../e2e/features/remote/ki-buddy/firstReleaseMatrix';
+
+describe('Ki-Buddy first-release disabled-feature evidence', () => {
+  it('classifies every disabled feature exactly once', () => {
+    const disabledFeatures = Object.entries(FIRST_RELEASE_MATRIX.features)
+      .filter(([, state]) => state === 'disabled')
+      .map(([featureId]) => featureId)
+      .toSorted();
+    const classifiedFeatures = Object.values(FIRST_RELEASE_MATRIX.disabledFeatureEvidence)
+      .flatMap((classification) => Object.keys(classification))
+      .toSorted();
+
+    expect(classifiedFeatures).toEqual(disabledFeatures);
+    expect(new Set(classifiedFeatures).size).toBe(classifiedFeatures.length);
+  });
+
+  it('keeps every flash-observed feature connected to at least one selector', () => {
+    for (const selectors of Object.values(FIRST_RELEASE_MATRIX.disabledFeatureEvidence.flashObserved)) {
+      expect(selectors.length).toBeGreaterThan(0);
+      expect(selectors.every((selector) => selector.startsWith('['))).toBe(true);
+    }
+  });
+});

--- a/tests/unit/e2e/processTreeNetworkState.test.ts
+++ b/tests/unit/e2e/processTreeNetworkState.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collectProcessTreePids,
+  partitionExpectedPlaywrightElectronListeners,
+  parseLsofListeners,
+  parsePsProcessTable,
+  parseWindowsListeners,
+  parseWindowsProcesses,
+} from '../../e2e/features/remote/ki-buddy/processTreeNetworkState';
+
+describe('packaged process-tree network evidence', () => {
+  it('parses Unix process rows and keeps commands with spaces', () => {
+    expect(parsePsProcessTable('  10   1 Electron Helper\n  11  10 aioncore\ninvalid\n')).toEqual([
+      { pid: 10, ppid: 1, command: 'Electron Helper' },
+      { pid: 11, ppid: 10, command: 'aioncore' },
+    ]);
+  });
+
+  it('parses lsof field output and ignores malformed endpoints', () => {
+    expect(parseLsofListeners('p10\ncElectron\nn127.0.0.1:43100\nninvalid\np11\ncaioncore\nn*:43101\n')).toEqual([
+      { pid: 10, command: 'Electron', address: '127.0.0.1:43100', port: 43100, protocol: 'tcp' },
+      { pid: 11, command: 'aioncore', address: '*:43101', port: 43101, protocol: 'tcp' },
+    ]);
+  });
+
+  it('finds descendants regardless of process-table order', () => {
+    const processes = [
+      { pid: 13, ppid: 12, command: 'grandchild' },
+      { pid: 12, ppid: 10, command: 'child' },
+      { pid: 99, ppid: 1, command: 'unrelated' },
+    ];
+    expect([...collectProcessTreePids(processes, 10)].toSorted((left, right) => left - right)).toEqual([10, 12, 13]);
+  });
+
+  it('normalizes single-object Windows snapshots and rejects incomplete records', () => {
+    const processes = parseWindowsProcesses(
+      JSON.stringify({
+        ProcessId: 20,
+        ParentProcessId: 10,
+        Name: 'aioncore.exe',
+        CommandLine: 'aioncore.exe --port 43200',
+      })
+    );
+    expect(processes).toEqual([{ pid: 20, ppid: 10, command: 'aioncore.exe --port 43200' }]);
+    expect(
+      parseWindowsListeners(
+        JSON.stringify([
+          { OwningProcess: 20, LocalAddress: '127.0.0.1', LocalPort: 43200 },
+          { OwningProcess: 'bad', LocalAddress: '127.0.0.1', LocalPort: 1 },
+        ]),
+        processes
+      )
+    ).toEqual([{ pid: 20, command: 'aioncore.exe --port 43200', address: '127.0.0.1', port: 43200, protocol: 'tcp' }]);
+  });
+
+  it('separates the two listeners created by Playwright Electron launch flags', () => {
+    const backendListener = {
+      pid: 11,
+      command: 'aioncore --port 43100',
+      address: '127.0.0.1:43100',
+      port: 43100,
+      protocol: 'tcp' as const,
+    };
+    const inspectListener = {
+      pid: 10,
+      command: 'Ki-Buddy --inspect=0 --remote-debugging-port=0',
+      address: '127.0.0.1:43101',
+      port: 43101,
+      protocol: 'tcp' as const,
+    };
+    const devtoolsListener = { ...inspectListener, address: '127.0.0.1:43102', port: 43102 };
+    const partition = partitionExpectedPlaywrightElectronListeners(
+      {
+        rootPid: 10,
+        processes: [
+          { pid: 10, ppid: 1, command: inspectListener.command },
+          { pid: 11, ppid: 10, command: backendListener.command },
+        ],
+        listeners: [backendListener, inspectListener, devtoolsListener],
+      },
+      43100
+    );
+
+    expect(partition.playwrightHarnessListeners).toEqual([inspectListener, devtoolsListener]);
+    expect(partition.applicationListeners).toEqual([backendListener]);
+  });
+
+  it('finds Playwright listeners on the Electron child of a Windows command wrapper', () => {
+    const electronCommand = '"C:\\Ki-Buddy.exe" "--inspect=0" "--remote-debugging-port=0"';
+    const inspectListener = {
+      pid: 12,
+      command: electronCommand,
+      address: '127.0.0.1',
+      port: 43101,
+      protocol: 'tcp' as const,
+    };
+    const devtoolsListener = { ...inspectListener, port: 43102 };
+    const partition = partitionExpectedPlaywrightElectronListeners(
+      {
+        rootPid: 10,
+        processes: [
+          { pid: 10, ppid: 1, command: `cmd.exe /c ${electronCommand}` },
+          { pid: 12, ppid: 10, command: electronCommand },
+        ],
+        listeners: [inspectListener, devtoolsListener],
+      },
+      43100
+    );
+
+    expect(partition.playwrightHarnessListeners).toEqual([inspectListener, devtoolsListener]);
+    expect(partition.applicationListeners).toEqual([]);
+  });
+
+  it.each([
+    ['missing launch flags', 'Ki-Buddy', [43101, 43102]],
+    ['an unexpected third listener', 'Ki-Buddy --inspect=0 --remote-debugging-port=0', [43101, 43102, 43103]],
+  ])('does not classify harness listeners when %s', (_scenario, command, ports) => {
+    const listeners = ports.map((port) => ({
+      pid: 10,
+      command,
+      address: `127.0.0.1:${port}`,
+      port,
+      protocol: 'tcp' as const,
+    }));
+    const partition = partitionExpectedPlaywrightElectronListeners(
+      { rootPid: 10, processes: [{ pid: 10, ppid: 1, command }], listeners },
+      43100
+    );
+
+    expect(partition.playwrightHarnessListeners).toEqual([]);
+    expect(partition.applicationListeners).toEqual(listeners);
+  });
+});

--- a/tests/unit/e2e/rendererLoadTarget.test.ts
+++ b/tests/unit/e2e/rendererLoadTarget.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  E2E_FORBIDDEN_SELECTORS_QUERY_KEY,
+  appendRendererQuery,
+  resolveE2ERendererQuery,
+} from '@/process/startup/rendererLoadTarget';
+
+describe('renderer first-frame observer target', () => {
+  it('passes validated selectors only in E2E mode', () => {
+    expect(
+      resolveE2ERendererQuery({
+        AIONUI_E2E_TEST: '1',
+        AIONUI_E2E_FORBIDDEN_SELECTORS: '["[data-disabled]"]',
+      })
+    ).toEqual({ [E2E_FORBIDDEN_SELECTORS_QUERY_KEY]: '["[data-disabled]"]' });
+    expect(
+      resolveE2ERendererQuery({
+        AIONUI_E2E_TEST: '0',
+        AIONUI_E2E_FORBIDDEN_SELECTORS: '["[data-disabled]"]',
+      })
+    ).toBeUndefined();
+  });
+
+  it('rejects a malformed selector contract before renderer startup', () => {
+    expect(() =>
+      resolveE2ERendererQuery({
+        AIONUI_E2E_TEST: '1',
+        AIONUI_E2E_FORBIDDEN_SELECTORS: '{"selector":"[data-disabled]"}',
+      })
+    ).toThrow('AIONUI_E2E_FORBIDDEN_SELECTORS must be a JSON string array');
+  });
+
+  it('preserves an existing development-server query', () => {
+    const target = new URL(
+      appendRendererQuery('http://127.0.0.1:5173/?existing=1', {
+        [E2E_FORBIDDEN_SELECTORS_QUERY_KEY]: '["[data-disabled]"]',
+      })
+    );
+    expect(target.searchParams.get('existing')).toBe('1');
+    expect(target.searchParams.get(E2E_FORBIDDEN_SELECTORS_QUERY_KEY)).toBe('["[data-disabled]"]');
+  });
+});

--- a/tests/unit/process/trayToggle.test.ts
+++ b/tests/unit/process/trayToggle.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { formatTrayBrandText, shouldShowFromTray } from '@/process/utils/tray';
+import { collectTrayMenuLabels, formatTrayBrandText, shouldShowFromTray } from '@/process/utils/tray';
 
 describe('shouldShowFromTray', () => {
   it('shows when window is not visible', () => {
@@ -25,5 +25,20 @@ describe('tray brand text', () => {
   it('uses the configured product name without changing unrelated translated text', () => {
     expect(formatTrayBrandText('Show AionUi', 'Ki-Buddy')).toBe('Show Ki-Buddy');
     expect(formatTrayBrandText('Recent conversations', 'Ki-Buddy')).toBe('Recent conversations');
+  });
+});
+
+describe('collectTrayMenuLabels', () => {
+  it('records nested tray contributions as stable label paths', () => {
+    expect(
+      collectTrayMenuLabels([
+        { label: 'Show Ki-Buddy' },
+        { label: 'Desktop Pet', submenu: { items: [{ label: 'Show / Hide' }, { label: 'Small' }] } },
+      ])
+    ).toEqual(['Show Ki-Buddy', 'Desktop Pet', 'Desktop Pet > Show / Hide', 'Desktop Pet > Small']);
+  });
+
+  it('ignores separators and empty submenus without producing empty paths', () => {
+    expect(collectTrayMenuLabels([{ submenu: { items: [] } }, {}, { label: '  ' }])).toEqual([]);
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

为 Ki-Buddy 首发产品矩阵增加基于真实 packaged Electron 应用的验收测试，并补充测试所需的窄观测接缝。

本 PR 覆盖以下行为：

- 校验安装包产品身份、源码 commit、工作树状态、策略来源 hash，以及 `release-pinned` Ki-Core manifest。
- 验证首次启动、登录前后、刷新和重启过程中禁用功能不会短暂出现。
- 验证导航、直接路由、Appearance 子能力、Scheduled Tasks 和资源访问矩阵。
- 通过真实 packaged backend 完成 Custom Model 与 Custom MCP 的创建、修改和删除。
- 隔离 Custom Model 的模型拉取与协议探测辅助流量，测试不依赖互联网。
- 采集窗口、Tray、端口、Extension contribution、日志、截图和进程网络状态，便于失败分析。
- 验证产品资源缺失时 Account 与诊断入口仍可操作，并保护 capability 缺失时的完整 AionUi 行为。
- 为 Linux packaged E2E 提供临时 D-Bus Secret Service，并兼容 Windows 的 Electron 包装进程与异步删除时序。

该验收用于防止产品策略、打包来源或 AionUi 上游同步导致入口、运行行为和资源权限出现不一致。

## Related Issues

- Closes #52

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

本 PR 的 Conventional Commit 类型为 `test`，模板中没有对应选项。

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [ ] `bun run format` — formatting passes（未执行写入式格式化；`just push` 的 `bun run format:check` 已通过）
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 4167 passed，5 skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

不适用。本 PR 主要增加自动化验收和测试观测能力。

## Additional Context

- 使用 `AIONUI_BACKEND_SOURCE_POLICY=release-pinned` 构建 packaged 应用。
- 本地 macOS packaged E2E：12/12 passed；对应修改前的应用源码提交 `bf29a3f3124404448f15db979efcdc0a4d58f3ef`，`sourceTreeDirty=false`。
- 当前提交为 `ccbeed152`；Linux 与 Windows CI 环境修复由新的跨平台构建任务验证。
- 两个全新 reviewer 分别完成 Standards 与 Spec 审查，均无 P0–P3。
- `package.json` 与 `bun.lock` 未修改。
- i18n 检查存在仓库既有 warning，但命令成功通过。
