### PR TITLE
feat(agents): add catalog describe and session cache

### DIFF
--- a/packages/desktop/src/process/ki-buddy/AgentsAuthService.ts
+++ b/packages/desktop/src/process/ki-buddy/AgentsAuthService.ts
@@ -182,6 +182,11 @@ export class AgentsAuthService {
   /** Creates the service with explicit network, credential, and Core-session dependencies. */
   constructor(private readonly dependencies: AgentsAuthServiceDependencies) {}
 
+  /** Returns the non-secret epoch that binds callers to the current authenticated session. */
+  getSessionEpoch(): number {
+    return this.sessionGeneration;
+  }
+
   /** Restores a saved Agents token and projects its verified identity into Core. */
   async getSession(): Promise<KiBuddyAuthSession> {
     if (this.session.status === 'authenticated' || this.restoreAttempted) {

--- a/packages/desktop/src/process/ki-buddy/agents/bridge.ts
+++ b/packages/desktop/src/process/ki-buddy/agents/bridge.ts
@@ -1,5 +1,6 @@
 import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AgentsCatalogIdentity } from './catalog';
 import { AgentsMcpError, getAgentsMcpErrorPresentation, type AgentsMcpErrorCode } from './errors';
 import { readBoundedJsonResponse } from './json';
 
@@ -7,7 +8,8 @@ const BRIDGE_HOST = '127.0.0.1';
 const MAX_CATALOG_RESPONSE_BYTES = 5 * 1024 * 1024;
 
 type StartAgentsMcpBridgeOptions = Readonly<{
-  fetchCatalog: (signal: AbortSignal) => Promise<Response>;
+  fetchCatalog: (signal: AbortSignal) => Promise<Readonly<{ identity: AgentsCatalogIdentity; response: Response }>>;
+  getSessionIdentity: () => Promise<AgentsCatalogIdentity>;
   token?: string;
 }>;
 
@@ -44,17 +46,26 @@ async function handleCatalogRequest(
   signal: AbortSignal
 ): Promise<void> {
   try {
-    const upstream = await options.fetchCatalog(signal);
+    const { identity, response: upstream } = await options.fetchCatalog(signal);
     if (signal.aborted) return;
     if (upstream.status === 401 || upstream.status === 403) {
       throw new AgentsMcpError('auth', 'Agents login is required');
     }
     if (!upstream.ok) throw new AgentsMcpError('server', 'Agents catalog service is unavailable');
     const payload = await readBoundedJsonResponse(upstream, MAX_CATALOG_RESPONSE_BYTES);
-    sendJson(response, 200, payload);
+    sendJson(response, 200, { identity, catalog: payload });
   } catch (error) {
     if (signal.aborted) return;
     const safe = bridgeError(error instanceof AgentsMcpError ? error.code : 'network');
+    sendJson(response, safe.status, safe.body);
+  }
+}
+
+async function handleSessionRequest(options: StartAgentsMcpBridgeOptions, response: ServerResponse): Promise<void> {
+  try {
+    sendJson(response, 200, await options.getSessionIdentity());
+  } catch (error) {
+    const safe = bridgeError(error instanceof AgentsMcpError ? error.code : 'auth');
     sendJson(response, safe.status, safe.body);
   }
 }
@@ -68,8 +79,12 @@ export async function startAgentsMcpBridge(options: StartAgentsMcpBridgeOptions)
       sendJson(response, 401, { error: 'adapter_auth_required' });
       return;
     }
-    if (request.method !== 'GET' || request.url !== '/catalog') {
+    if (request.method !== 'GET' || !['/catalog', '/session'].includes(request.url ?? '')) {
       sendJson(response, 404, { error: 'not_found' });
+      return;
+    }
+    if (request.url === '/session') {
+      void handleSessionRequest(options, response);
       return;
     }
     const controller = new AbortController();

--- a/packages/desktop/src/process/ki-buddy/agents/catalog.ts
+++ b/packages/desktop/src/process/ki-buddy/agents/catalog.ts
@@ -5,6 +5,10 @@ const MAX_AGENT_ID_LENGTH = 200;
 const MAX_AGENT_TITLE_LENGTH = 500;
 const MAX_AGENT_DESCRIPTION_LENGTH = 4000;
 const MAX_AGENT_TYPE_LENGTH = 100;
+const MAX_SCHEMA_FIELDS = 200;
+const MAX_SCHEMA_FIELD_NAME_LENGTH = 200;
+const MAX_ALLOWED_FILE_TYPES = 100;
+const MAX_ALLOWED_FILE_TYPE_LENGTH = 200;
 
 export type AgentsCatalogSummary = Readonly<{
   agentId: string;
@@ -17,6 +21,40 @@ export type AgentsCatalogInventory = Readonly<{
   agents: readonly AgentsCatalogSummary[];
   total: number;
 }>;
+
+export type AgentsCatalogIdentity = Readonly<{
+  deploymentOrigin: string;
+  sessionEpoch: number;
+  userId: string;
+}>;
+
+export type AgentsSchemaField = Readonly<{
+  allowed_file_types?: readonly string[];
+  description: string;
+  name: string;
+  required: boolean;
+  type: string;
+}>;
+
+export type AgentsCatalogDescription = AgentsCatalogSummary &
+  Readonly<{
+    inputSchema: readonly AgentsSchemaField[];
+    outputSchema: readonly AgentsSchemaField[];
+  }>;
+
+export type AgentsCatalogSelection = Readonly<{
+  description: AgentsCatalogDescription;
+  inventory: AgentsCatalogInventory;
+}>;
+
+/** Compares every field that binds a catalog snapshot to an authenticated Agents session. */
+export function isSameAgentsCatalogIdentity(left: AgentsCatalogIdentity, right: AgentsCatalogIdentity): boolean {
+  return (
+    left.deploymentOrigin === right.deploymentOrigin &&
+    left.sessionEpoch === right.sessionEpoch &&
+    left.userId === right.userId
+  );
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -32,6 +70,47 @@ function requireString(value: unknown, label: string, maxLength: number, allowEm
     throw new AgentsMcpError('contract', `${label} exceeds the supported length`);
   }
   return normalized;
+}
+
+function normalizeAllowedFileTypes(value: unknown, label: string): readonly string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length > MAX_ALLOWED_FILE_TYPES) {
+    throw new AgentsMcpError('contract', `${label} must be a supported string array`);
+  }
+  const seen = new Set<string>();
+  return value.map((item) => {
+    const fileType = requireString(item, label, MAX_ALLOWED_FILE_TYPE_LENGTH);
+    if (seen.has(fileType)) throw new AgentsMcpError('contract', `${label} contains a duplicate value`);
+    seen.add(fileType);
+    return fileType;
+  });
+}
+
+function normalizeSchema(value: unknown, label: string): readonly AgentsSchemaField[] {
+  if (!Array.isArray(value) || value.length > MAX_SCHEMA_FIELDS) {
+    throw new AgentsMcpError('contract', `${label} must be a supported array`);
+  }
+  const seenNames = new Set<string>();
+  return value.map((item): AgentsSchemaField => {
+    if (!isRecord(item)) throw new AgentsMcpError('contract', `${label} field must be an object`);
+    const name = requireString(item.name, `${label} field name`, MAX_SCHEMA_FIELD_NAME_LENGTH);
+    if (seenNames.has(name)) throw new AgentsMcpError('contract', `${label} contains a duplicate field name`);
+    seenNames.add(name);
+    if (typeof item.required !== 'boolean') {
+      throw new AgentsMcpError('contract', `${label} field required must be a boolean`);
+    }
+    const allowedFileTypes = normalizeAllowedFileTypes(item.allowed_file_types, `${label} allowed_file_types`);
+    return {
+      name,
+      description:
+        item.description === undefined || item.description === null
+          ? ''
+          : requireString(item.description, `${label} field description`, MAX_AGENT_DESCRIPTION_LENGTH, true),
+      type: requireString(item.type, `${label} field type`, MAX_AGENT_TYPE_LENGTH),
+      required: item.required,
+      ...(allowedFileTypes ? { allowed_file_types: allowedFileTypes } : {}),
+    };
+  });
 }
 
 /** Projects one complete Agents Bridge catalog envelope into its safe public inventory. */
@@ -57,7 +136,7 @@ export function normalizeAgentsCatalog(value: unknown): AgentsCatalogInventory {
     if (!isRecord(item)) throw new AgentsMcpError('contract', 'Agents catalog entry must be an object');
     const agentId = requireString(item.agentId, 'Agents catalog agentId', MAX_AGENT_ID_LENGTH);
     if (seenAgentIds.has(agentId)) {
-      throw new AgentsMcpError('contract', 'Agents catalog contains a duplicate agentId');
+      throw new AgentsMcpError('ambiguous', 'Agents catalog contains a duplicate agentId');
     }
     seenAgentIds.add(agentId);
 
@@ -73,4 +152,21 @@ export function normalizeAgentsCatalog(value: unknown): AgentsCatalogInventory {
   });
 
   return { total: agents.length, agents };
+}
+
+/** Projects the safe inventory and exact supported schema for one candidate in a single validation pass. */
+export function normalizeAgentsCatalogSelection(value: unknown, requestedAgentId: string): AgentsCatalogSelection {
+  const inventory = normalizeAgentsCatalog(value);
+  const index = inventory.agents.findIndex(({ agentId }) => agentId === requestedAgentId);
+  if (index < 0) throw new AgentsMcpError('not_found', 'Agent is not in the current catalog');
+  const catalogRecord = (value as { agents: unknown[] }).agents[index];
+  if (!isRecord(catalogRecord)) throw new AgentsMcpError('contract', 'Agents catalog entry must be an object');
+  return {
+    inventory,
+    description: {
+      ...inventory.agents[index],
+      inputSchema: normalizeSchema(catalogRecord.defaultInputModes, 'Agents input schema'),
+      outputSchema: normalizeSchema(catalogRecord.defaultOutputModes, 'Agents output schema'),
+    },
+  };
 }

--- a/packages/desktop/src/process/ki-buddy/agents/client.ts
+++ b/packages/desktop/src/process/ki-buddy/agents/client.ts
@@ -1,23 +1,82 @@
-import { normalizeAgentsCatalog, type AgentsCatalogInventory } from './catalog';
+import {
+  isSameAgentsCatalogIdentity,
+  normalizeAgentsCatalog,
+  normalizeAgentsCatalogSelection,
+  type AgentsCatalogDescription,
+  type AgentsCatalogIdentity,
+  type AgentsCatalogInventory,
+} from './catalog';
 import { AgentsMcpError, getAgentsMcpErrorPresentation, resolveAgentsBridgeErrorCode } from './errors';
 import { readBoundedJsonResponse } from './json';
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
-const MAX_CATALOG_RESPONSE_BYTES = 5 * 1024 * 1024;
+const MAX_SESSION_RESPONSE_BYTES = 16 * 1024;
+const MAX_CATALOG_RESPONSE_BYTES = 5 * 1024 * 1024 + MAX_SESSION_RESPONSE_BYTES;
+const DEFAULT_CATALOG_CACHE_TTL_MS = 5 * 60 * 1000;
 
 export const AGENTS_MCP_BRIDGE_URL_ENV = 'KI_BUDDY_AGENTS_ADAPTER_BRIDGE_URL';
 export const AGENTS_MCP_BRIDGE_TOKEN_ENV = 'KI_BUDDY_AGENTS_ADAPTER_BRIDGE_TOKEN';
 
 export type AgentsCatalogClient = Readonly<{
-  list: () => Promise<AgentsCatalogInventory>;
+  describe: (agentId: string) => Promise<AgentsCatalogDescription>;
+  list: (options?: Readonly<{ forceRefresh?: boolean }>) => Promise<AgentsCatalogInventory>;
 }>;
 
 type AgentsCatalogClientOptions = Readonly<{
   bridgeToken: string;
   bridgeUrl: string;
   fetchImpl?: typeof fetch;
+  cacheTtlMs?: number;
+  now?: () => number;
   timeoutMs?: number;
 }>;
+
+type AgentsCatalogEnvelope = Readonly<{
+  catalog: unknown;
+  identity: AgentsCatalogIdentity;
+}>;
+
+type AgentsCatalogProjection<T> = Readonly<{
+  inventory: AgentsCatalogInventory;
+  result: T;
+}>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeIdentity(value: unknown): AgentsCatalogIdentity {
+  if (
+    !isRecord(value) ||
+    typeof value.deploymentOrigin !== 'string' ||
+    !Number.isSafeInteger(value.sessionEpoch) ||
+    (value.sessionEpoch as number) < 0 ||
+    typeof value.userId !== 'string'
+  ) {
+    throw new AgentsMcpError('contract', 'Agents catalog identity is incompatible');
+  }
+  let origin: string;
+  try {
+    const url = new URL(value.deploymentOrigin);
+    origin = url.origin;
+    if (!['http:', 'https:'].includes(url.protocol) || value.deploymentOrigin !== origin)
+      throw new Error('invalid origin');
+  } catch {
+    throw new AgentsMcpError('contract', 'Agents catalog deployment origin is incompatible');
+  }
+  const userId = value.userId.trim();
+  if (!userId || userId.length > 200) {
+    throw new AgentsMcpError('contract', 'Agents catalog user identity is incompatible');
+  }
+  return { deploymentOrigin: origin, sessionEpoch: value.sessionEpoch as number, userId };
+}
+
+function normalizeCatalogEnvelope(value: unknown): AgentsCatalogEnvelope {
+  if (!isRecord(value) || !('catalog' in value)) {
+    throw new AgentsMcpError('contract', 'Agents catalog bridge response is incompatible');
+  }
+  return { identity: normalizeIdentity(value.identity), catalog: value.catalog };
+}
 
 function resolveBridgeUrl(rawUrl: string): string {
   let url: URL;
@@ -45,32 +104,80 @@ export function createAgentsCatalogClient(options: AgentsCatalogClientOptions): 
     throw new AgentsMcpError('configuration', 'Agents Adapter timeout must be between 1000 and 120000 milliseconds');
   }
   const fetchImpl = options.fetchImpl ?? fetch;
+  const cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CATALOG_CACHE_TTL_MS;
+  if (!Number.isSafeInteger(cacheTtlMs) || cacheTtlMs <= 0 || cacheTtlMs > 60 * 60 * 1000) {
+    throw new AgentsMcpError('configuration', 'Agents catalog cache TTL must be between 1 and 3600000 milliseconds');
+  }
+  const now = options.now ?? Date.now;
+  let cache: Readonly<{
+    expiresAt: number;
+    identity: AgentsCatalogIdentity;
+    inventory: AgentsCatalogInventory;
+  }> | null = null;
+
+  const request = async (path: '/catalog' | '/session', maxResponseBytes: number): Promise<unknown> => {
+    let response: Response;
+    try {
+      response = await fetchImpl(`${bridgeUrl}${path}`, {
+        method: 'GET',
+        headers: {
+          accept: 'application/json',
+          authorization: `Bearer ${bridgeToken}`,
+        },
+        redirect: 'error',
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (error) {
+      if (error instanceof AgentsMcpError) throw error;
+      throw new AgentsMcpError('network', 'Agents Adapter bridge is unavailable');
+    }
+    if (response.status === 401 || response.status === 403) {
+      throw new AgentsMcpError('auth', 'Agents login is required');
+    }
+    if (!response.ok) {
+      const code = resolveAgentsBridgeErrorCode(await readBoundedJsonResponse(response, 1024)) ?? ('server' as const);
+      throw new AgentsMcpError(code, getAgentsMcpErrorPresentation(code).message);
+    }
+    return readBoundedJsonResponse(response, maxResponseBytes);
+  };
+
+  const withCacheInvalidation = async <T>(operation: () => Promise<T>): Promise<T> => {
+    try {
+      return await operation();
+    } catch (error) {
+      cache = null;
+      throw error;
+    }
+  };
+
+  const refreshCatalog = async <T>(project: (catalog: unknown) => AgentsCatalogProjection<T>): Promise<T> => {
+    const envelope = normalizeCatalogEnvelope(await request('/catalog', MAX_CATALOG_RESPONSE_BYTES));
+    const { inventory, result } = project(envelope.catalog);
+    cache = { identity: envelope.identity, inventory, expiresAt: now() + cacheTtlMs };
+    return result;
+  };
 
   return {
-    async list() {
-      let response: Response;
-      try {
-        response = await fetchImpl(`${bridgeUrl}/catalog`, {
-          method: 'GET',
-          headers: {
-            accept: 'application/json',
-            authorization: `Bearer ${bridgeToken}`,
-          },
-          redirect: 'error',
-          signal: AbortSignal.timeout(timeoutMs),
+    async describe(agentId) {
+      return withCacheInvalidation(() =>
+        refreshCatalog((catalog) => {
+          const { description, inventory } = normalizeAgentsCatalogSelection(catalog, agentId);
+          return { inventory, result: description };
+        })
+      );
+    },
+    async list({ forceRefresh = false } = {}) {
+      return withCacheInvalidation(async () => {
+        if (!forceRefresh && cache && cache.expiresAt > now()) {
+          const currentIdentity = normalizeIdentity(await request('/session', MAX_SESSION_RESPONSE_BYTES));
+          if (isSameAgentsCatalogIdentity(cache.identity, currentIdentity)) return cache.inventory;
+          cache = null;
+        }
+        return refreshCatalog((catalog) => {
+          const inventory = normalizeAgentsCatalog(catalog);
+          return { inventory, result: inventory };
         });
-      } catch (error) {
-        if (error instanceof AgentsMcpError) throw error;
-        throw new AgentsMcpError('network', 'Agents Adapter bridge is unavailable');
-      }
-      if (response.status === 401 || response.status === 403) {
-        throw new AgentsMcpError('auth', 'Agents login is required');
-      }
-      if (!response.ok) {
-        const code = resolveAgentsBridgeErrorCode(await readBoundedJsonResponse(response, 1024)) ?? ('server' as const);
-        throw new AgentsMcpError(code, getAgentsMcpErrorPresentation(code).message);
-      }
-      return normalizeAgentsCatalog(await readBoundedJsonResponse(response, MAX_CATALOG_RESPONSE_BYTES));
+      });
     },
   };
 }

--- a/packages/desktop/src/process/ki-buddy/agents/errors.ts
+++ b/packages/desktop/src/process/ki-buddy/agents/errors.ts
@@ -1,4 +1,11 @@
-export type AgentsMcpErrorCode = 'auth' | 'configuration' | 'contract' | 'network' | 'server';
+export type AgentsMcpErrorCode =
+  | 'ambiguous'
+  | 'auth'
+  | 'configuration'
+  | 'contract'
+  | 'network'
+  | 'not_found'
+  | 'server';
 
 type AgentsMcpErrorPresentation = Readonly<{
   bridgeError: string;
@@ -7,6 +14,11 @@ type AgentsMcpErrorPresentation = Readonly<{
 }>;
 
 const AGENTS_MCP_ERROR_PRESENTATIONS = {
+  ambiguous: {
+    bridgeError: 'agents_ambiguous',
+    bridgeStatus: 409,
+    message: 'Agent identity is ambiguous in the current catalog',
+  },
   auth: { bridgeError: 'agents_auth_required', bridgeStatus: 401, message: 'Agents login is required' },
   configuration: {
     bridgeError: 'agents_network_error',
@@ -23,6 +35,11 @@ const AGENTS_MCP_ERROR_PRESENTATIONS = {
     bridgeStatus: 502,
     message: 'Agents Adapter bridge is unavailable',
   },
+  not_found: {
+    bridgeError: 'agents_not_found',
+    bridgeStatus: 404,
+    message: 'Agent is not in the current catalog',
+  },
   server: {
     bridgeError: 'agents_server_error',
     bridgeStatus: 502,
@@ -31,9 +48,11 @@ const AGENTS_MCP_ERROR_PRESENTATIONS = {
 } as const satisfies Readonly<Record<AgentsMcpErrorCode, AgentsMcpErrorPresentation>>;
 
 const BRIDGE_ERROR_CODES = {
+  agents_ambiguous: 'ambiguous',
   agents_auth_required: 'auth',
   agents_contract_error: 'contract',
   agents_network_error: 'network',
+  agents_not_found: 'not_found',
   agents_server_error: 'server',
 } as const satisfies Readonly<Record<string, AgentsMcpErrorCode>>;
 

--- a/packages/desktop/src/process/ki-buddy/agents/index.ts
+++ b/packages/desktop/src/process/ki-buddy/agents/index.ts
@@ -1,9 +1,10 @@
 import type { AgentsAuthService } from '../AgentsAuthService';
 import { startAgentsMcpBridge, type AgentsMcpBridgeHandle } from './bridge';
+import { isSameAgentsCatalogIdentity, type AgentsCatalogIdentity } from './catalog';
 import { AGENTS_MCP_BRIDGE_TOKEN_ENV, AGENTS_MCP_BRIDGE_URL_ENV } from './client';
 import { AgentsMcpError } from './errors';
 
-type AgentsMcpAuthService = Pick<AgentsAuthService, 'fetchAuthenticated' | 'getSession'>;
+type AgentsMcpAuthService = Pick<AgentsAuthService, 'fetchAuthenticated' | 'getSession' | 'getSessionEpoch'>;
 type StartBridge = typeof startAgentsMcpBridge;
 
 /** Starts the product bridge and publishes only its ephemeral loopback coordinates for Ki-Core inheritance. */
@@ -12,23 +13,44 @@ export async function startAgentsMcpRuntimeBridge(
   env: NodeJS.ProcessEnv = process.env,
   startBridge: StartBridge = startAgentsMcpBridge
 ): Promise<AgentsMcpBridgeHandle> {
+  const getSessionIdentity = async (): Promise<AgentsCatalogIdentity> => {
+    let session: Awaited<ReturnType<AgentsAuthService['getSession']>>;
+    try {
+      session = await authService.getSession();
+    } catch {
+      throw new AgentsMcpError('auth', 'Agents login is required');
+    }
+    if (session.status !== 'authenticated') {
+      throw new AgentsMcpError('auth', 'Agents login is required');
+    }
+    let deploymentOrigin: string;
+    try {
+      deploymentOrigin = new URL(session.user.agents.deploymentUrl).origin;
+    } catch {
+      throw new AgentsMcpError('contract', 'Agents session deployment is incompatible');
+    }
+    return {
+      deploymentOrigin,
+      sessionEpoch: authService.getSessionEpoch(),
+      userId: session.user.agents.userId,
+    };
+  };
+
   const handle = await startBridge({
+    getSessionIdentity,
     fetchCatalog: async (signal) => {
-      let session: Awaited<ReturnType<AgentsAuthService['getSession']>>;
+      const identity = await getSessionIdentity();
       try {
-        session = await authService.getSession();
-      } catch {
-        throw new AgentsMcpError('auth', 'Agents login is required');
-      }
-      if (session.status !== 'authenticated') {
-        throw new AgentsMcpError('auth', 'Agents login is required');
-      }
-      try {
-        return await authService.fetchAuthenticated('/bridge/agents/catalog', {
+        const response = await authService.fetchAuthenticated('/bridge/agents/catalog', {
           method: 'GET',
           headers: { accept: 'application/json' },
           signal,
         });
+        const currentIdentity = await getSessionIdentity();
+        if (!isSameAgentsCatalogIdentity(currentIdentity, identity)) {
+          throw new AgentsMcpError('auth', 'Agents session changed during catalog refresh');
+        }
+        return { identity, response };
       } catch (error) {
         if (error instanceof AgentsMcpError) throw error;
         throw new AgentsMcpError('network', 'Agents catalog request failed');

--- a/packages/desktop/src/process/ki-buddy/agents/mcpServer.ts
+++ b/packages/desktop/src/process/ki-buddy/agents/mcpServer.ts
@@ -1,23 +1,36 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
 import type { AgentsCatalogClient } from './client';
 import { AgentsMcpError, getAgentsMcpErrorPresentation } from './errors';
 
 /** Stable model-facing MCP metadata; the renderer resolves localized product presentation separately. */
 const AGENTS_LIST_PROTOCOL_DESCRIPTION =
   'List the complete compact catalog of published Agents available to the current signed-in account. Compare the full returned inventory before reporting that no matching agent exists.';
+const AGENTS_DESCRIBE_PROTOCOL_DESCRIPTION =
+  'Describe the exact input and output schema for one agentId from the current safe catalog. Use agents_list first and do not infer an agentId.';
 
 const textResult = (value: unknown, isError = false) => ({
   content: [{ type: 'text' as const, text: JSON.stringify(value) }],
   ...(isError ? { isError: true } : {}),
 });
 
-/** Creates the first-release, catalog-only MCP surface for the Agents Adapter. */
+async function executeCatalogTool<T>(operation: () => Promise<T>) {
+  try {
+    return textResult(await operation());
+  } catch (error) {
+    const code = error instanceof AgentsMcpError ? error.code : 'server';
+    return textResult({ ok: false, error: { code, message: getAgentsMcpErrorPresentation(code).message } }, true);
+  }
+}
+
+/** Creates the read-only catalog discovery surface for the Agents Adapter. */
 export function createAgentsMcpServer(client: AgentsCatalogClient): McpServer {
-  const server = new McpServer({ name: 'ki-buddy-agents-mcp-adapter', version: '0.1.0' });
+  const server = new McpServer({ name: 'ki-buddy-agents-mcp-adapter', version: '0.2.0' });
   server.registerTool(
     'agents_list',
     {
       description: AGENTS_LIST_PROTOCOL_DESCRIPTION,
+      inputSchema: { forceRefresh: z.boolean().optional() },
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -25,14 +38,21 @@ export function createAgentsMcpServer(client: AgentsCatalogClient): McpServer {
         openWorldHint: true,
       },
     },
-    async () => {
-      try {
-        return textResult(await client.list());
-      } catch (error) {
-        const code = error instanceof AgentsMcpError ? error.code : 'server';
-        return textResult({ ok: false, error: { code, message: getAgentsMcpErrorPresentation(code).message } }, true);
-      }
-    }
+    ({ forceRefresh }) => executeCatalogTool(() => client.list({ forceRefresh }))
+  );
+  server.registerTool(
+    'agents_describe',
+    {
+      description: AGENTS_DESCRIBE_PROTOCOL_DESCRIPTION,
+      inputSchema: { agentId: z.string().trim().min(1).max(200) },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    ({ agentId }) => executeCatalogTool(() => client.describe(agentId))
   );
   return server;
 }

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1900,6 +1900,7 @@ export type I18nKey =
   | 'settings.imageInputUnsupported'
   | 'settings.includePrereleaseUpdates'
   | 'settings.installed'
+  | 'settings.kiBuddy.agentsDescribeDescription'
   | 'settings.kiBuddy.agentsListDescription'
   | 'settings.language'
   | 'settings.lark.agent'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
@@ -773,6 +773,7 @@
   },
   "mcpNoDescription": "Keine Beschreibung",
   "kiBuddy": {
+    "agentsDescribeDescription": "Zeigt das genaue Ein- und Ausgabeschema eines Agent im aktuellen Katalog an.",
     "agentsListDescription": "Listet den vollständigen Agents-Katalog auf, der für das aktuell angemeldete Konto verfügbar ist."
   },
   "mcpAuthRequired": "Authentifizierung erforderlich",

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
@@ -781,6 +781,7 @@
   },
   "mcpNoDescription": "No description",
   "kiBuddy": {
+    "agentsDescribeDescription": "Shows the exact input and output schema for one agent in the current catalog.",
     "agentsListDescription": "Lists the complete Agents catalog available to the current signed-in account."
   },
   "mcpAuthRequired": "Authentication required",

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
@@ -771,6 +771,7 @@
   },
   "mcpNoDescription": "Sin descripción",
   "kiBuddy": {
+    "agentsDescribeDescription": "Muestra el esquema exacto de entrada y salida de un Agent del catálogo actual.",
     "agentsListDescription": "Muestra el catálogo completo de Agents disponible para la cuenta que ha iniciado sesión."
   },
   "mcpAuthRequired": "Autenticación requerida",

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
@@ -781,6 +781,7 @@
   },
   "mcpNoDescription": "بدون توضیحات",
   "kiBuddy": {
+    "agentsDescribeDescription": "طرح‌وارهٔ دقیق ورودی و خروجی یک Agent در فهرست فعلی را نمایش می‌دهد.",
     "agentsListDescription": "فهرست کامل Agents در دسترس حساب واردشده فعلی را نمایش می‌دهد."
   },
   "mcpAuthRequired": "احراز هویت لازم است",

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
@@ -781,6 +781,7 @@
   },
   "mcpNoDescription": "Aucune description",
   "kiBuddy": {
+    "agentsDescribeDescription": "Affiche le schéma exact des entrées et sorties d’un Agent du catalogue actuel.",
     "agentsListDescription": "Répertorie le catalogue Agents complet disponible pour le compte actuellement connecté."
   },
   "mcpAuthRequired": "Authentification requise",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -769,6 +769,7 @@
   },
   "mcpNoDescription": "説明なし",
   "kiBuddy": {
+    "agentsDescribeDescription": "現在のカタログ内の1つの Agent について、正確な入力と出力のスキーマを表示します。",
     "agentsListDescription": "現在サインインしているアカウントで利用可能な完全な Agents カタログを一覧表示します。"
   },
   "mcpAuthRequired": "認証が必要です",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -769,6 +769,7 @@
   },
   "mcpNoDescription": "설명 없음",
   "kiBuddy": {
+    "agentsDescribeDescription": "현재 카탈로그에 있는 Agent 하나의 정확한 입력 및 출력 스키마를 표시합니다.",
     "agentsListDescription": "현재 로그인한 계정에서 사용할 수 있는 전체 Agents 카탈로그를 표시합니다."
   },
   "mcpAuthRequired": "인증 필요",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
@@ -781,6 +781,7 @@
   },
   "mcpNoDescription": "Nenhuma descrição",
   "kiBuddy": {
+    "agentsDescribeDescription": "Mostra o esquema exato de entrada e saída de um Agent no catálogo atual.",
     "agentsListDescription": "Lista o catálogo completo de Agents disponível para a conta conectada."
   },
   "mcpAuthRequired": "Autenticação obrigatória",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -761,6 +761,7 @@
   },
   "mcpNoDescription": "Нет описания",
   "kiBuddy": {
+    "agentsDescribeDescription": "Показывает точную схему входных и выходных данных одного Agent из текущего каталога.",
     "agentsListDescription": "Показывает полный каталог Agents, доступный текущей учётной записи."
   },
   "mcpAuthRequired": "Требуется аутентификация",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -769,6 +769,7 @@
   },
   "mcpNoDescription": "Açıklama yok",
   "kiBuddy": {
+    "agentsDescribeDescription": "Geçerli katalogdaki bir Agent için tam giriş ve çıkış şemasını gösterir.",
     "agentsListDescription": "Geçerli oturum açmış hesabın kullanabildiği eksiksiz Agents kataloğunu listeler."
   },
   "mcpAuthRequired": "Kimlik doğrulama gerekli",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -767,6 +767,7 @@
   },
   "mcpNoDescription": "Немає опису",
   "kiBuddy": {
+    "agentsDescribeDescription": "Показує точну схему вхідних і вихідних даних одного Agent з поточного каталогу.",
     "agentsListDescription": "Показує повний каталог Agents, доступний поточному обліковому запису."
   },
   "mcpAuthRequired": "Потрібна автентифікація",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -781,6 +781,7 @@
   },
   "mcpNoDescription": "暂无描述",
   "kiBuddy": {
+    "agentsDescribeDescription": "显示当前目录中一个 Agent 的精确输入和输出结构。",
     "agentsListDescription": "列出当前登录账号可用的完整 Agents 目录。"
   },
   "mcpAuthRequired": "需要身份验证",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -781,6 +781,7 @@
   },
   "mcpNoDescription": "暫無描述",
   "kiBuddy": {
+    "agentsDescribeDescription": "顯示目前目錄中一個 Agent 的精確輸入與輸出結構。",
     "agentsListDescription": "列出目前登入帳號可用的完整 Agents 目錄。"
   },
   "mcpAuthRequired": "需要身份驗證",

--- a/packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyResourceRegistry.ts
+++ b/packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyResourceRegistry.ts
@@ -74,6 +74,10 @@ export const KI_BUDDY_PRODUCT_RESOURCE_REGISTRY = {
       backendName: 'agents-mcp-adapter',
       scriptName: 'builtin-mcp-agents.js',
       tools: {
+        describe: {
+          name: 'agents_describe',
+          descriptionKey: 'settings.kiBuddy.agentsDescribeDescription',
+        },
         list: {
           name: 'agents_list',
           descriptionKey: 'settings.kiBuddy.agentsListDescription',
@@ -106,13 +110,11 @@ export function resolveKiBuddyMcpToolDescriptionKey(
   server: Pick<IMcpServer, 'builtin' | 'name' | 'transport'>,
   origin: ProductResourceOrigin | undefined,
   toolName: string
-): 'settings.kiBuddy.agentsListDescription' | null {
+): 'settings.kiBuddy.agentsDescribeDescription' | 'settings.kiBuddy.agentsListDescription' | null {
   const definition = KI_BUDDY_PRODUCT_RESOURCE_REGISTRY.mcp.agentsAdapter;
-  return origin === 'productBuiltin' &&
-    resolveKiBuddyProductMcpResourceId(server) === definition.id &&
-    toolName === definition.tools.list.name
-    ? definition.tools.list.descriptionKey
-    : null;
+  if (origin !== 'productBuiltin' || resolveKiBuddyProductMcpResourceId(server) !== definition.id) return null;
+  const tool = Object.values(definition.tools).find(({ name }) => name === toolName);
+  return tool?.descriptionKey ?? null;
 }
 
 export const KI_CLI_PRODUCT_RESOURCE_ID = KI_BUDDY_PRODUCT_RESOURCE_REGISTRY.agent.kiCli.id;

--- a/tests/e2e/features/remote/ki-buddy-auth.e2e.ts
+++ b/tests/e2e/features/remote/ki-buddy-auth.e2e.ts
@@ -38,6 +38,12 @@ type AgentsListResult = Readonly<{
   total: number;
 }>;
 
+type AgentsDescribeResult = Readonly<{
+  agentId: string;
+  inputSchema: Array<{ name: string; required: boolean; type: string }>;
+  outputSchema: Array<{ name: string; required: boolean; type: string }>;
+}>;
+
 type HeldCatalogRequest = Readonly<{
   release: () => void;
   waitForStart: () => Promise<void>;
@@ -79,6 +85,8 @@ const AGENTS_CATALOGS = {
         agentTitle: 'Account A Agent',
         agentDescription: 'Visible only to account A.',
         agentType: 'workflow',
+        defaultInputModes: [{ name: 'query', description: 'Query', type: 'text', required: true }],
+        defaultOutputModes: [{ name: 'result', description: 'Result', type: 'text', required: true }],
       },
     ],
   },
@@ -91,6 +99,8 @@ const AGENTS_CATALOGS = {
         agentTitle: 'Account B Agent',
         agentDescription: 'Visible only to account B.',
         agentType: 'workflow',
+        defaultInputModes: [{ name: 'query', description: 'Query', type: 'text', required: true }],
+        defaultOutputModes: [{ name: 'result', description: 'Result', type: 'text', required: true }],
       },
     ],
   },
@@ -294,14 +304,24 @@ async function readAgentsAdapterRegistration(
   return servers.find(({ name }) => name === 'agents-mcp-adapter');
 }
 
-function readAgentsListResult(result: Awaited<ReturnType<Client['callTool']>>): AgentsListResult {
+type AgentsToolResult = Awaited<ReturnType<Client['callTool']>>;
+
+type AgentsToolResults = Readonly<{
+  agents_describe: AgentsDescribeResult;
+  agents_list: AgentsListResult;
+}>;
+
+function readAgentsToolResult<T extends keyof AgentsToolResults>(
+  toolName: T,
+  result: AgentsToolResult
+): AgentsToolResults[T] {
   const first = Array.isArray(result.content) ? result.content[0] : null;
-  if (!first || typeof first !== 'object') throw new Error('agents_list returned no content');
+  if (!first || typeof first !== 'object') throw new Error(`${toolName} returned no content`);
   const content = first as { text?: unknown; type?: unknown };
   if (content.type !== 'text' || typeof content.text !== 'string') {
-    throw new Error('agents_list returned non-text content');
+    throw new Error(`${toolName} returned non-text content`);
   }
-  return JSON.parse(content.text) as AgentsListResult;
+  return JSON.parse(content.text) as AgentsToolResults[T];
 }
 
 async function createCoreConversation(
@@ -855,9 +875,12 @@ test.describe('Ki-Buddy packaged Agents authentication', () => {
       client = new Client({ name: 'ki-buddy-account-switch-e2e', version: '1.0.0' });
       await client.connect(transport);
       const tools = await client.listTools();
-      const accountAResult = readAgentsListResult(await client.callTool({ name: 'agents_list', arguments: {} }));
+      const accountAResult = readAgentsToolResult(
+        'agents_list',
+        await client.callTool({ name: 'agents_list', arguments: {} })
+      );
       heldCatalog = agents.holdNextCatalog('A');
-      const staleAccountACall = client.callTool({ name: 'agents_list', arguments: {} });
+      const staleAccountACall = client.callTool({ name: 'agents_list', arguments: { forceRefresh: true } });
       await heldCatalog.waitForStart();
 
       await logoutThroughUi(page);
@@ -865,13 +888,26 @@ test.describe('Ki-Buddy packaged Agents authentication', () => {
       await expect.poll(() => heldCatalog?.wasCancelled()).toBe(true);
       heldCatalog.release();
       const staleAccountAResult = await staleAccountACall;
-      const accountBResult = readAgentsListResult(await client.callTool({ name: 'agents_list', arguments: {} }));
+      const accountBResult = readAgentsToolResult(
+        'agents_list',
+        await client.callTool({ name: 'agents_list', arguments: {} })
+      );
+      const accountBDescription = readAgentsToolResult(
+        'agents_describe',
+        await client.callTool({ name: 'agents_describe', arguments: { agentId: 'agent-for-user-b' } })
+      );
 
       expect(tools.tools.map(({ name }) => name)).toContain('agents_list');
+      expect(tools.tools.map(({ name }) => name)).toContain('agents_describe');
       expect(accountAResult).toEqual({ total: 1, agents: [expect.objectContaining({ agentId: 'agent-for-user-a' })] });
       expect(staleAccountAResult.isError).toBe(true);
       expect(accountBResult).toEqual({ total: 1, agents: [expect.objectContaining({ agentId: 'agent-for-user-b' })] });
-      expect(agents.getCatalogIdentitySequence()).toEqual(['A', 'A', 'B']);
+      expect(accountBDescription).toMatchObject({
+        agentId: 'agent-for-user-b',
+        inputSchema: [{ name: 'query', type: 'text', required: true }],
+        outputSchema: [{ name: 'result', type: 'text', required: true }],
+      });
+      expect(agents.getCatalogIdentitySequence()).toEqual(['A', 'A', 'B', 'B']);
       expect(stderr).not.toContain(bridge.token);
       expect(stderr).not.toContain(bridge.url);
     } finally {

--- a/tests/e2e/features/remote/ki-buddy/productMatrix.e2e.ts
+++ b/tests/e2e/features/remote/ki-buddy/productMatrix.e2e.ts
@@ -696,6 +696,7 @@ test.describe.serial('Ki-Buddy packaged first-release product matrix', () => {
 
     expect(result.success).toBe(true);
     expect(result.tools?.map(({ name }) => name)).toContain('agents_list');
+    expect(result.tools?.map(({ name }) => name)).toContain('agents_describe');
     expect(await readFirstFrameViolations(productApp.page)).toEqual([]);
   });
 

--- a/tests/fixtures/ki-buddy/agents/catalog.json
+++ b/tests/fixtures/ki-buddy/agents/catalog.json
@@ -9,10 +9,11 @@
       "agentType": "workflow",
       "defaultInputModes": [
         {
-          "name": "feedback",
-          "description": "脱敏后的反馈文本",
-          "type": "text",
-          "required": true
+          "name": "feedbackFile",
+          "description": "脱敏后的反馈文件",
+          "type": "file",
+          "required": true,
+          "allowed_file_types": ["text/plain"]
         }
       ],
       "defaultOutputModes": [

--- a/tests/integration/kiBuddyAgentsMcpStdio.test.ts
+++ b/tests/integration/kiBuddyAgentsMcpStdio.test.ts
@@ -1,12 +1,16 @@
 import { execFileSync, spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { once } from 'node:events';
 import { existsSync } from 'node:fs';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import path from 'node:path';
 import { createInterface } from 'node:readline';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { startAgentsMcpRuntimeBridge } from '@/process/ki-buddy/agents';
 import { startAgentsMcpBridge, type AgentsMcpBridgeHandle } from '@/process/ki-buddy/agents/bridge';
+import { createAgentsCatalogClient, type AgentsCatalogClient } from '@/process/ki-buddy/agents/client';
 import { AgentsMcpError } from '@/process/ki-buddy/agents/errors';
 
 const projectRoot = path.resolve(__dirname, '../..');
@@ -15,6 +19,7 @@ const bridges: AgentsMcpBridgeHandle[] = [];
 const clients: Client[] = [];
 const childProcesses: ChildProcess[] = [];
 const externalProcessIds = new Set<number>();
+const fakeGateways: Array<Readonly<{ close: () => Promise<void> }>> = [];
 const adapterEnvironment = {
   KI_BUDDY_AGENTS_ADAPTER_BRIDGE_URL: 'http://127.0.0.1:43123',
   KI_BUDDY_AGENTS_ADAPTER_BRIDGE_TOKEN: 'process-exit-secret',
@@ -29,6 +34,113 @@ const initializeRequest = `${JSON.stringify({
     clientInfo: { name: 'agents-mcp-lifecycle-test', version: '1.0.0' },
   },
 })}\n`;
+
+const fakeCatalog = {
+  status: 'ok',
+  total: 1,
+  agents: [
+    {
+      agentId: 'agent-feedback',
+      agentTitle: 'Feedback analyst',
+      agentDescription: 'Summarizes customer feedback.',
+      agentType: 'workflow',
+      defaultInputModes: [{ name: 'query', description: 'Feedback text', type: 'text', required: true }],
+      defaultOutputModes: [{ name: 'summary', description: 'Summary', type: 'text', required: true }],
+    },
+  ],
+};
+
+type FakeCatalogGateway = Readonly<{
+  baseUrl: string;
+  close: () => Promise<void>;
+  requestPaths: () => readonly string[];
+  setCatalog: (catalog: unknown) => void;
+  setStatus: (status: number) => void;
+}>;
+
+type MutableSessionBinding = {
+  deploymentUrl: string;
+  sessionEpoch: number;
+  userId: string;
+};
+
+async function startFakeCatalogGateway(initialCatalog: unknown = fakeCatalog): Promise<FakeCatalogGateway> {
+  let catalog = initialCatalog;
+  let status = 200;
+  const paths: string[] = [];
+  const server = createServer((request, response) => {
+    paths.push(request.url ?? '');
+    if (
+      request.method !== 'GET' ||
+      request.url !== '/bridge/agents/catalog' ||
+      request.headers.authorization !== 'Bearer fake-agents-token'
+    ) {
+      response.writeHead(request.headers.authorization ? 404 : 401).end();
+      return;
+    }
+    if (status !== 200) {
+      response.writeHead(status).end();
+      return;
+    }
+    response.writeHead(status, { 'content-type': 'application/json' });
+    response.end(JSON.stringify(catalog));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  const gateway = {
+    baseUrl: `http://127.0.0.1:${port}`,
+    requestPaths: () => [...paths],
+    setCatalog: (nextCatalog: unknown) => {
+      catalog = nextCatalog;
+    },
+    setStatus: (nextStatus: number) => {
+      status = nextStatus;
+    },
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.closeAllConnections();
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+  fakeGateways.push(gateway);
+  return gateway;
+}
+
+async function startGatewayBackedBridge(binding: MutableSessionBinding): Promise<AgentsMcpBridgeHandle> {
+  const authService = {
+    getSession: async () => ({
+      status: 'authenticated',
+      user: {
+        id: 'core-user',
+        agents: { deploymentUrl: binding.deploymentUrl, userId: binding.userId },
+      },
+    }),
+    getSessionEpoch: () => binding.sessionEpoch,
+    fetchAuthenticated: (requestPath: string, init: RequestInit) => {
+      const headers = new Headers(init.headers);
+      headers.set('authorization', 'Bearer fake-agents-token');
+      return fetch(`${binding.deploymentUrl}${requestPath}`, { ...init, headers });
+    },
+  };
+  const bridge = await startAgentsMcpRuntimeBridge(authService as never, {});
+  bridges.push(bridge);
+  return bridge;
+}
+
+async function createGatewayBackedClient(
+  binding: MutableSessionBinding,
+  options: Readonly<{ now?: () => number }> = {}
+): Promise<AgentsCatalogClient> {
+  const bridge = await startGatewayBackedBridge(binding);
+  return createAgentsCatalogClient({
+    bridgeToken: bridge.token,
+    bridgeUrl: bridge.url,
+    ...options,
+  });
+}
 
 async function waitForLine(stream: NodeJS.ReadableStream, timeoutMessage: string): Promise<string> {
   const lines = createInterface({ input: stream });
@@ -93,6 +205,7 @@ beforeAll(() => {
 afterEach(async () => {
   await Promise.allSettled(clients.splice(0).map((client) => client.close()));
   await Promise.allSettled(bridges.splice(0).map((bridge) => bridge.close()));
+  await Promise.allSettled(fakeGateways.splice(0).map((gateway) => gateway.close()));
   await Promise.all(
     childProcesses.splice(0).map(async (child) => {
       if (child.exitCode !== null || child.signalCode !== null) return;
@@ -118,21 +231,172 @@ afterEach(async () => {
 });
 
 describe('packaged Agents MCP stdio entry', () => {
-  it('builds a self-contained entry and serves the complete catalog over real stdio MCP', async () => {
+  it('applies TTL and force refresh through a local fake Agents Gateway', async () => {
+    let currentTime = 10_000;
+    const gateway = await startFakeCatalogGateway();
+    const client = await createGatewayBackedClient(
+      { deploymentUrl: gateway.baseUrl, sessionEpoch: 1, userId: 'user-1' },
+      { now: () => currentTime }
+    );
+
+    await client.list();
+    await client.list();
+    await client.list({ forceRefresh: true });
+    currentTime += 5 * 60 * 1000;
+    await client.list();
+
+    expect(gateway.requestPaths()).toEqual([
+      '/bridge/agents/catalog',
+      '/bridge/agents/catalog',
+      '/bridge/agents/catalog',
+    ]);
+  });
+
+  it('invalidates a local fake Gateway cache when the same account starts a new session', async () => {
+    const gateway = await startFakeCatalogGateway();
+    const binding = { deploymentUrl: gateway.baseUrl, sessionEpoch: 1, userId: 'user-1' };
+    const client = await createGatewayBackedClient(binding);
+
+    await client.list();
+    binding.sessionEpoch = 2;
+    gateway.setCatalog({
+      ...fakeCatalog,
+      agents: [{ ...fakeCatalog.agents[0], agentId: 'agent-after-reauthentication' }],
+    });
+
+    await expect(client.list()).resolves.toMatchObject({
+      agents: [{ agentId: 'agent-after-reauthentication' }],
+    });
+    expect(gateway.requestPaths()).toEqual(['/bridge/agents/catalog', '/bridge/agents/catalog']);
+  });
+
+  it('invalidates a local fake Gateway cache when deployment origin changes', async () => {
+    const gatewayA = await startFakeCatalogGateway();
+    const gatewayB = await startFakeCatalogGateway({
+      ...fakeCatalog,
+      agents: [{ ...fakeCatalog.agents[0], agentId: 'agent-other-deployment' }],
+    });
+    const binding = { deploymentUrl: gatewayA.baseUrl, sessionEpoch: 1, userId: 'user-1' };
+    const client = await createGatewayBackedClient(binding);
+
+    await client.list();
+    binding.deploymentUrl = gatewayB.baseUrl;
+
+    await expect(client.list()).resolves.toMatchObject({ agents: [{ agentId: 'agent-other-deployment' }] });
+    expect(gatewayA.requestPaths()).toEqual(['/bridge/agents/catalog']);
+    expect(gatewayB.requestPaths()).toEqual(['/bridge/agents/catalog']);
+  });
+
+  it('rejects a candidate revoked by the local fake Gateway without invoking an agent', async () => {
+    const gateway = await startFakeCatalogGateway();
+    const client = await createGatewayBackedClient({
+      deploymentUrl: gateway.baseUrl,
+      sessionEpoch: 1,
+      userId: 'user-1',
+    });
+
+    await client.list();
+    gateway.setCatalog({ status: 'ok', total: 0, agents: [] });
+
+    await expect(client.describe('agent-feedback')).rejects.toMatchObject({ code: 'not_found' });
+    await expect(client.list()).resolves.toEqual({ total: 0, agents: [] });
+    expect(gateway.requestPaths()).toEqual([
+      '/bridge/agents/catalog',
+      '/bridge/agents/catalog',
+      '/bridge/agents/catalog',
+    ]);
+  });
+
+  it('clears cached inventory when the local fake Gateway rejects authentication', async () => {
+    const gateway = await startFakeCatalogGateway();
+    const client = await createGatewayBackedClient({
+      deploymentUrl: gateway.baseUrl,
+      sessionEpoch: 1,
+      userId: 'user-1',
+    });
+
+    await client.list();
+    gateway.setStatus(401);
+    await expect(client.describe('agent-feedback')).rejects.toMatchObject({ code: 'auth' });
+    gateway.setStatus(200);
+    gateway.setCatalog({ status: 'ok', total: 0, agents: [] });
+
+    await expect(client.list()).resolves.toEqual({ total: 0, agents: [] });
+    expect(gateway.requestPaths()).toEqual([
+      '/bridge/agents/catalog',
+      '/bridge/agents/catalog',
+      '/bridge/agents/catalog',
+    ]);
+  });
+
+  it('fails closed on ambiguous and incompatible local fake Gateway catalogs', async () => {
+    const gateway = await startFakeCatalogGateway({
+      ...fakeCatalog,
+      total: 2,
+      agents: [fakeCatalog.agents[0], fakeCatalog.agents[0]],
+    });
+    const client = await createGatewayBackedClient({
+      deploymentUrl: gateway.baseUrl,
+      sessionEpoch: 1,
+      userId: 'user-1',
+    });
+
+    await expect(client.list()).rejects.toMatchObject({ code: 'ambiguous' });
+    gateway.setCatalog({
+      ...fakeCatalog,
+      agents: [{ ...fakeCatalog.agents[0], defaultInputModes: [{ name: 'query', type: 'text' }] }],
+    });
+    await expect(client.describe('agent-feedback')).rejects.toMatchObject({ code: 'contract' });
+  });
+
+  it('rejects a missing describe parameter before the local fake Gateway is called', async () => {
+    const gateway = await startFakeCatalogGateway();
+    const bridge = await startGatewayBackedBridge({
+      deploymentUrl: gateway.baseUrl,
+      sessionEpoch: 1,
+      userId: 'user-1',
+    });
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [adapterScript],
+      env: {
+        KI_BUDDY_AGENTS_ADAPTER_BRIDGE_TOKEN: bridge.token,
+        KI_BUDDY_AGENTS_ADAPTER_BRIDGE_URL: bridge.url,
+      },
+      stderr: 'pipe',
+    });
+    const client = new Client({ name: 'ki-buddy-agents-missing-param', version: '1.0.0' });
+    clients.push(client);
+    await client.connect(transport);
+
+    const result = await client.callTool({ name: 'agents_describe', arguments: {} });
+
+    expect(result.isError).toBe(true);
+    expect(gateway.requestPaths()).toEqual([]);
+  });
+
+  it('builds a self-contained entry and serves list plus exact describe over real stdio MCP', async () => {
+    const identity = { deploymentOrigin: 'https://agents.example.test', sessionEpoch: 1, userId: 'user-1' };
     const bridge = await startAgentsMcpBridge({
       token: 'stdio-bridge-secret',
-      fetchCatalog: vi.fn().mockResolvedValue(
-        Response.json({
-          status: 'ok',
-          total: 1,
-          agents: [
-            {
-              agentId: 'agent-feedback',
-              agentTitle: 'Feedback analyst',
-              agentDescription: 'Summarizes customer feedback.',
-              agentType: 'workflow',
-            },
-          ],
+      getSessionIdentity: vi.fn().mockResolvedValue(identity),
+      fetchCatalog: vi.fn(() =>
+        Promise.resolve({
+          identity,
+          response: Response.json({
+            status: 'ok',
+            total: 1,
+            agents: [
+              {
+                agentId: 'agent-feedback',
+                agentTitle: 'Feedback analyst',
+                agentDescription: 'Summarizes customer feedback.',
+                agentType: 'workflow',
+                defaultInputModes: [{ name: 'query', description: 'Feedback text', type: 'text', required: true }],
+                defaultOutputModes: [{ name: 'summary', description: 'Summary', type: 'text', required: true }],
+              },
+            ],
+          }),
         })
       ),
     });
@@ -156,9 +420,13 @@ describe('packaged Agents MCP stdio entry', () => {
     await client.connect(transport);
     const tools = await client.listTools();
     const result = await client.callTool({ name: 'agents_list', arguments: {} });
+    const description = await client.callTool({
+      name: 'agents_describe',
+      arguments: { agentId: 'agent-feedback' },
+    });
 
     expect(existsSync(adapterScript)).toBe(true);
-    expect(tools.tools.map(({ name }) => name)).toEqual(['agents_list']);
+    expect(tools.tools.map(({ name }) => name)).toEqual(['agents_list', 'agents_describe']);
     expect(result.content).toEqual([
       {
         type: 'text',
@@ -172,6 +440,19 @@ describe('packaged Agents MCP stdio entry', () => {
               agentType: 'workflow',
             },
           ],
+        }),
+      },
+    ]);
+    expect(description.content).toEqual([
+      {
+        type: 'text',
+        text: JSON.stringify({
+          agentId: 'agent-feedback',
+          title: 'Feedback analyst',
+          description: 'Summarizes customer feedback.',
+          agentType: 'workflow',
+          inputSchema: [{ name: 'query', description: 'Feedback text', type: 'text', required: true }],
+          outputSchema: [{ name: 'summary', description: 'Summary', type: 'text', required: true }],
         }),
       },
     ]);
@@ -202,6 +483,11 @@ describe('packaged Agents MCP stdio entry', () => {
     await Promise.all(
       cases.map(async (testCase) => {
         const bridge = await startAgentsMcpBridge({
+          getSessionIdentity: vi.fn().mockResolvedValue({
+            deploymentOrigin: 'https://agents.example.test',
+            sessionEpoch: 1,
+            userId: `user-${testCase.code}`,
+          }),
           fetchCatalog: async () => {
             throw new AgentsMcpError(testCase.code, 'sensitive upstream detail');
           },

--- a/tests/unit/process/ki-buddy/AgentsAuthService.test.ts
+++ b/tests/unit/process/ki-buddy/AgentsAuthService.test.ts
@@ -218,11 +218,15 @@ describe('AgentsAuthService', () => {
     };
 
     const firstLogin = await service.login(credentials);
+    const firstSessionEpoch = service.getSessionEpoch();
     await service.logout();
+    const loggedOutEpoch = service.getSessionEpoch();
     const secondLogin = await service.login(credentials);
+    const secondSessionEpoch = service.getSessionEpoch();
 
     expect(firstLogin).toMatchObject({ success: true, session: { user: { id: 'core-user-42' } } });
     expect(secondLogin).toMatchObject({ success: true, session: { user: { id: 'core-user-42' } } });
+    expect([firstSessionEpoch, loggedOutEpoch, secondSessionEpoch]).toEqual([1, 2, 3]);
     expect(fetchMock.mock.calls[1]?.[0]).toBe(fetchMock.mock.calls[5]?.[0]);
   });
 

--- a/tests/unit/process/ki-buddy/agents/bridge.test.ts
+++ b/tests/unit/process/ki-buddy/agents/bridge.test.ts
@@ -3,6 +3,7 @@ import { startAgentsMcpBridge, type AgentsMcpBridgeHandle } from '@/process/ki-b
 import { AgentsMcpError } from '@/process/ki-buddy/agents/errors';
 
 const handles: AgentsMcpBridgeHandle[] = [];
+const identity = { deploymentOrigin: 'https://agents.example.test', sessionEpoch: 1, userId: 'user-1' };
 
 afterEach(async () => {
   await Promise.all(handles.splice(0).map((handle) => handle.close()));
@@ -15,22 +16,30 @@ describe('startAgentsMcpBridge', () => {
       total: 1,
       agents: [{ agentId: 'agent-1', agentTitle: 'Agent 1', agentType: 'workflow' }],
     };
-    const fetchCatalog = vi.fn().mockResolvedValue(Response.json(catalog));
-    const bridge = await startAgentsMcpBridge({ fetchCatalog, token: 'bridge-secret' });
+    const getSessionIdentity = vi.fn().mockResolvedValue(identity);
+    const fetchCatalog = vi.fn().mockResolvedValue({ identity, response: Response.json(catalog) });
+    const bridge = await startAgentsMcpBridge({ fetchCatalog, getSessionIdentity, token: 'bridge-secret' });
     handles.push(bridge);
 
-    const response = await fetch(`${bridge.url}/catalog`, {
+    const catalogResponse = await fetch(`${bridge.url}/catalog`, {
+      headers: { authorization: `Bearer ${bridge.token}` },
+    });
+    const sessionResponse = await fetch(`${bridge.url}/session`, {
       headers: { authorization: `Bearer ${bridge.token}` },
     });
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual(catalog);
+    expect(catalogResponse.status).toBe(200);
+    await expect(catalogResponse.json()).resolves.toEqual({ identity, catalog });
+    expect(sessionResponse.status).toBe(200);
+    await expect(sessionResponse.json()).resolves.toEqual(identity);
     expect(fetchCatalog).toHaveBeenCalledOnce();
+    expect(getSessionIdentity).toHaveBeenCalledOnce();
   });
 
   it('rejects requests without the exact Adapter token before reading the Agents session', async () => {
     const fetchCatalog = vi.fn();
-    const bridge = await startAgentsMcpBridge({ fetchCatalog, token: 'bridge-secret' });
+    const getSessionIdentity = vi.fn();
+    const bridge = await startAgentsMcpBridge({ fetchCatalog, getSessionIdentity, token: 'bridge-secret' });
     handles.push(bridge);
 
     const response = await fetch(`${bridge.url}/catalog`, {
@@ -39,7 +48,24 @@ describe('startAgentsMcpBridge', () => {
 
     expect(response.status).toBe(401);
     expect(fetchCatalog).not.toHaveBeenCalled();
+    expect(getSessionIdentity).not.toHaveBeenCalled();
     await expect(response.json()).resolves.toEqual({ error: 'adapter_auth_required' });
+  });
+
+  it('returns an authentication status when the current session identity is unavailable', async () => {
+    const bridge = await startAgentsMcpBridge({
+      fetchCatalog: vi.fn(),
+      getSessionIdentity: vi.fn().mockRejectedValue(new AgentsMcpError('auth', 'private session detail')),
+      token: 'bridge-secret',
+    });
+    handles.push(bridge);
+
+    const response = await fetch(`${bridge.url}/session`, {
+      headers: { authorization: `Bearer ${bridge.token}` },
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'agents_auth_required' });
   });
 
   it('cancels the upstream catalog request when the Adapter request disconnects', async () => {
@@ -51,11 +77,15 @@ describe('startAgentsMcpBridge', () => {
     const fetchCatalog = vi.fn((signal?: AbortSignal) => {
       upstreamSignal = signal;
       releaseStarted?.();
-      return new Promise<Response>((_resolve, reject) => {
+      return new Promise<never>((_resolve, reject) => {
         signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
       });
     });
-    const bridge = await startAgentsMcpBridge({ fetchCatalog, token: 'bridge-secret' });
+    const bridge = await startAgentsMcpBridge({
+      fetchCatalog,
+      getSessionIdentity: vi.fn().mockResolvedValue(identity),
+      token: 'bridge-secret',
+    });
     handles.push(bridge);
     const requestController = new AbortController();
     const request = fetch(`${bridge.url}/catalog`, {
@@ -79,11 +109,15 @@ describe('startAgentsMcpBridge', () => {
     const fetchCatalog = vi.fn((signal: AbortSignal) => {
       upstreamSignal = signal;
       releaseStarted?.();
-      return new Promise<Response>((_resolve, reject) => {
+      return new Promise<never>((_resolve, reject) => {
         signal.addEventListener('abort', () => reject(signal.reason), { once: true });
       });
     });
-    const bridge = await startAgentsMcpBridge({ fetchCatalog, token: 'bridge-secret' });
+    const bridge = await startAgentsMcpBridge({
+      fetchCatalog,
+      getSessionIdentity: vi.fn().mockResolvedValue(identity),
+      token: 'bridge-secret',
+    });
     const request = fetch(`${bridge.url}/catalog`, {
       headers: { authorization: `Bearer ${bridge.token}` },
     }).catch(() => undefined);
@@ -114,6 +148,7 @@ describe('startAgentsMcpBridge', () => {
     for (const testCase of cases) {
       const bridge = await startAgentsMcpBridge({
         fetchCatalog: vi.fn().mockRejectedValue(testCase.error),
+        getSessionIdentity: vi.fn().mockResolvedValue(identity),
         token: `bridge-secret-${testCase.expectedCode}`,
       });
       handles.push(bridge);

--- a/tests/unit/process/ki-buddy/agents/catalog.test.ts
+++ b/tests/unit/process/ki-buddy/agents/catalog.test.ts
@@ -1,8 +1,30 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeAgentsCatalog } from '@/process/ki-buddy/agents/catalog';
+import { normalizeAgentsCatalog, normalizeAgentsCatalogSelection } from '@/process/ki-buddy/agents/catalog';
 import catalogFixture from '../../../../fixtures/ki-buddy/agents/catalog.json';
 
 describe('normalizeAgentsCatalog', () => {
+  it('projects the exact supported schema for one fixture candidate without credential fields', () => {
+    const result = normalizeAgentsCatalogSelection(catalogFixture, 'fixture-feedback-analysis').description;
+
+    expect(result).toEqual({
+      agentId: 'fixture-feedback-analysis',
+      title: '客户反馈分析',
+      description: '分析脱敏后的客户反馈文本并生成摘要。',
+      agentType: 'workflow',
+      inputSchema: [
+        {
+          name: 'feedbackFile',
+          description: '脱敏后的反馈文件',
+          type: 'file',
+          required: true,
+          allowed_file_types: ['text/plain'],
+        },
+      ],
+      outputSchema: [{ name: 'summary', description: '分析摘要', type: 'text', required: true }],
+    });
+    expect(JSON.stringify(result)).not.toMatch(/apiKey|token|userId/u);
+  });
+
   it('returns the complete safe inventory and excludes fields outside the public catalog summary', () => {
     const result = normalizeAgentsCatalog(catalogFixture);
 

--- a/tests/unit/process/ki-buddy/agents/client.test.ts
+++ b/tests/unit/process/ki-buddy/agents/client.test.ts
@@ -10,13 +10,52 @@ const validCatalog = {
       agentTitle: 'Feedback analyst',
       agentDescription: 'Summarizes customer feedback.',
       agentType: 'workflow',
+      defaultInputModes: [
+        {
+          name: 'attachment',
+          description: 'A source document.',
+          type: 'file',
+          required: true,
+          allowed_file_types: ['application/pdf'],
+        },
+      ],
+      defaultOutputModes: [{ name: 'summary', description: 'The generated summary.', type: 'text', required: true }],
     },
   ],
 };
 
+const accountIdentity = { deploymentOrigin: 'https://agents.example.test', sessionEpoch: 1, userId: 'user-1' };
+
 describe('createAgentsCatalogClient', () => {
+  it('describes the exact schema for one current catalog candidate', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ identity: accountIdentity, catalog: validCatalog }));
+    const client = createAgentsCatalogClient({
+      bridgeUrl: 'http://127.0.0.1:43123',
+      bridgeToken: 'bridge-secret',
+      fetchImpl: fetchMock,
+    });
+
+    await expect(client.describe('agent-feedback')).resolves.toEqual({
+      agentId: 'agent-feedback',
+      title: 'Feedback analyst',
+      description: 'Summarizes customer feedback.',
+      agentType: 'workflow',
+      inputSchema: [
+        {
+          name: 'attachment',
+          description: 'A source document.',
+          type: 'file',
+          required: true,
+          allowed_file_types: ['application/pdf'],
+        },
+      ],
+      outputSchema: [{ name: 'summary', description: 'The generated summary.', type: 'text', required: true }],
+    });
+    expect(fetchMock).toHaveBeenCalledWith('http://127.0.0.1:43123/catalog', expect.any(Object));
+  });
+
   it('loads a complete inventory only through the authenticated loopback bridge', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(Response.json(validCatalog));
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ identity: accountIdentity, catalog: validCatalog }));
     const client = createAgentsCatalogClient({
       bridgeUrl: 'http://127.0.0.1:43123',
       bridgeToken: 'bridge-secret',
@@ -43,6 +82,288 @@ describe('createAgentsCatalogClient', () => {
       redirect: 'error',
       signal: expect.any(AbortSignal),
     });
+  });
+
+  it('caches inventory for five minutes within the same deployment, account, and Adapter session', async () => {
+    let currentTime = 10_000;
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const path = new URL(String(input)).pathname;
+      return Promise.resolve(
+        Response.json(path === '/session' ? accountIdentity : { identity: accountIdentity, catalog: validCatalog })
+      );
+    });
+    const client = createAgentsCatalogClient({
+      bridgeUrl: 'http://127.0.0.1:43123',
+      bridgeToken: 'bridge-secret',
+      fetchImpl: fetchMock as typeof fetch,
+      now: () => currentTime,
+    });
+
+    await client.list();
+    await client.list();
+    currentTime += 5 * 60 * 1000;
+    await client.list();
+
+    expect(fetchMock.mock.calls.map(([input]) => new URL(String(input)).pathname)).toEqual([
+      '/catalog',
+      '/session',
+      '/catalog',
+    ]);
+  });
+
+  it('forces a catalog refresh without using the cached inventory', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(Response.json({ identity: accountIdentity, catalog: validCatalog })));
+    const client = createAgentsCatalogClient({
+      bridgeUrl: 'http://127.0.0.1:43123',
+      bridgeToken: 'bridge-secret',
+      fetchImpl: fetchMock,
+    });
+
+    await client.list();
+    await client.list({ forceRefresh: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.every(([input]) => new URL(String(input)).pathname === '/catalog')).toBe(true);
+  });
+
+  it('does not reuse a previous account inventory after the session identity changes', async () => {
+    const accountBIdentity = { deploymentOrigin: 'https://agents.example.test', sessionEpoch: 2, userId: 'user-2' };
+    const accountBCatalog = {
+      status: 'ok',
+      total: 1,
+      agents: [
+        {
+          agentId: 'agent-account-b',
+          agentTitle: 'Account B agent',
+          agentDescription: '',
+          agentType: 'workflow',
+          defaultInputModes: [],
+          defaultOutputModes: [],
+        },
+      ],
+    };
+    const responses = [
+      Response.json({ identity: accountIdentity, catalog: validCatalog }),
+      Response.json(accountBIdentity),
+      Response.json({ identity: accountBIdentity, catalog: accountBCatalog }),
+    ];
+    const fetchMock = vi.fn(() => Promise.resolve(responses.shift() as Response));
+    const client = createAgentsCatalogClient({
+      bridgeUrl: 'http://127.0.0.1:43123',
+      bridgeToken: 'bridge-secret',
+      fetchImpl: fetchMock,
+    });
+
+    await client.list();
+    await expect(client.list()).resolves.toMatchObject({ agents: [{ agentId: 'agent-account-b' }] });
+
+    expect(fetchMock.mock.calls.map(([input]) => new URL(String(input)).pathname)).toEqual([
+      '/catalog',
+      '/session',
+      '/catalog',
+    ]);
+  });
+
+  it('does not reuse inventory after the same account starts a new authenticated session', async () => {
+    const renewedIdentity = { ...accountIdentity, sessionEpoch: 2 };
+    const renewedCatalog = {
+      ...validCatalog,
+      agents: [{ ...validCatalog.agents[0], agentId: 'agent-after-reauthentication' }],
+    };
+    const responses = [
+      Response.json({ identity: accountIdentity, catalog: validCatalog }),
+      Response.json(renewedIdentity),
+      Response.json({ identity: renewedIdentity, catalog: renewedCatalog }),
+    ];
+    const fetchMock = vi.fn(() => Promise.resolve(responses.shift() as Response));
+    const client = createAgentsCatalogClient({
+      bridgeUrl: 'http://127.0.0.1:43123',
+      bridgeToken: 'bridge-secret',
+      fetchImpl: fetchMock,
+    });
+
+    await client.list();
+    await expect(client.list()).resolves.toMatchObject({
+      agents: [{ agentId: 'agent-after-reauthentication' }],
+    });
+
+    expect(fetchMock.mock.calls.map(([input]) => new URL(String(input)).pathname)).toEqual([
+      '/catalog',
+      '/session',
+      '/catalog',
+    ]);
+  });
+
+  it('does not reuse inventory when the same Adapter session changes deployment origin', async () => {
+    const otherDeploymentIdentity = {
+      deploymentOrigin: 'https://other-agents.example.test',
+      sessionEpoch: 1,
+      userId: 'user-1',
+    };
+    const otherDeploymentCatalog = {
+      ...validCatalog,
+      agents: [{ ...validCatalog.agents[0], agentId: 'agent-other-deployment' }],
+    };
+    const responses = [
+      Response.json({ identity: accountIdentity, catalog: validCatalog }),
+      Response.json(otherDeploymentIdentity),
+      Response.json({ identity: otherDeploymentIdentity, catalog: otherDeploymentCatalog }),
+    ];
+    const fetchMock = vi.fn(() => Promise.resolve(responses.shift() as Response));
+    const client = createAgentsCatalogClient({
+      bridgeUrl: 'http://127.0.0.1:43123',
+      bridgeToken: 'bridge-secret',
+      fetchImpl: fetchMock,
+    });
+
+    await client.list();
+    await expect(client.list()).resolves.toMatchObject({ agents: [{ agentId: 'agent-other-deployment' }] });
+
+    expect(fetchMock.mock.calls.map(([input]) => new URL(String(input)).pathname)).toEqual([
+      '/catalog',
+      '/session',
+      '/catalog',
+    ]);
+  });
+
+  it('does not share inventory across Adapter sessions', async () => {
+    const fetchA = vi.fn(() => Promise.resolve(Response.json({ identity: accountIdentity, catalog: validCatalog })));
+    const fetchB = vi.fn(() => Promise.resolve(Response.json({ identity: accountIdentity, catalog: validCatalog })));
+    const clientA = createAgentsCatalogClient({
+      bridgeUrl: 'http://127.0.0.1:43123',
+      bridgeToken: 'bridge-secret-a',
+      fetchImpl: fetchA as typeof fetch,
+    });
+    const clientB = createAgentsCatalogClient({
+      bridgeUrl: 'http://127.0.0.1:43124',
+      bridgeToken: 'bridge-secret-b',
+      fetchImpl: fetchB as typeof fetch,
+    });
+
+    await clientA.list();
+    await clientB.list();
+
+    expect(fetchA).toHaveBeenCalledOnce();
+    expect(fetchB).toHaveBeenCalledOnce();
+  });
+
+  it('clears the cached account after authentication is invalidated', async () => {
+    const responses = [
+      Response.json({ identity: accountIdentity, catalog: validCatalog }),
+      Response.json({ error: 'agents_auth_required' }, { status: 401 }),
+      Response.json({ identity: accountIdentity, catalog: validCatalog }),
+    ];
+    const fetchMock = vi.fn(() => Promise.resolve(responses.shift() as Response));
+    const client = createAgentsCatalogClient({
+      bridgeUrl: 'http://127.0.0.1:43123',
+      bridgeToken: 'bridge-secret',
+      fetchImpl: fetchMock,
+    });
+
+    await client.list();
+    await expect(client.list()).rejects.toMatchObject({ code: 'auth' });
+    await client.list();
+
+    expect(fetchMock.mock.calls.map(([input]) => new URL(String(input)).pathname)).toEqual([
+      '/catalog',
+      '/session',
+      '/catalog',
+    ]);
+  });
+
+  it('clears cached inventory when the session epoch is incompatible', async () => {
+    const responses = [
+      Response.json({ identity: accountIdentity, catalog: validCatalog }),
+      Response.json({ ...accountIdentity, sessionEpoch: -1 }),
+      Response.json({ identity: accountIdentity, catalog: validCatalog }),
+    ];
+    const fetchMock = vi.fn(() => Promise.resolve(responses.shift() as Response));
+    const client = createAgentsCatalogClient({
+      bridgeUrl: 'http://127.0.0.1:43123',
+      bridgeToken: 'bridge-secret',
+      fetchImpl: fetchMock,
+    });
+
+    await client.list();
+    await expect(client.list()).rejects.toMatchObject({ code: 'contract' });
+    await client.list();
+
+    expect(fetchMock.mock.calls.map(([input]) => new URL(String(input)).pathname)).toEqual([
+      '/catalog',
+      '/session',
+      '/catalog',
+    ]);
+  });
+
+  it('reconfirms catalog membership before describe and discards a revoked candidate', async () => {
+    const emptyCatalog = { status: 'ok', total: 0, agents: [] };
+    const responses = [
+      Response.json({ identity: accountIdentity, catalog: validCatalog }),
+      Response.json({ identity: accountIdentity, catalog: emptyCatalog }),
+      Response.json({ identity: accountIdentity, catalog: emptyCatalog }),
+    ];
+    const fetchMock = vi.fn(() => Promise.resolve(responses.shift() as Response));
+    const client = createAgentsCatalogClient({
+      bridgeUrl: 'http://127.0.0.1:43123',
+      bridgeToken: 'bridge-secret',
+      fetchImpl: fetchMock,
+    });
+
+    await client.list();
+    await expect(client.describe('agent-feedback')).rejects.toMatchObject({ code: 'not_found' });
+    await expect(client.list()).resolves.toEqual({ total: 0, agents: [] });
+
+    expect(fetchMock.mock.calls.map(([input]) => new URL(String(input)).pathname)).toEqual([
+      '/catalog',
+      '/catalog',
+      '/catalog',
+    ]);
+  });
+
+  it('fails closed when the selected candidate schema is incompatible', async () => {
+    const incompatibleCatalog = {
+      ...validCatalog,
+      agents: [{ ...validCatalog.agents[0], defaultInputModes: [{ name: 'query', type: 'text' }] }],
+    };
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(Response.json({ identity: accountIdentity, catalog: incompatibleCatalog }))
+    );
+    const client = createAgentsCatalogClient({
+      bridgeUrl: 'http://127.0.0.1:43123',
+      bridgeToken: 'bridge-secret',
+      fetchImpl: fetchMock as typeof fetch,
+    });
+
+    await expect(client.describe('agent-feedback')).rejects.toMatchObject({ code: 'contract' });
+  });
+
+  it('discards cached inventory when a forced refresh finds an ambiguous catalog', async () => {
+    const duplicateCatalog = {
+      ...validCatalog,
+      total: 2,
+      agents: [validCatalog.agents[0], validCatalog.agents[0]],
+    };
+    const responses = [
+      Response.json({ identity: accountIdentity, catalog: validCatalog }),
+      Response.json({ identity: accountIdentity, catalog: duplicateCatalog }),
+      Response.json({ identity: accountIdentity, catalog: validCatalog }),
+    ];
+    const fetchMock = vi.fn(() => Promise.resolve(responses.shift() as Response));
+    const client = createAgentsCatalogClient({
+      bridgeUrl: 'http://127.0.0.1:43123',
+      bridgeToken: 'bridge-secret',
+      fetchImpl: fetchMock,
+    });
+
+    await client.list();
+    await expect(client.list({ forceRefresh: true })).rejects.toMatchObject({ code: 'ambiguous' });
+    await client.list();
+
+    expect(fetchMock.mock.calls.map(([input]) => new URL(String(input)).pathname)).toEqual([
+      '/catalog',
+      '/catalog',
+      '/catalog',
+    ]);
   });
 
   it('rejects non-loopback bridge configuration before making a request', async () => {

--- a/tests/unit/process/ki-buddy/agents/mcpServer.test.ts
+++ b/tests/unit/process/ki-buddy/agents/mcpServer.test.ts
@@ -1,7 +1,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createAgentsMcpServer } from '@/process/ki-buddy/agents/mcpServer';
 import { AgentsMcpError } from '@/process/ki-buddy/agents/errors';
 
@@ -36,8 +36,11 @@ afterEach(async () => {
   await Promise.all(clients.splice(0).map((client) => client.close()));
 });
 
-async function connect(list: () => Promise<unknown>) {
-  const server = createAgentsMcpServer({ list } as never);
+async function connect(
+  list: (options?: { forceRefresh?: boolean }) => Promise<unknown>,
+  describeAgent: (agentId: string) => Promise<unknown> = async () => ({})
+) {
+  const server = createAgentsMcpServer({ describe: describeAgent, list } as never);
   const client = new Client({ name: 'agents-mcp-test', version: '1.0.0' });
   const [serverTransport, clientTransport] = linkedTransports();
   await server.connect(serverTransport);
@@ -47,15 +50,23 @@ async function connect(list: () => Promise<unknown>) {
 }
 
 describe('createAgentsMcpServer', () => {
-  it('publishes only the read-only complete catalog tool', async () => {
+  it('publishes read-only tools for complete inventory and exact schema description', async () => {
     const client = await connect(async () => ({ total: 0, agents: [] }));
 
     const result = await client.listTools();
 
-    expect(result.tools.map(({ name }) => name)).toEqual(['agents_list']);
+    expect(result.tools.map(({ name }) => name)).toEqual(['agents_list', 'agents_describe']);
     expect(result.tools[0]).toMatchObject({
       name: 'agents_list',
       annotations: { readOnlyHint: true },
+    });
+    expect(result.tools[1]).toMatchObject({
+      name: 'agents_describe',
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        required: ['agentId'],
+        properties: { agentId: { type: 'string' } },
+      },
     });
   });
 
@@ -72,6 +83,68 @@ describe('createAgentsMcpServer', () => {
     expect(result.content).toEqual([{ type: 'text', text: JSON.stringify(inventory) }]);
   });
 
+  it('forwards an explicit inventory refresh request to the session cache boundary', async () => {
+    const list = vi.fn().mockResolvedValue({ total: 0, agents: [] });
+    const client = await connect(list);
+
+    await client.callTool({ name: 'agents_list', arguments: { forceRefresh: true } });
+
+    expect(list).toHaveBeenCalledWith({ forceRefresh: true });
+  });
+
+  it('returns the exact schema for the requested catalog candidate', async () => {
+    const description = {
+      agentId: 'agent-1',
+      title: 'Agent 1',
+      description: '',
+      agentType: 'workflow',
+      inputSchema: [{ name: 'query', description: 'Query', type: 'text', required: true }],
+      outputSchema: [],
+    };
+    const describeAgent = vi.fn().mockResolvedValue(description);
+    const client = await connect(async () => ({ total: 0, agents: [] }), describeAgent);
+
+    const result = await client.callTool({ name: 'agents_describe', arguments: { agentId: 'agent-1' } });
+
+    expect(describeAgent).toHaveBeenCalledWith('agent-1');
+    expect(result.content).toEqual([{ type: 'text', text: JSON.stringify(description) }]);
+  });
+
+  it('rejects a describe call without the required exact agentId before reading the catalog', async () => {
+    const describeAgent = vi.fn();
+    const client = await connect(async () => ({ total: 0, agents: [] }), describeAgent);
+
+    const result = await client.callTool({ name: 'agents_describe', arguments: {} });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: 'text', text: expect.stringMatching(/-32602:.*Invalid arguments.*agentId/su) },
+    ]);
+    expect(describeAgent).not.toHaveBeenCalled();
+  });
+
+  it('returns a distinct safe status when the exact candidate is no longer available', async () => {
+    const client = await connect(
+      async () => ({ total: 0, agents: [] }),
+      async () => {
+        throw new AgentsMcpError('not_found', 'private catalog detail');
+      }
+    );
+
+    const result = await client.callTool({ name: 'agents_describe', arguments: { agentId: 'agent-1' } });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      {
+        type: 'text',
+        text: JSON.stringify({
+          ok: false,
+          error: { code: 'not_found', message: 'Agent is not in the current catalog' },
+        }),
+      },
+    ]);
+  });
+
   it('returns a categorized error without forwarding sensitive details', async () => {
     const client = await connect(async () => {
       throw new AgentsMcpError('auth', 'Agents login is required: token=secret');
@@ -84,6 +157,25 @@ describe('createAgentsMcpServer', () => {
       {
         type: 'text',
         text: JSON.stringify({ ok: false, error: { code: 'auth', message: 'Agents login is required' } }),
+      },
+    ]);
+  });
+
+  it('maps an unexpected client failure to a safe server error', async () => {
+    const client = await connect(async () => {
+      throw new Error('private implementation detail');
+    });
+
+    const result = await client.callTool({ name: 'agents_list', arguments: {} });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      {
+        type: 'text',
+        text: JSON.stringify({
+          ok: false,
+          error: { code: 'server', message: 'Agents catalog service is unavailable' },
+        }),
       },
     ]);
   });

--- a/tests/unit/process/ki-buddy/agents/runtime.test.ts
+++ b/tests/unit/process/ki-buddy/agents/runtime.test.ts
@@ -4,6 +4,18 @@ import { AgentsMcpError } from '@/process/ki-buddy/agents/errors';
 
 const originalBridgeUrl = process.env.KI_BUDDY_AGENTS_ADAPTER_BRIDGE_URL;
 const originalBridgeToken = process.env.KI_BUDDY_AGENTS_ADAPTER_BRIDGE_TOKEN;
+const authenticatedSession = {
+  status: 'authenticated',
+  user: {
+    id: 'core-user',
+    agents: { deploymentUrl: 'https://agents.example.test/tenant', userId: 'agents-user-1' },
+  },
+} as const;
+const accountIdentity = {
+  deploymentOrigin: 'https://agents.example.test',
+  sessionEpoch: 1,
+  userId: 'agents-user-1',
+};
 
 afterEach(() => {
   if (originalBridgeUrl === undefined) delete process.env.KI_BUDDY_AGENTS_ADAPTER_BRIDGE_URL;
@@ -22,6 +34,7 @@ describe('startAgentsMcpRuntimeBridge', () => {
     });
     const authService = {
       getSession: vi.fn(),
+      getSessionEpoch: vi.fn(),
       fetchAuthenticated: vi.fn(),
     };
 
@@ -45,7 +58,7 @@ describe('startAgentsMcpRuntimeBridge', () => {
       return { url: 'http://127.0.0.1:43123', token: 'bridge-secret', close: vi.fn() };
     });
     const handle = await startAgentsMcpRuntimeBridge(
-      { getSession, fetchAuthenticated } as never,
+      { getSession, getSessionEpoch: vi.fn().mockReturnValue(1), fetchAuthenticated } as never,
       process.env,
       startBridge as never
     );
@@ -64,7 +77,7 @@ describe('startAgentsMcpRuntimeBridge', () => {
       return { url: 'http://127.0.0.1:43123', token: 'bridge-secret', close: vi.fn() };
     });
     const handle = await startAgentsMcpRuntimeBridge(
-      { getSession, fetchAuthenticated } as never,
+      { getSession, getSessionEpoch: vi.fn().mockReturnValue(1), fetchAuthenticated } as never,
       process.env,
       startBridge as never
     );
@@ -76,21 +89,29 @@ describe('startAgentsMcpRuntimeBridge', () => {
 
   it('uses the auth service boundary for the current catalog instead of exposing credentials', async () => {
     const response = Response.json({ status: 'ok', total: 0, agents: [] });
-    const getSession = vi.fn().mockResolvedValue({ status: 'authenticated', user: { id: 'core-user' } });
+    const getSession = vi.fn().mockResolvedValue(authenticatedSession);
     const fetchAuthenticated = vi.fn().mockResolvedValue(response);
     let fetchCatalog: ((signal: AbortSignal) => Promise<Response>) | undefined;
-    const startBridge = vi.fn(async (options: { fetchCatalog: (signal: AbortSignal) => Promise<Response> }) => {
-      fetchCatalog = options.fetchCatalog;
-      return { url: 'http://127.0.0.1:43123', token: 'bridge-secret', close: vi.fn() };
-    });
+    let getSessionIdentity: (() => Promise<unknown>) | undefined;
+    const startBridge = vi.fn(
+      async (options: {
+        fetchCatalog: (signal: AbortSignal) => Promise<Response>;
+        getSessionIdentity: () => Promise<unknown>;
+      }) => {
+        fetchCatalog = options.fetchCatalog;
+        getSessionIdentity = options.getSessionIdentity;
+        return { url: 'http://127.0.0.1:43123', token: 'bridge-secret', close: vi.fn() };
+      }
+    );
     const handle = await startAgentsMcpRuntimeBridge(
-      { getSession, fetchAuthenticated } as never,
+      { getSession, getSessionEpoch: vi.fn().mockReturnValue(1), fetchAuthenticated } as never,
       process.env,
       startBridge as never
     );
 
     const signal = new AbortController().signal;
-    await expect(fetchCatalog?.(signal)).resolves.toBe(response);
+    await expect(getSessionIdentity?.()).resolves.toEqual(accountIdentity);
+    await expect(fetchCatalog?.(signal)).resolves.toEqual({ identity: accountIdentity, response });
     expect(fetchAuthenticated).toHaveBeenCalledWith('/bridge/agents/catalog', {
       method: 'GET',
       headers: { accept: 'application/json' },
@@ -100,7 +121,7 @@ describe('startAgentsMcpRuntimeBridge', () => {
   });
 
   it('classifies an unexpected catalog request failure as a network error', async () => {
-    const getSession = vi.fn().mockResolvedValue({ status: 'authenticated', user: { id: 'core-user' } });
+    const getSession = vi.fn().mockResolvedValue(authenticatedSession);
     const fetchAuthenticated = vi.fn().mockRejectedValue(new Error('private upstream detail'));
     let fetchCatalog: (() => Promise<Response>) | undefined;
     const startBridge = vi.fn(async (options: { fetchCatalog: () => Promise<Response> }) => {
@@ -108,7 +129,7 @@ describe('startAgentsMcpRuntimeBridge', () => {
       return { url: 'http://127.0.0.1:43123', token: 'bridge-secret', close: vi.fn() };
     });
     const handle = await startAgentsMcpRuntimeBridge(
-      { getSession, fetchAuthenticated } as never,
+      { getSession, getSessionEpoch: vi.fn().mockReturnValue(1), fetchAuthenticated } as never,
       process.env,
       startBridge as never
     );
@@ -120,9 +141,53 @@ describe('startAgentsMcpRuntimeBridge', () => {
     await handle.close();
   });
 
+  it('rejects a catalog response when the Agents account changes during refresh', async () => {
+    const switchedSession = {
+      ...authenticatedSession,
+      user: {
+        ...authenticatedSession.user,
+        agents: { ...authenticatedSession.user.agents, userId: 'agents-user-2' },
+      },
+    };
+    const getSession = vi.fn().mockResolvedValueOnce(authenticatedSession).mockResolvedValueOnce(switchedSession);
+    const fetchAuthenticated = vi.fn().mockResolvedValue(Response.json({ status: 'ok', total: 0, agents: [] }));
+    let fetchCatalog: ((signal: AbortSignal) => Promise<unknown>) | undefined;
+    const startBridge = vi.fn(async (options: { fetchCatalog: (signal: AbortSignal) => Promise<unknown> }) => {
+      fetchCatalog = options.fetchCatalog;
+      return { url: 'http://127.0.0.1:43123', token: 'bridge-secret', close: vi.fn() };
+    });
+    const handle = await startAgentsMcpRuntimeBridge(
+      { getSession, getSessionEpoch: vi.fn().mockReturnValue(1), fetchAuthenticated } as never,
+      process.env,
+      startBridge as never
+    );
+
+    await expect(fetchCatalog?.(new AbortController().signal)).rejects.toMatchObject({ code: 'auth' });
+    await handle.close();
+  });
+
+  it('rejects a catalog response when the same account session changes during refresh', async () => {
+    const getSession = vi.fn().mockResolvedValue(authenticatedSession);
+    const getSessionEpoch = vi.fn().mockReturnValueOnce(1).mockReturnValueOnce(2);
+    const fetchAuthenticated = vi.fn().mockResolvedValue(Response.json({ status: 'ok', total: 0, agents: [] }));
+    let fetchCatalog: ((signal: AbortSignal) => Promise<unknown>) | undefined;
+    const startBridge = vi.fn(async (options: { fetchCatalog: (signal: AbortSignal) => Promise<unknown> }) => {
+      fetchCatalog = options.fetchCatalog;
+      return { url: 'http://127.0.0.1:43123', token: 'bridge-secret', close: vi.fn() };
+    });
+    const handle = await startAgentsMcpRuntimeBridge(
+      { getSession, getSessionEpoch, fetchAuthenticated } as never,
+      process.env,
+      startBridge as never
+    );
+
+    await expect(fetchCatalog?.(new AbortController().signal)).rejects.toMatchObject({ code: 'auth' });
+    await handle.close();
+  });
+
   it('preserves an error already classified by the authenticated Agents boundary', async () => {
     const classifiedError = new AgentsMcpError('server', 'Agents catalog service is unavailable');
-    const getSession = vi.fn().mockResolvedValue({ status: 'authenticated', user: { id: 'core-user' } });
+    const getSession = vi.fn().mockResolvedValue(authenticatedSession);
     const fetchAuthenticated = vi.fn().mockRejectedValue(classifiedError);
     let fetchCatalog: (() => Promise<Response>) | undefined;
     const startBridge = vi.fn(async (options: { fetchCatalog: () => Promise<Response> }) => {
@@ -130,7 +195,7 @@ describe('startAgentsMcpRuntimeBridge', () => {
       return { url: 'http://127.0.0.1:43123', token: 'bridge-secret', close: vi.fn() };
     });
     const handle = await startAgentsMcpRuntimeBridge(
-      { getSession, fetchAuthenticated } as never,
+      { getSession, getSessionEpoch: vi.fn().mockReturnValue(1), fetchAuthenticated } as never,
       process.env,
       startBridge as never
     );

--- a/tests/unit/renderer/ki-buddy/McpServerToolsList.dom.test.tsx
+++ b/tests/unit/renderer/ki-buddy/McpServerToolsList.dom.test.tsx
@@ -10,8 +10,14 @@ import McpServerToolsList from '@/renderer/pages/settings/ToolsSettings/McpServe
 
 const PROTOCOL_DESCRIPTION = 'Protocol-provided Agents description';
 const PRODUCT_DESCRIPTIONS = {
-  'en-US': 'Lists the complete Agents catalog available to the current signed-in account.',
-  'zh-CN': '列出当前登录账号可用的完整 Agents 目录。',
+  'en-US': {
+    list: 'Lists the complete Agents catalog available to the current signed-in account.',
+    describe: 'Shows the exact input and output schema for one agent in the current catalog.',
+  },
+  'zh-CN': {
+    list: '列出当前登录账号可用的完整 Agents 目录。',
+    describe: '显示当前目录中一个 Agent 的精确输入和输出结构。',
+  },
 } as const;
 
 const buildServer = (overrides: Partial<IMcpServer> = {}): IMcpServer => ({
@@ -24,7 +30,10 @@ const buildServer = (overrides: Partial<IMcpServer> = {}): IMcpServer => ({
     command: 'node',
     args: ['/Applications/Ki-Buddy.app/Contents/Resources/app.asar.unpacked/out/main/builtin-mcp-agents.js'],
   },
-  tools: [{ name: 'agents_list', description: PROTOCOL_DESCRIPTION }],
+  tools: [
+    { name: 'agents_list', description: PROTOCOL_DESCRIPTION },
+    { name: 'agents_describe', description: PROTOCOL_DESCRIPTION },
+  ],
   created_at: 0,
   updated_at: 0,
   original_json: '{}',
@@ -37,9 +46,18 @@ async function createTestI18n(language: keyof typeof PRODUCT_DESCRIPTIONS): Prom
     lng: language,
     fallbackLng: 'en-US',
     resources: Object.fromEntries(
-      Object.entries(PRODUCT_DESCRIPTIONS).map(([locale, description]) => [
+      Object.entries(PRODUCT_DESCRIPTIONS).map(([locale, descriptions]) => [
         locale,
-        { translation: { settings: { kiBuddy: { agentsListDescription: description } } } },
+        {
+          translation: {
+            settings: {
+              kiBuddy: {
+                agentsListDescription: descriptions.list,
+                agentsDescribeDescription: descriptions.describe,
+              },
+            },
+          },
+        },
       ])
     ),
   });
@@ -80,14 +98,16 @@ describe('Ki-Buddy Agents MCP tool presentation', () => {
       </I18nextProvider>
     );
 
-    expect(screen.getByText(PRODUCT_DESCRIPTIONS['en-US'])).toBeInTheDocument();
+    expect(screen.getByText(PRODUCT_DESCRIPTIONS['en-US'].list)).toBeInTheDocument();
+    expect(screen.getByText(PRODUCT_DESCRIPTIONS['en-US'].describe)).toBeInTheDocument();
     expect(screen.queryByText(PROTOCOL_DESCRIPTION)).not.toBeInTheDocument();
   });
 
   it.each(['en-US', 'zh-CN'] as const)('shows the localized Agents description in %s', async (language) => {
     await renderTools(language, buildServer(), 'productBuiltin');
 
-    expect(screen.getByText(PRODUCT_DESCRIPTIONS[language])).toBeInTheDocument();
+    expect(screen.getByText(PRODUCT_DESCRIPTIONS[language].list)).toBeInTheDocument();
+    expect(screen.getByText(PRODUCT_DESCRIPTIONS[language].describe)).toBeInTheDocument();
     expect(screen.queryByText(PROTOCOL_DESCRIPTION)).not.toBeInTheDocument();
   });
 
@@ -97,11 +117,11 @@ describe('Ki-Buddy Agents MCP tool presentation', () => {
     [
       'for another tool',
       'productBuiltin' as const,
-      buildServer({ tools: [{ name: 'agents_describe', description: PROTOCOL_DESCRIPTION }] }),
+      buildServer({ tools: [{ name: 'agents_unknown', description: PROTOCOL_DESCRIPTION }] }),
     ],
   ])('keeps the protocol description %s', async (_scenario, origin, server) => {
     await renderTools('en-US', server, origin);
 
-    expect(screen.getByText(PROTOCOL_DESCRIPTION)).toBeInTheDocument();
+    expect(screen.getAllByText(PROTOCOL_DESCRIPTION)).not.toHaveLength(0);
   });
 });

--- a/tests/unit/renderer/services/runtime/kiBuddyAssistantCatalog.dom.test.ts
+++ b/tests/unit/renderer/services/runtime/kiBuddyAssistantCatalog.dom.test.ts
@@ -73,6 +73,10 @@ describe('projectProductAssistantCatalog', () => {
         backendName: 'agents-mcp-adapter',
         scriptName: 'builtin-mcp-agents.js',
         tools: {
+          describe: {
+            name: 'agents_describe',
+            descriptionKey: 'settings.kiBuddy.agentsDescribeDescription',
+          },
           list: {
             name: 'agents_list',
             descriptionKey: 'settings.kiBuddy.agentsListDescription',


### PR DESCRIPTION
## Description

在现有 `agents_list` 能力上增加精确的 `agents_describe`，并为 catalog inventory 增加按 deployment origin、Agents user 和 Adapter session 隔离的五分钟内存缓存。

主要变化：

- 返回当前账号完整、紧凑的 Agents inventory，并保留准确的 `total`。
- 支持显式强制刷新；账号、部署或 Adapter session 变化时不会复用旧缓存。
- `agents_describe` 在读取 schema 前重新确认候选仍属于当前安全 catalog。
- 对无匹配、候选含糊、缺少 required 参数及 contract 不兼容返回可区分错误，并保持零 invoke。
- 增加本地 fake Gateway、MCP stdio、账号切换和 packaged Adapter 注册链路测试。

## Related Issues

- Closes #19

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (888 个既有 warning)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 4270 passed，5 skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

不适用。本 PR 修改主进程 Agents catalog/MCP 能力，不涉及 UI 布局。

## Additional Context

- `just push -u origin feat/agents-catalog-describe-cache` 已完整通过并完成推送。
- 测试期间仍会出现仓库既有的 `MaxListenersExceededWarning`，不影响退出状态。
- 本地未设置 `E2E_PACKAGED=1`，因此 packaged E2E 没有实际执行；对应测试链路已包含在本 PR。
- 当前项目全局 coverage 为 54.11%，低于项目 80% 目标；本次 Agents 模块相关覆盖约 90%。
