### PR TITLE
feat(ki-buddy): upload Agents file inputs

### DIFF
--- a/packages/desktop/src/process/ki-buddy/agents/bridge.ts
+++ b/packages/desktop/src/process/ki-buddy/agents/bridge.ts
@@ -1,11 +1,16 @@
 import { randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import {
+  AGENTS_MCP_AGENT_ID_HEADER,
   AGENTS_MCP_CLIENT_ID_HEADER,
+  AGENTS_MCP_FIELD_NAME_HEADER,
+  AGENTS_MCP_FILE_NAME_HEADER,
+  AGENTS_MCP_FILE_SIZE_HEADER,
   isAgentsMcpClientId,
   normalizeAgentsCatalogSelection,
-  validateAgentsScalarInputs,
-  type AgentsScalarInputs,
+  validateAgentsFileField,
+  validateAgentsInvokeInputs,
+  type AgentsInvokeRequest,
 } from './contracts';
 import { AgentsMcpError, getAgentsMcpErrorPresentation, type AgentsMcpErrorCode } from './errors';
 import { readBoundedJsonRequest, readBoundedJsonResponse } from './json';
@@ -15,12 +20,7 @@ const MAX_CATALOG_RESPONSE_BYTES = 5 * 1024 * 1024;
 const MAX_INVOKE_REQUEST_BYTES = 1024 * 1024;
 const MAX_INVOKE_RESPONSE_BYTES = 5 * 1024 * 1024;
 
-export type AgentsInvokeRequest = Readonly<{
-  agentId: string;
-  agentType: string;
-  conversationId: string;
-  inputs: AgentsScalarInputs;
-}>;
+export type { AgentsInvokeRequest } from './contracts';
 
 type StartAgentsMcpBridgeOptions = Readonly<{
   fetchCatalog: (
@@ -33,6 +33,13 @@ type StartAgentsMcpBridgeOptions = Readonly<{
     clientId: string,
     signal: AbortSignal
   ) => Promise<Response>;
+  uploadFile?: (
+    body: IncomingMessage,
+    contentType: string,
+    sessionEpoch: number,
+    clientId: string,
+    signal: AbortSignal
+  ) => Promise<Readonly<{ fileUrl: string; sessionEpoch: number }>>;
   token?: string;
 }>;
 
@@ -55,6 +62,29 @@ function requireClientId(request: IncomingMessage): string {
     throw new AgentsMcpError('invalid_input', 'Agents Adapter client identity is invalid');
   }
   return clientId;
+}
+
+function requireEncodedHeader(request: IncomingMessage, name: string, label: string, maxLength: number): string {
+  const value = request.headers[name];
+  if (typeof value !== 'string' || value.length === 0 || value.length > maxLength * 9) {
+    throw new AgentsMcpError('invalid_input', `${label} is invalid`);
+  }
+  try {
+    const decoded = decodeURIComponent(value).trim();
+    if (!decoded || decoded.length > maxLength) throw new Error('invalid length');
+    return decoded;
+  } catch {
+    throw new AgentsMcpError('invalid_input', `${label} is invalid`);
+  }
+}
+
+function requireFileSize(request: IncomingMessage): number {
+  const value = request.headers[AGENTS_MCP_FILE_SIZE_HEADER];
+  const size = typeof value === 'string' ? Number(value) : Number.NaN;
+  if (!Number.isSafeInteger(size) || size < 0) {
+    throw new AgentsMcpError('invalid_input', 'Agents upload file size is invalid');
+  }
+  return size;
 }
 
 function sendJson(response: ServerResponse, status: number, body: unknown): void {
@@ -139,7 +169,7 @@ async function handleInvokeRequest(
     const catalog = await readBoundedJsonResponse(catalogResponse, MAX_CATALOG_RESPONSE_BYTES);
     const { description } = normalizeAgentsCatalogSelection(catalog, agentId);
     const bodyInputs = (body as { inputs?: unknown }).inputs;
-    const inputs = validateAgentsScalarInputs(description, bodyInputs === undefined ? {} : bodyInputs);
+    const inputs = validateAgentsInvokeInputs(description, bodyInputs === undefined ? {} : bodyInputs);
     if (!options.invokeAgent) throw new AgentsMcpError('configuration', 'Agents invoke is unavailable');
 
     dispatchedAgentId = agentId;
@@ -184,6 +214,53 @@ async function handleInvokeRequest(
   }
 }
 
+async function handleUploadRequest(
+  options: StartAgentsMcpBridgeOptions,
+  request: IncomingMessage,
+  response: ServerResponse,
+  clientId: string,
+  signal: AbortSignal
+): Promise<void> {
+  try {
+    const contentType = request.headers['content-type'];
+    if (typeof contentType !== 'string' || !contentType.toLowerCase().startsWith('multipart/form-data; boundary=')) {
+      throw new AgentsMcpError('invalid_input', 'Agents upload requires multipart form data');
+    }
+    const agentId = requireEncodedHeader(request, AGENTS_MCP_AGENT_ID_HEADER, 'Agents upload agentId', 200);
+    const fieldName = requireEncodedHeader(request, AGENTS_MCP_FIELD_NAME_HEADER, 'Agents upload field name', 200);
+    const fileName = requireEncodedHeader(request, AGENTS_MCP_FILE_NAME_HEADER, 'Agents upload file name', 1024);
+    const size = requireFileSize(request);
+    const { response: catalogResponse, sessionEpoch: catalogSessionEpoch } = await options.fetchCatalog(
+      clientId,
+      signal
+    );
+    if (catalogResponse.status === 401 || catalogResponse.status === 403) {
+      throw new AgentsMcpError('auth', 'Agents login is required');
+    }
+    if (!catalogResponse.ok) throw new AgentsMcpError('server', 'Agents catalog service is unavailable');
+    const catalog = await readBoundedJsonResponse(catalogResponse, MAX_CATALOG_RESPONSE_BYTES);
+    const { description } = normalizeAgentsCatalogSelection(catalog, agentId);
+    validateAgentsFileField(description, fieldName, fileName);
+    if (!options.uploadFile) throw new AgentsMcpError('configuration', 'Agents file upload is unavailable');
+
+    const { fileUrl, sessionEpoch } = await options.uploadFile(
+      request,
+      contentType,
+      catalogSessionEpoch,
+      clientId,
+      signal
+    );
+    if (catalogSessionEpoch !== sessionEpoch) {
+      throw new AgentsMcpError('auth', 'Agents session changed during file upload');
+    }
+    sendJson(response, 200, { fileUrl, fileName, size });
+  } catch (error) {
+    if (signal.aborted) return;
+    const safe = bridgeError(error instanceof AgentsMcpError ? error.code : 'network');
+    sendJson(response, safe.status, safe.body);
+  }
+}
+
 /** Starts the per-app loopback bridge that keeps Agents credentials inside Electron main. */
 export async function startAgentsMcpBridge(options: StartAgentsMcpBridgeOptions): Promise<AgentsMcpBridgeHandle> {
   const token = options.token?.trim() || randomBytes(32).toString('base64url');
@@ -204,6 +281,12 @@ export async function startAgentsMcpBridge(options: StartAgentsMcpBridgeOptions)
     if (request.method === 'POST' && request.url === '/invoke') {
       runActiveRequest(request, response, activeRequests, (signal) =>
         handleInvokeRequest(options, request, response, clientId, signal)
+      );
+      return;
+    }
+    if (request.method === 'POST' && request.url === '/upload') {
+      runActiveRequest(request, response, activeRequests, (signal) =>
+        handleUploadRequest(options, request, response, clientId, signal)
       );
       return;
     }

--- a/packages/desktop/src/process/ki-buddy/agents/client.ts
+++ b/packages/desktop/src/process/ki-buddy/agents/client.ts
@@ -1,5 +1,12 @@
+import { constants, openAsBlob } from 'node:fs';
+import { access, stat } from 'node:fs/promises';
+import path from 'node:path';
 import {
+  AGENTS_MCP_AGENT_ID_HEADER,
   AGENTS_MCP_CLIENT_ID_HEADER,
+  AGENTS_MCP_FIELD_NAME_HEADER,
+  AGENTS_MCP_FILE_NAME_HEADER,
+  AGENTS_MCP_FILE_SIZE_HEADER,
   isAgentsMcpClientId,
   normalizeAgentsCatalog,
   normalizeAgentsCatalogSelection,
@@ -7,7 +14,7 @@ import {
   type AgentsCatalogInventory,
   type AgentsInvokeCorrelation,
   type AgentsInvokeResult,
-  type AgentsScalarInputs,
+  type AgentsInvokeInputs,
 } from './contracts';
 import { AgentsMcpError, getAgentsMcpErrorPresentation, resolveAgentsBridgeErrorCode } from './errors';
 import { readBoundedJsonResponse } from './json';
@@ -17,14 +24,22 @@ const DEFAULT_INVOKE_TIMEOUT_MS = 310_000;
 const MAX_REQUEST_TIMEOUT_MS = 30 * 60 * 1000;
 const MAX_CATALOG_RESPONSE_BYTES = 5 * 1024 * 1024;
 const MAX_INVOKE_RESPONSE_BYTES = 5 * 1024 * 1024 + 1024;
+const MAX_UPLOAD_RESPONSE_BYTES = 64 * 1024;
 
 export const AGENTS_MCP_BRIDGE_URL_ENV = 'KI_BUDDY_AGENTS_ADAPTER_BRIDGE_URL';
 export const AGENTS_MCP_BRIDGE_TOKEN_ENV = 'KI_BUDDY_AGENTS_ADAPTER_BRIDGE_TOKEN';
 
 export type AgentsClient = Readonly<{
   describe: (agentId: string) => Promise<AgentsCatalogDescription>;
-  invoke: (agentId: string, inputs: AgentsScalarInputs) => Promise<AgentsInvokeResult>;
+  invoke: (agentId: string, inputs: AgentsInvokeInputs) => Promise<AgentsInvokeResult>;
   list: () => Promise<AgentsCatalogInventory>;
+  upload: (agentId: string, fieldName: string, filePath: string) => Promise<AgentsUploadResult>;
+}>;
+
+export type AgentsUploadResult = Readonly<{
+  fileUrl: string;
+  fileName: string;
+  size: number;
 }>;
 
 type AgentsClientOptions = Readonly<{
@@ -45,6 +60,22 @@ function normalizeInvokeCorrelation(value: unknown, expectedAgentId: string): Ag
     throw new AgentsMcpError('contract', 'Agents invoke failure correlation is incompatible');
   }
   return { agentId: expectedAgentId };
+}
+
+function normalizeUploadResult(value: unknown): AgentsUploadResult {
+  if (
+    !isRecord(value) ||
+    typeof value.fileUrl !== 'string' ||
+    value.fileUrl.trim().length === 0 ||
+    typeof value.fileName !== 'string' ||
+    value.fileName.length === 0 ||
+    typeof value.size !== 'number' ||
+    !Number.isSafeInteger(value.size) ||
+    value.size < 0
+  ) {
+    throw new AgentsMcpError('contract', 'Agents upload response is incompatible');
+  }
+  return { fileUrl: value.fileUrl, fileName: value.fileName, size: value.size };
 }
 
 function resolveBridgeUrl(rawUrl: string): string {
@@ -73,7 +104,7 @@ function normalizeTimeout(value: number, label: string): number {
   return value;
 }
 
-/** Creates the direct catalog and invoke client used by the external stdio process. */
+/** Creates the catalog, file-upload, and invoke client used by the external stdio process. */
 export function createAgentsClient(options: AgentsClientOptions): AgentsClient {
   const bridgeUrl = resolveBridgeUrl(options.bridgeUrl.trim());
   const bridgeToken = options.bridgeToken.trim();
@@ -90,7 +121,7 @@ export function createAgentsClient(options: AgentsClientOptions): AgentsClient {
   const fetchImpl = options.fetchImpl ?? fetch;
 
   const request = async (
-    path: '/catalog' | '/invoke',
+    requestPath: '/catalog' | '/invoke',
     maxResponseBytes: number,
     init: Readonly<{ body?: string; method?: 'GET' | 'POST' }> = {},
     expectedAgentId?: string,
@@ -98,7 +129,7 @@ export function createAgentsClient(options: AgentsClientOptions): AgentsClient {
   ): Promise<unknown> => {
     let response: Response;
     try {
-      response = await fetchImpl(`${bridgeUrl}${path}`, {
+      response = await fetchImpl(`${bridgeUrl}${requestPath}`, {
         method: init.method ?? 'GET',
         headers: {
           accept: 'application/json',
@@ -112,7 +143,7 @@ export function createAgentsClient(options: AgentsClientOptions): AgentsClient {
       });
     } catch (error) {
       if (error instanceof AgentsMcpError) throw error;
-      if (path === '/invoke') {
+      if (requestPath === '/invoke') {
         throw new AgentsMcpError('result_unknown', 'Agent execution result is unknown', {
           agentId: expectedAgentId ?? 'unknown',
         });
@@ -146,7 +177,10 @@ export function createAgentsClient(options: AgentsClientOptions): AgentsClient {
       const result = await request(
         '/invoke',
         MAX_INVOKE_RESPONSE_BYTES,
-        { method: 'POST', body: JSON.stringify({ agentId, inputs }) },
+        {
+          method: 'POST',
+          body: JSON.stringify({ agentId, inputs }),
+        },
         agentId,
         invokeTimeoutMs
       );
@@ -154,6 +188,57 @@ export function createAgentsClient(options: AgentsClientOptions): AgentsClient {
     },
     async list() {
       return normalizeAgentsCatalog(await fetchCatalog());
+    },
+    async upload(agentId, fieldName, filePath) {
+      if (!path.isAbsolute(filePath)) {
+        throw new AgentsMcpError('invalid_input', 'Agents upload requires an absolute local file path');
+      }
+      let fileStat;
+      try {
+        fileStat = await stat(filePath);
+      } catch {
+        throw new AgentsMcpError('invalid_input', 'The local file is not readable');
+      }
+      if (!fileStat.isFile()) throw new AgentsMcpError('invalid_input', 'Agents upload requires a regular file');
+      let fileBlob: Blob;
+      try {
+        await access(filePath, constants.R_OK);
+        fileBlob = await openAsBlob(filePath);
+      } catch {
+        throw new AgentsMcpError('invalid_input', 'The local file is not readable');
+      }
+      const fileName = path.basename(filePath);
+      const form = new FormData();
+      form.append('file', fileBlob, fileName);
+      let response: Response;
+      try {
+        response = await fetchImpl(`${bridgeUrl}/upload`, {
+          method: 'POST',
+          headers: {
+            accept: 'application/json',
+            authorization: `Bearer ${bridgeToken}`,
+            [AGENTS_MCP_AGENT_ID_HEADER]: encodeURIComponent(agentId),
+            [AGENTS_MCP_CLIENT_ID_HEADER]: clientId,
+            [AGENTS_MCP_FIELD_NAME_HEADER]: encodeURIComponent(fieldName),
+            [AGENTS_MCP_FILE_NAME_HEADER]: encodeURIComponent(fileName),
+            [AGENTS_MCP_FILE_SIZE_HEADER]: String(fileStat.size),
+          },
+          body: form,
+          redirect: 'error',
+          signal: AbortSignal.timeout(invokeTimeoutMs),
+        });
+      } catch {
+        throw new AgentsMcpError('network', 'Agents file upload is temporarily unavailable');
+      }
+      if (response.status === 401 || response.status === 403) {
+        throw new AgentsMcpError('auth', 'Agents login is required');
+      }
+      if (!response.ok) {
+        const body = await readBoundedJsonResponse(response, 1024);
+        const code = resolveAgentsBridgeErrorCode(body) ?? ('server' as const);
+        throw new AgentsMcpError(code, getAgentsMcpErrorPresentation(code).message);
+      }
+      return normalizeUploadResult(await readBoundedJsonResponse(response, MAX_UPLOAD_RESPONSE_BYTES));
     },
   };
 }

--- a/packages/desktop/src/process/ki-buddy/agents/contracts.ts
+++ b/packages/desktop/src/process/ki-buddy/agents/contracts.ts
@@ -13,6 +13,10 @@ const AGENTS_INVOKE_CONTROL_FIELDS = new Set(['apiKey', 'userId', 'flowId', 'oau
 const AGENTS_MCP_CLIENT_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 
 export const AGENTS_MCP_CLIENT_ID_HEADER = 'x-ki-buddy-agents-client-id';
+export const AGENTS_MCP_AGENT_ID_HEADER = 'x-ki-buddy-agents-agent-id';
+export const AGENTS_MCP_FIELD_NAME_HEADER = 'x-ki-buddy-agents-field-name';
+export const AGENTS_MCP_FILE_NAME_HEADER = 'x-ki-buddy-agents-file-name';
+export const AGENTS_MCP_FILE_SIZE_HEADER = 'x-ki-buddy-agents-file-size';
 
 export type AgentsCatalogSummary = Readonly<{
   agentId: string;
@@ -47,6 +51,13 @@ export type AgentsCatalogSelection = Readonly<{
 
 export type AgentsScalarInput = boolean | number | string;
 export type AgentsScalarInputs = Readonly<Record<string, AgentsScalarInput>>;
+export type AgentsInvokeInputs = AgentsScalarInputs;
+export type AgentsInvokeRequest = Readonly<{
+  agentId: string;
+  agentType: string;
+  conversationId: string;
+  inputs: AgentsInvokeInputs;
+}>;
 
 export type AgentsInvokeCorrelation = Readonly<{
   agentId: string;
@@ -198,8 +209,7 @@ function validateScalarValue(field: AgentsSchemaField, value: unknown): value is
   }
 }
 
-/** Validates one model-provided input object against the freshly fetched exact scalar schema. */
-export function validateAgentsScalarInputs(description: AgentsCatalogDescription, value: unknown): AgentsScalarInputs {
+function validateInputObject(description: AgentsCatalogDescription, value: unknown): AgentsInvokeInputs {
   if (!isRecord(value)) throw new AgentsMcpError('invalid_input', 'Agents invoke inputs must be an object');
   const schemaByName = new Map(description.inputSchema.map((field) => [field.name, field]));
   const entries = Object.entries(value);
@@ -213,6 +223,13 @@ export function validateAgentsScalarInputs(description: AgentsCatalogDescription
     if (!field || AGENTS_INVOKE_CONTROL_FIELDS.has(name)) {
       throw new AgentsMcpError('invalid_input', 'Agents invoke inputs contain a forbidden field');
     }
+    if (field.type.toLowerCase() === 'file') {
+      if (typeof input !== 'string' || input.trim().length === 0) {
+        throw new AgentsMcpError('invalid_input', 'Agents file input must be a non-empty uploaded file URL');
+      }
+      normalizedEntries.push([name, input]);
+      continue;
+    }
     if (!validateScalarValue(field, input)) {
       throw new AgentsMcpError('invalid_input', 'Agents invoke input does not match the exact scalar schema');
     }
@@ -220,12 +237,39 @@ export function validateAgentsScalarInputs(description: AgentsCatalogDescription
   }
 
   const normalized = Object.fromEntries(normalizedEntries) as Record<string, AgentsScalarInput>;
-
   for (const field of description.inputSchema) {
     const input = normalized[field.name];
     if (field.required && (input === undefined || (typeof input === 'string' && input.trim().length === 0))) {
-      throw new AgentsMcpError('invalid_input', 'Agents invoke is missing a required scalar input');
+      throw new AgentsMcpError('invalid_input', 'Agents invoke is missing a required input');
     }
   }
   return normalized;
+}
+
+/** Validates model-provided scalar values and uploaded file URLs against the current exact schema. */
+export function validateAgentsInvokeInputs(description: AgentsCatalogDescription, value: unknown): AgentsInvokeInputs {
+  return validateInputObject(description, value);
+}
+
+/** Validates one upload target and its filename metadata against an exact type=file field. */
+export function validateAgentsFileField(
+  description: AgentsCatalogDescription,
+  fieldName: string,
+  fileName: string
+): AgentsSchemaField {
+  const field = description.inputSchema.find(({ name }) => name === fieldName);
+  if (!field || AGENTS_INVOKE_CONTROL_FIELDS.has(fieldName) || field.type.toLowerCase() !== 'file') {
+    throw new AgentsMcpError('invalid_input', 'Agents upload target must be an exact file field');
+  }
+  const allowed = field.allowed_file_types;
+  if (!allowed?.length) return field;
+  const extension = fileName.includes('.') ? fileName.split('.').at(-1)?.toLowerCase() : undefined;
+  const matches = allowed.some((candidate) => {
+    const normalized = candidate.trim().toLowerCase();
+    if (!normalized) return false;
+    if (extension && (normalized === extension || normalized === `.${extension}`)) return true;
+    return false;
+  });
+  if (!matches) throw new AgentsMcpError('invalid_input', 'The attachment type is not allowed for this file field');
+  return field;
 }

--- a/packages/desktop/src/process/ki-buddy/agents/index.ts
+++ b/packages/desktop/src/process/ki-buddy/agents/index.ts
@@ -1,8 +1,7 @@
 import type { AgentsAuthService } from '../AgentsAuthService';
-import { startAgentsMcpBridge, type AgentsInvokeRequest, type AgentsMcpBridgeHandle } from './bridge';
+import { startAgentsMcpBridge, type AgentsMcpBridgeHandle } from './bridge';
 import { AGENTS_MCP_BRIDGE_TOKEN_ENV, AGENTS_MCP_BRIDGE_URL_ENV } from './client';
-import { AgentsMcpError } from './errors';
-import { AGENTS_MCP_CLIENT_ID_HEADER } from './contracts';
+import { createAgentsGatewayClient } from './networkClient';
 
 type AgentsMcpAuthService = Pick<AgentsAuthService, 'fetchAuthenticated' | 'getSessionEpoch'>;
 type StartBridge = typeof startAgentsMcpBridge;
@@ -13,47 +12,7 @@ export async function startAgentsMcpRuntimeBridge(
   env: NodeJS.ProcessEnv = process.env,
   startBridge: StartBridge = startAgentsMcpBridge
 ): Promise<AgentsMcpBridgeHandle> {
-  const handle = await startBridge({
-    fetchCatalog: async (clientId, signal) => {
-      const sessionEpoch = authService.getSessionEpoch();
-      try {
-        const response = await authService.fetchAuthenticated('/bridge/agents/catalog', {
-          method: 'GET',
-          headers: { accept: 'application/json', [AGENTS_MCP_CLIENT_ID_HEADER]: clientId },
-          signal,
-        });
-        if (authService.getSessionEpoch() !== sessionEpoch) {
-          throw new AgentsMcpError('auth', 'Agents session changed during catalog refresh');
-        }
-        return { response, sessionEpoch };
-      } catch (error) {
-        if (error instanceof AgentsMcpError) throw error;
-        throw new AgentsMcpError('network', 'Agents catalog request failed');
-      }
-    },
-    invokeAgent: async (request: AgentsInvokeRequest, sessionEpoch, clientId, signal) => {
-      if (authService.getSessionEpoch() !== sessionEpoch) {
-        throw new AgentsMcpError('auth', 'Agents session changed before invoke dispatch');
-      }
-      try {
-        return await authService.fetchAuthenticated('/bridge/agents/invoke', {
-          method: 'POST',
-          headers: {
-            accept: 'application/json',
-            'content-type': 'application/json',
-            [AGENTS_MCP_CLIENT_ID_HEADER]: clientId,
-          },
-          body: JSON.stringify(request),
-          signal,
-        });
-      } catch (error) {
-        if (error instanceof AgentsMcpError) throw error;
-        throw new AgentsMcpError('result_unknown', 'Agents invoke result is unknown', {
-          agentId: request.agentId,
-        });
-      }
-    },
-  });
+  const handle = await startBridge(createAgentsGatewayClient(authService));
 
   env[AGENTS_MCP_BRIDGE_URL_ENV] = handle.url;
   env[AGENTS_MCP_BRIDGE_TOKEN_ENV] = handle.token;

--- a/packages/desktop/src/process/ki-buddy/agents/mcpServer.ts
+++ b/packages/desktop/src/process/ki-buddy/agents/mcpServer.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { AgentsClient } from './client';
+import type { AgentsInvokeInputs } from './contracts';
 import { getAgentsMcpErrorPresentation, AgentsMcpError } from './errors';
 
 /** Stable model-facing MCP metadata; the renderer resolves localized product presentation separately. */
@@ -9,7 +10,9 @@ const AGENTS_LIST_PROTOCOL_DESCRIPTION =
 const AGENTS_DESCRIBE_PROTOCOL_DESCRIPTION =
   'Describe the exact input and output schema for one agentId from the current safe catalog. Use agents_list first and do not infer an agentId.';
 const AGENTS_INVOKE_PROTOCOL_DESCRIPTION =
-  'Direct invoke one current agentId with complete scalar inputs. The Adapter refreshes the current catalog and exact schema before dispatch.';
+  'Direct invoke one current agentId with complete inputs. File fields must use fileUrl values returned by agents_upload_file. The Adapter refreshes the current catalog and exact schema before dispatch.';
+const AGENTS_UPLOAD_PROTOCOL_DESCRIPTION =
+  'Upload one local regular file by absolute path for one exact type=file input field and return the remote Agents fileUrl.';
 
 const textResult = (value: unknown, isError = false) => ({
   content: [{ type: 'text' as const, text: JSON.stringify(value) }],
@@ -34,7 +37,7 @@ async function executeAgentsTool<T>(operation: () => Promise<T>) {
 
 /** Creates the catalog discovery and one-agent direct invoke surface for the Agents Adapter. */
 export function createAgentsMcpServer(client: AgentsClient): McpServer {
-  const server = new McpServer({ name: 'ki-buddy-agents-mcp-adapter', version: '0.3.0' });
+  const server = new McpServer({ name: 'ki-buddy-agents-mcp-adapter', version: '0.4.0' });
   server.registerTool(
     'agents_list',
     {
@@ -64,6 +67,24 @@ export function createAgentsMcpServer(client: AgentsClient): McpServer {
     ({ agentId }) => executeAgentsTool(() => client.describe(agentId))
   );
   server.registerTool(
+    'agents_upload_file',
+    {
+      description: AGENTS_UPLOAD_PROTOCOL_DESCRIPTION,
+      inputSchema: {
+        agentId: z.string().trim().min(1).max(200),
+        fieldName: z.string().trim().min(1).max(200),
+        filePath: z.string().min(1).max(32_768),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    ({ agentId, fieldName, filePath }) => executeAgentsTool(() => client.upload(agentId, fieldName, filePath))
+  );
+  server.registerTool(
     'agents_invoke',
     {
       description: AGENTS_INVOKE_PROTOCOL_DESCRIPTION,
@@ -80,7 +101,7 @@ export function createAgentsMcpServer(client: AgentsClient): McpServer {
         openWorldHint: true,
       },
     },
-    ({ agentId, inputs }) => executeAgentsTool(() => client.invoke(agentId, inputs))
+    ({ agentId, inputs }) => executeAgentsTool(() => client.invoke(agentId, inputs as AgentsInvokeInputs))
   );
   return server;
 }

--- a/packages/desktop/src/process/ki-buddy/agents/networkClient.ts
+++ b/packages/desktop/src/process/ki-buddy/agents/networkClient.ts
@@ -1,11 +1,39 @@
+import type { IncomingMessage } from 'node:http';
 import { isIP } from 'node:net';
+import { Readable } from 'node:stream';
 import { session } from 'electron';
-import { AGENTS_MCP_CLIENT_ID_HEADER, isAgentsMcpClientId } from './contracts';
+import { AGENTS_MCP_CLIENT_ID_HEADER, isAgentsMcpClientId, type AgentsInvokeRequest } from './contracts';
+import { AgentsMcpError } from './errors';
+import { readBoundedJsonResponse } from './json';
 
 const AGENTS_NETWORK_PARTITION = 'ki-buddy-agents-network';
 const ALLOWED_SELF_SIGNED_ERRORS = new Set(['CERT_AUTHORITY_INVALID', 'CERT_COMMON_NAME_INVALID']);
 const SERVER_NEXT_GATEWAY_API_PREFIX = '/kagents_core/api';
 const AGENTS_BRIDGE_PATH_PREFIX = '/bridge/agents/';
+const MAX_UPLOAD_RESPONSE_BYTES = 64 * 1024;
+
+type AgentsGatewayTransport = Readonly<{
+  fetchAuthenticated: (path: string, init?: RequestInit) => Promise<Response>;
+  getSessionEpoch: () => number;
+}>;
+
+type StreamingRequestInit = RequestInit & Readonly<{ duplex: 'half' }>;
+
+function normalizeAgentsUploadResponse(value: unknown): string {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new AgentsMcpError('contract', 'Agents upload response is incompatible');
+  }
+  const envelope = value as { errorCode?: unknown; responseBody?: unknown };
+  if (envelope.errorCode !== 0) throw new AgentsMcpError('server', 'Agents file upload failed');
+  if (!envelope.responseBody || typeof envelope.responseBody !== 'object' || Array.isArray(envelope.responseBody)) {
+    throw new AgentsMcpError('contract', 'Agents upload response is incompatible');
+  }
+  const fileUrl = (envelope.responseBody as { fileUrl?: unknown }).fileUrl;
+  if (typeof fileUrl !== 'string' || fileUrl.trim().length === 0) {
+    throw new AgentsMcpError('contract', 'Agents upload response is incompatible');
+  }
+  return fileUrl;
+}
 
 function isAgentsBridgePath(path: string): boolean {
   try {
@@ -21,6 +49,91 @@ export function resolveAgentsRequestUrl(baseUrl: string, path: string): string {
     return `${new URL(baseUrl).origin}${SERVER_NEXT_GATEWAY_API_PREFIX}${path}`;
   }
   return `${baseUrl}${path}`;
+}
+
+/** Creates the authenticated product client for the remote Agents gateway contract. */
+export function createAgentsGatewayClient(transport: AgentsGatewayTransport) {
+  return {
+    fetchCatalog: async (clientId: string, signal: AbortSignal) => {
+      const sessionEpoch = transport.getSessionEpoch();
+      try {
+        const response = await transport.fetchAuthenticated('/bridge/agents/catalog', {
+          method: 'GET',
+          headers: { accept: 'application/json', [AGENTS_MCP_CLIENT_ID_HEADER]: clientId },
+          signal,
+        });
+        if (transport.getSessionEpoch() !== sessionEpoch) {
+          throw new AgentsMcpError('auth', 'Agents session changed during catalog refresh');
+        }
+        return { response, sessionEpoch };
+      } catch (error) {
+        if (error instanceof AgentsMcpError) throw error;
+        throw new AgentsMcpError('network', 'Agents catalog request failed');
+      }
+    },
+    invokeAgent: async (request: AgentsInvokeRequest, sessionEpoch: number, clientId: string, signal: AbortSignal) => {
+      if (transport.getSessionEpoch() !== sessionEpoch) {
+        throw new AgentsMcpError('auth', 'Agents session changed before invoke dispatch');
+      }
+      try {
+        return await transport.fetchAuthenticated('/bridge/agents/invoke', {
+          method: 'POST',
+          headers: {
+            accept: 'application/json',
+            'content-type': 'application/json',
+            [AGENTS_MCP_CLIENT_ID_HEADER]: clientId,
+          },
+          body: JSON.stringify(request),
+          signal,
+        });
+      } catch (error) {
+        if (error instanceof AgentsMcpError) throw error;
+        throw new AgentsMcpError('result_unknown', 'Agents invoke result is unknown', {
+          agentId: request.agentId,
+        });
+      }
+    },
+    uploadFile: async (
+      body: IncomingMessage,
+      contentType: string,
+      sessionEpoch: number,
+      clientId: string,
+      signal: AbortSignal
+    ) => {
+      if (transport.getSessionEpoch() !== sessionEpoch) {
+        throw new AgentsMcpError('auth', 'Agents session changed before file upload dispatch');
+      }
+      try {
+        const init: StreamingRequestInit = {
+          method: 'POST',
+          headers: {
+            accept: 'application/json',
+            'content-type': contentType,
+            [AGENTS_MCP_CLIENT_ID_HEADER]: clientId,
+          },
+          body: Readable.toWeb(body) as unknown as BodyInit,
+          duplex: 'half',
+          signal,
+        };
+        const response = await transport.fetchAuthenticated('/kagent/sys/file/upload', init);
+        if (transport.getSessionEpoch() !== sessionEpoch) {
+          throw new AgentsMcpError('auth', 'Agents session changed during file upload');
+        }
+        if (response.status === 401 || response.status === 403) {
+          throw new AgentsMcpError('auth', 'Agents login is required');
+        }
+        if (!response.ok) throw new AgentsMcpError('server', 'Agents file upload failed');
+        const payload = await readBoundedJsonResponse(response, MAX_UPLOAD_RESPONSE_BYTES);
+        return { fileUrl: normalizeAgentsUploadResponse(payload), sessionEpoch };
+      } catch (error) {
+        if (transport.getSessionEpoch() !== sessionEpoch) {
+          throw new AgentsMcpError('auth', 'Agents session changed during file upload');
+        }
+        if (error instanceof AgentsMcpError) throw error;
+        throw new AgentsMcpError('network', 'Agents file upload request failed');
+      }
+    },
+  };
 }
 
 function isPrivateIpv4(hostname: string): boolean {
@@ -62,9 +175,9 @@ function canTrustPrivateSelfSignedCertificate(request: Electron.Request): boolea
   );
 }
 
-/** Creates the isolated Chromium-network client used only for Agents authentication requests. */
+/** Creates the isolated Chromium-network transport used for authenticated Agents requests. */
 export function createAgentsNetworkFetch(): typeof fetch {
-  const agentsSessions = new Map<'catalog' | 'invoke', Electron.Session>();
+  const agentsSessions = new Map<'catalog' | 'invoke' | 'upload', Electron.Session>();
   return ((input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
     const requestUrl = input instanceof Request ? input.url : input instanceof URL ? input.toString() : String(input);
     const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined));
@@ -73,7 +186,12 @@ export function createAgentsNetworkFetch(): typeof fetch {
       throw new Error('Agents network client identity is invalid');
     }
     headers.delete(AGENTS_MCP_CLIENT_ID_HEADER);
-    const requestKind = new URL(requestUrl).pathname.endsWith('/bridge/agents/invoke') ? 'invoke' : 'catalog';
+    const pathname = new URL(requestUrl).pathname;
+    const requestKind = pathname.endsWith('/bridge/agents/invoke')
+      ? 'invoke'
+      : pathname.endsWith('/kagent/sys/file/upload')
+        ? 'upload'
+        : 'catalog';
     let agentsSession = agentsSessions.get(requestKind);
     if (!agentsSession) {
       agentsSession = session.fromPartition(`${AGENTS_NETWORK_PARTITION}-${requestKind}`, { cache: false });

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1903,6 +1903,7 @@ export type I18nKey =
   | 'settings.kiBuddy.agentsDescribeDescription'
   | 'settings.kiBuddy.agentsInvokeDescription'
   | 'settings.kiBuddy.agentsListDescription'
+  | 'settings.kiBuddy.agentsUploadDescription'
   | 'settings.language'
   | 'settings.lark.agent'
   | 'settings.lark.agentDesc'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
@@ -775,7 +775,8 @@
   "kiBuddy": {
     "agentsDescribeDescription": "Zeigt das genaue Ein- und Ausgabeschema eines Agent im aktuellen Katalog an.",
     "agentsInvokeDescription": "Ruft den beschriebenen Agent nach Aktualisierung von Berechtigung und Schema einmal mit vollständigen Skalarwerten auf.",
-    "agentsListDescription": "Listet den vollständigen Agents-Katalog auf, der für das aktuell angemeldete Konto verfügbar ist."
+    "agentsListDescription": "Listet den vollständigen Agents-Katalog auf, der für das aktuell angemeldete Konto verfügbar ist.",
+    "agentsUploadDescription": "Lädt eine lokale Datei für ein bestimmtes Datei-Eingabefeld hoch und gibt deren Agents-Datei-URL zurück."
   },
   "mcpAuthRequired": "Authentifizierung erforderlich",
   "mcpOAuthLoginSuccess": "OAuth-Anmeldung erfolgreich",

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
@@ -783,7 +783,8 @@
   "kiBuddy": {
     "agentsDescribeDescription": "Shows the exact input and output schema for one agent in the current catalog.",
     "agentsInvokeDescription": "Invokes the described Agent once with complete scalar inputs after refreshing its permission and schema.",
-    "agentsListDescription": "Lists the complete Agents catalog available to the current signed-in account."
+    "agentsListDescription": "Lists the complete Agents catalog available to the current signed-in account.",
+    "agentsUploadDescription": "Uploads one local file for a specified file input field and returns its Agents file URL."
   },
   "mcpAuthRequired": "Authentication required",
   "mcpOAuthLoginSuccess": "OAuth login successful",

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
@@ -773,7 +773,8 @@
   "kiBuddy": {
     "agentsDescribeDescription": "Muestra el esquema exacto de entrada y salida de un Agent del catálogo actual.",
     "agentsInvokeDescription": "Invoca una vez el Agent descrito con entradas escalares completas después de actualizar sus permisos y esquema.",
-    "agentsListDescription": "Muestra el catálogo completo de Agents disponible para la cuenta que ha iniciado sesión."
+    "agentsListDescription": "Muestra el catálogo completo de Agents disponible para la cuenta que ha iniciado sesión.",
+    "agentsUploadDescription": "Sube un archivo local para un campo de entrada de archivo específico y devuelve su URL de archivo en Agents."
   },
   "mcpAuthRequired": "Autenticación requerida",
   "mcpOAuthLoginSuccess": "Inicio de sesión OAuth exitoso",

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
@@ -783,7 +783,8 @@
   "kiBuddy": {
     "agentsDescribeDescription": "طرح‌وارهٔ دقیق ورودی و خروجی یک Agent در فهرست فعلی را نمایش می‌دهد.",
     "agentsInvokeDescription": "پس از به‌روزرسانی مجوز و طرح‌واره، Agent توضیح‌داده‌شده را یک‌بار با ورودی‌های اسکالر کامل فراخوانی می‌کند.",
-    "agentsListDescription": "فهرست کامل Agents در دسترس حساب واردشده فعلی را نمایش می‌دهد."
+    "agentsListDescription": "فهرست کامل Agents در دسترس حساب واردشده فعلی را نمایش می‌دهد.",
+    "agentsUploadDescription": "یک فایل محلی را برای فیلد ورودی فایل مشخص بارگذاری می‌کند و نشانی URL فایل آن را در Agents برمی‌گرداند."
   },
   "mcpAuthRequired": "احراز هویت لازم است",
   "mcpOAuthLoginSuccess": "ورود OAuth موفق بود",

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
@@ -783,7 +783,8 @@
   "kiBuddy": {
     "agentsDescribeDescription": "Affiche le schéma exact des entrées et sorties d’un Agent du catalogue actuel.",
     "agentsInvokeDescription": "Appelle une fois l’Agent décrit avec des entrées scalaires complètes après actualisation de ses droits et de son schéma.",
-    "agentsListDescription": "Répertorie le catalogue Agents complet disponible pour le compte actuellement connecté."
+    "agentsListDescription": "Répertorie le catalogue Agents complet disponible pour le compte actuellement connecté.",
+    "agentsUploadDescription": "Téléverse un fichier local pour un champ d’entrée de fichier précis et renvoie son URL de fichier Agents."
   },
   "mcpAuthRequired": "Authentification requise",
   "mcpOAuthLoginSuccess": "Connexion OAuth réussie",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -771,7 +771,8 @@
   "kiBuddy": {
     "agentsDescribeDescription": "現在のカタログ内の1つの Agent について、正確な入力と出力のスキーマを表示します。",
     "agentsInvokeDescription": "権限と入力スキーマを更新した後、完全なスカラー入力で説明済みの Agent を1回呼び出します。",
-    "agentsListDescription": "現在サインインしているアカウントで利用可能な完全な Agents カタログを一覧表示します。"
+    "agentsListDescription": "現在サインインしているアカウントで利用可能な完全な Agents カタログを一覧表示します。",
+    "agentsUploadDescription": "指定したファイル入力フィールド用にローカルファイルを1つアップロードし、その Agents ファイル URL を返します。"
   },
   "mcpAuthRequired": "認証が必要です",
   "mcpOAuthLoginSuccess": "OAuth ログイン成功",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -771,7 +771,8 @@
   "kiBuddy": {
     "agentsDescribeDescription": "현재 카탈로그에 있는 Agent 하나의 정확한 입력 및 출력 스키마를 표시합니다.",
     "agentsInvokeDescription": "권한과 입력 스키마를 새로 확인한 후 완전한 스칼라 입력으로 설명된 Agent를 한 번 호출합니다.",
-    "agentsListDescription": "현재 로그인한 계정에서 사용할 수 있는 전체 Agents 카탈로그를 표시합니다."
+    "agentsListDescription": "현재 로그인한 계정에서 사용할 수 있는 전체 Agents 카탈로그를 표시합니다.",
+    "agentsUploadDescription": "지정된 파일 입력 필드에 로컬 파일 하나를 업로드하고 해당 Agents 파일 URL을 반환합니다."
   },
   "mcpAuthRequired": "인증 필요",
   "mcpOAuthLoginSuccess": "OAuth 로그인 성공",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
@@ -783,7 +783,8 @@
   "kiBuddy": {
     "agentsDescribeDescription": "Mostra o esquema exato de entrada e saída de um Agent no catálogo atual.",
     "agentsInvokeDescription": "Invoca uma vez o Agent descrito com entradas escalares completas após atualizar a permissão e o esquema.",
-    "agentsListDescription": "Lista o catálogo completo de Agents disponível para a conta conectada."
+    "agentsListDescription": "Lista o catálogo completo de Agents disponível para a conta conectada.",
+    "agentsUploadDescription": "Envia um arquivo local para um campo de entrada de arquivo específico e retorna a URL do arquivo no Agents."
   },
   "mcpAuthRequired": "Autenticação obrigatória",
   "mcpOAuthLoginSuccess": "Login OAuth bem-sucedido",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -763,7 +763,8 @@
   "kiBuddy": {
     "agentsDescribeDescription": "Показывает точную схему входных и выходных данных одного Agent из текущего каталога.",
     "agentsInvokeDescription": "Однократно вызывает описанный Agent с полным набором скалярных входных данных после обновления прав и схемы.",
-    "agentsListDescription": "Показывает полный каталог Agents, доступный текущей учётной записи."
+    "agentsListDescription": "Показывает полный каталог Agents, доступный текущей учётной записи.",
+    "agentsUploadDescription": "Загружает один локальный файл для указанного файлового поля ввода и возвращает URL файла в Agents."
   },
   "mcpAuthRequired": "Требуется аутентификация",
   "mcpOAuthLoginSuccess": "OAuth-вход успешен",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -771,7 +771,8 @@
   "kiBuddy": {
     "agentsDescribeDescription": "Geçerli katalogdaki bir Agent için tam giriş ve çıkış şemasını gösterir.",
     "agentsInvokeDescription": "İzin ve giriş şeması yenilendikten sonra açıklanan Agent’ı eksiksiz skaler girişlerle bir kez çağırır.",
-    "agentsListDescription": "Geçerli oturum açmış hesabın kullanabildiği eksiksiz Agents kataloğunu listeler."
+    "agentsListDescription": "Geçerli oturum açmış hesabın kullanabildiği eksiksiz Agents kataloğunu listeler.",
+    "agentsUploadDescription": "Belirtilen dosya giriş alanı için bir yerel dosya yükler ve Agents dosya URL'sini döndürür."
   },
   "mcpAuthRequired": "Kimlik doğrulama gerekli",
   "mcpOAuthLoginSuccess": "OAuth girişi başarılı",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -769,7 +769,8 @@
   "kiBuddy": {
     "agentsDescribeDescription": "Показує точну схему вхідних і вихідних даних одного Agent з поточного каталогу.",
     "agentsInvokeDescription": "Одноразово викликає описаний Agent із повним набором скалярних вхідних даних після оновлення прав і схеми.",
-    "agentsListDescription": "Показує повний каталог Agents, доступний поточному обліковому запису."
+    "agentsListDescription": "Показує повний каталог Agents, доступний поточному обліковому запису.",
+    "agentsUploadDescription": "Завантажує один локальний файл для вказаного файлового поля вводу та повертає URL файлу в Agents."
   },
   "mcpAuthRequired": "Потрібна автентифікація",
   "mcpOAuthLoginSuccess": "OAuth-вхід успішний",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -783,7 +783,8 @@
   "kiBuddy": {
     "agentsDescribeDescription": "显示当前目录中一个 Agent 的精确输入和输出结构。",
     "agentsInvokeDescription": "刷新权限和输入结构后，使用完整的标量参数调用一次已描述的 Agent。",
-    "agentsListDescription": "列出当前登录账号可用的完整 Agents 目录。"
+    "agentsListDescription": "列出当前登录账号可用的完整 Agents 目录。",
+    "agentsUploadDescription": "为指定的文件输入字段上传一个本地文件，并返回其 Agents 文件 URL。"
   },
   "mcpAuthRequired": "需要身份验证",
   "mcpOAuthLoginSuccess": "OAuth 登录成功",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -783,7 +783,8 @@
   "kiBuddy": {
     "agentsDescribeDescription": "顯示目前目錄中一個 Agent 的精確輸入與輸出結構。",
     "agentsInvokeDescription": "重新整理權限與輸入結構後，以完整的純量參數呼叫一次已描述的 Agent。",
-    "agentsListDescription": "列出目前登入帳號可用的完整 Agents 目錄。"
+    "agentsListDescription": "列出目前登入帳號可用的完整 Agents 目錄。",
+    "agentsUploadDescription": "為指定的檔案輸入欄位上傳一個本機檔案，並傳回其 Agents 檔案 URL。"
   },
   "mcpAuthRequired": "需要身份驗證",
   "mcpOAuthLoginSuccess": "OAuth 登入成功",

--- a/packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyResourceRegistry.ts
+++ b/packages/desktop/src/renderer/services/runtime/catalogs/kiBuddyResourceRegistry.ts
@@ -43,6 +43,10 @@ const AGENTS_MCP_ADAPTER = {
       name: 'agents_list',
       descriptionKey: 'settings.kiBuddy.agentsListDescription',
     },
+    upload: {
+      name: 'agents_upload_file',
+      descriptionKey: 'settings.kiBuddy.agentsUploadDescription',
+    },
   },
 } as const satisfies ProductMcpResourceDefinition;
 
@@ -168,6 +172,7 @@ export function resolveKiBuddyMcpToolDescriptionKey(
   | 'settings.kiBuddy.agentsDescribeDescription'
   | 'settings.kiBuddy.agentsInvokeDescription'
   | 'settings.kiBuddy.agentsListDescription'
+  | 'settings.kiBuddy.agentsUploadDescription'
   | null {
   const definition = KI_BUDDY_PRODUCT_RESOURCE_REGISTRY.mcp.agentsAdapter;
   if (origin !== 'productBuiltin' || resolveKiBuddyProductMcpResourceId(server) !== definition.id) return null;

--- a/scripts/build-mcp-servers.js
+++ b/scripts/build-mcp-servers.js
@@ -25,22 +25,29 @@ const SHARED_OPTIONS = {
   loader: { '.wasm': 'empty' },
 };
 
+function resolveOutputDirectory(args) {
+  if (args.length === 0) return path.join(ROOT, 'out/main');
+  if (args.length === 2 && args[0] === '--out-dir' && args[1]) return path.resolve(args[1]);
+  throw new Error('Usage: node scripts/build-mcp-servers.js [--out-dir <path>]');
+}
+
 async function main() {
+  const outputDirectory = resolveOutputDirectory(process.argv.slice(2));
   await Promise.all([
     esbuild.build({
       ...SHARED_OPTIONS,
       entryPoints: [path.join(ROOT, 'packages/desktop/src/process/resources/builtinMcp/imageGenServer.ts')],
-      outfile: path.join(ROOT, 'out/main/builtin-mcp-image-gen.js'),
+      outfile: path.join(outputDirectory, 'builtin-mcp-image-gen.js'),
     }),
     esbuild.build({
       ...SHARED_OPTIONS,
       entryPoints: [path.join(ROOT, 'packages/desktop/src/process/resources/builtinMcp/browserServer.ts')],
-      outfile: path.join(ROOT, 'out/main/builtin-mcp-browser.js'),
+      outfile: path.join(outputDirectory, 'builtin-mcp-browser.js'),
     }),
     esbuild.build({
       ...SHARED_OPTIONS,
       entryPoints: [path.join(ROOT, 'packages/desktop/src/process/ki-buddy/agents/server.ts')],
-      outfile: path.join(ROOT, 'out/main/builtin-mcp-agents.js'),
+      outfile: path.join(outputDirectory, 'builtin-mcp-agents.js'),
     }),
   ]);
 }

--- a/tests/fixtures/ki-buddy/agents/catalog.json
+++ b/tests/fixtures/ki-buddy/agents/catalog.json
@@ -13,7 +13,7 @@
           "description": "脱敏后的反馈文件",
           "type": "file",
           "required": true,
-          "allowed_file_types": ["text/plain"]
+          "allowed_file_types": ["txt"]
         }
       ],
       "defaultOutputModes": [

--- a/tests/integration/kiBuddyAgentsMcpStdio.test.ts
+++ b/tests/integration/kiBuddyAgentsMcpStdio.test.ts
@@ -1,25 +1,29 @@
 import { execFileSync, spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { once } from 'node:events';
 import { existsSync } from 'node:fs';
-import { createServer } from 'node:http';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer, type IncomingMessage } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import os from 'node:os';
 import path from 'node:path';
 import { createInterface } from 'node:readline';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { startAgentsMcpRuntimeBridge } from '@/process/ki-buddy/agents';
 import { startAgentsMcpBridge, type AgentsMcpBridgeHandle } from '@/process/ki-buddy/agents/bridge';
 import { createAgentsClient, type AgentsClient } from '@/process/ki-buddy/agents/client';
 import { AgentsMcpError } from '@/process/ki-buddy/agents/errors';
 
 const projectRoot = path.resolve(__dirname, '../..');
-const adapterScript = path.join(projectRoot, 'out/main/builtin-mcp-agents.js');
+let adapterBundleDirectory: string | undefined;
+let adapterScript = '';
 const bridges: AgentsMcpBridgeHandle[] = [];
 const clients: Client[] = [];
 const childProcesses: ChildProcess[] = [];
 const externalProcessIds = new Set<number>();
-const fakeGateways: Array<Readonly<{ close: () => Promise<void> }>> = [];
+const fakeServers: Array<Readonly<{ close: () => Promise<void> }>> = [];
+const tempDirectories = new Set<string>();
 const adapterEnvironment = {
   KI_BUDDY_AGENTS_ADAPTER_BRIDGE_URL: 'http://127.0.0.1:43123',
   KI_BUDDY_AGENTS_ADAPTER_BRIDGE_TOKEN: 'process-exit-secret',
@@ -47,6 +51,28 @@ const fakeCatalog = {
       agentType: 'workflow',
       defaultInputModes: [{ name: 'query', description: 'Feedback text', type: 'text', required: true }],
       defaultOutputModes: [{ name: 'summary', description: 'Summary', type: 'text', required: true }],
+    },
+  ],
+};
+
+const fileAgentCatalog = {
+  status: 'ok',
+  total: 1,
+  agents: [
+    {
+      agentId: 'agent-file',
+      agentTitle: 'File agent',
+      agentType: 'workflow',
+      defaultInputModes: [
+        {
+          name: 'source',
+          description: 'Source file',
+          type: 'file',
+          required: true,
+          allowed_file_types: ['txt'],
+        },
+      ],
+      defaultOutputModes: [],
     },
   ],
 };
@@ -137,8 +163,14 @@ async function startFakeCatalogGateway(initialCatalog: unknown = fakeCatalog): P
         server.close((error) => (error ? reject(error) : resolve()));
       }),
   };
-  fakeGateways.push(gateway);
+  fakeServers.push(gateway);
   return gateway;
+}
+
+async function createTrackedTempDirectory(prefix: string): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirectories.add(directory);
+  return directory;
 }
 
 async function startGatewayBackedBridge(binding: MutableSessionBinding): Promise<AgentsMcpBridgeHandle> {
@@ -166,7 +198,8 @@ async function createGatewayBackedClient(binding: MutableSessionBinding): Promis
 
 async function connectStdioAdapter(
   name: string,
-  bridge: AgentsMcpBridgeHandle
+  bridge: AgentsMcpBridgeHandle,
+  env: Readonly<Record<string, string>> = {}
 ): Promise<Readonly<{ client: Client; processId: number | null }>> {
   const transport = new StdioClientTransport({
     command: process.execPath,
@@ -174,6 +207,7 @@ async function connectStdioAdapter(
     env: {
       KI_BUDDY_AGENTS_ADAPTER_BRIDGE_TOKEN: bridge.token,
       KI_BUDDY_AGENTS_ADAPTER_BRIDGE_URL: bridge.url,
+      ...env,
     },
     stderr: 'pipe',
   });
@@ -271,17 +305,32 @@ async function waitForProcessIdExit(processId: number): Promise<void> {
   throw new Error(`Agents MCP Adapter process ${processId} did not exit after its parent ended`);
 }
 
-beforeAll(() => {
-  execFileSync(process.execPath, [path.join(projectRoot, 'scripts/build-mcp-servers.js')], {
-    cwd: projectRoot,
-    stdio: 'pipe',
-  });
+beforeAll(async () => {
+  adapterBundleDirectory = await mkdtemp(path.join(os.tmpdir(), 'ki-buddy-agents-mcp-bundle-'));
+  adapterScript = path.join(adapterBundleDirectory, 'builtin-mcp-agents.js');
+  execFileSync(
+    process.execPath,
+    [path.join(projectRoot, 'scripts/build-mcp-servers.js'), '--out-dir', adapterBundleDirectory],
+    {
+      cwd: projectRoot,
+      stdio: 'pipe',
+    }
+  );
+});
+
+afterAll(async () => {
+  if (!adapterBundleDirectory) return;
+  await rm(adapterBundleDirectory, { recursive: true, force: true });
+  adapterBundleDirectory = undefined;
+  adapterScript = '';
 });
 
 afterEach(async () => {
   await Promise.allSettled(clients.splice(0).map((client) => client.close()));
   await Promise.allSettled(bridges.splice(0).map((bridge) => bridge.close()));
-  await Promise.allSettled(fakeGateways.splice(0).map((gateway) => gateway.close()));
+  await Promise.allSettled(fakeServers.splice(0).map((server) => server.close()));
+  await Promise.allSettled([...tempDirectories].map((directory) => rm(directory, { recursive: true, force: true })));
+  tempDirectories.clear();
   await Promise.all(
     childProcesses.splice(0).map(async (child) => {
       if (child.exitCode !== null || child.signalCode !== null) return;
@@ -307,6 +356,125 @@ afterEach(async () => {
 });
 
 describe('packaged Agents MCP Adapter stdio process', () => {
+  it('uploads a local file path and invokes with the remote file URL', async () => {
+    const directory = await createTrackedTempDirectory('ki-buddy-agents-stdio-upload-');
+    const filePath = path.join(directory, 'feedback.txt');
+    await writeFile(filePath, 'stdio upload canary');
+    const invokeAgent = vi.fn().mockResolvedValue(Response.json({ state: 'completed' }));
+    const bridge = await startAgentsMcpBridge({
+      fetchCatalog: vi.fn().mockImplementation(async () => ({
+        response: Response.json(fileAgentCatalog),
+        sessionEpoch: 1,
+      })),
+      uploadFile: vi.fn().mockImplementation(async (body) => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of body) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        expect(Buffer.concat(chunks).toString('utf8')).toContain('stdio upload canary');
+        return {
+          fileUrl: 'https://agents.example.test/files/remote-stdio',
+          sessionEpoch: 1,
+        };
+      }),
+      invokeAgent,
+      token: 'bridge-secret-stdio-upload',
+    });
+    bridges.push(bridge);
+
+    const { client } = await connectStdioAdapter('ki-buddy-agents-file-upload', bridge);
+    const uploadResult = await client.callTool({
+      name: 'agents_upload_file',
+      arguments: { agentId: 'agent-file', fieldName: 'source', filePath },
+    });
+    expect(uploadResult.isError).not.toBe(true);
+    const uploadText = (uploadResult.content[0] as { text: string }).text;
+    const { fileUrl } = JSON.parse(uploadText) as { fileUrl: string };
+
+    const invokeResult = await client.callTool({
+      name: 'agents_invoke',
+      arguments: { agentId: 'agent-file', inputs: { source: fileUrl } },
+    });
+
+    expect(invokeResult.isError).not.toBe(true);
+    expect(invokeAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputs: { source: 'https://agents.example.test/files/remote-stdio' },
+      }),
+      1,
+      expect.any(String),
+      expect.any(AbortSignal)
+    );
+  });
+
+  it.each([
+    ['remote upload failure', 'server'],
+    ['expired upload authentication', 'auth'],
+  ] as const)('stops before invoke after %s', async (_scenario, expectedCode) => {
+    const directory = await createTrackedTempDirectory('ki-buddy-agents-stdio-upload-failure-');
+    const filePath = path.join(directory, 'feedback.txt');
+    await writeFile(filePath, 'stdio upload failure canary');
+    const invokeAgent = vi.fn();
+    const uploadFile = vi.fn(async (body: IncomingMessage) => {
+      for await (const _chunk of body) {
+        // Consume the multipart stream before returning the simulated remote response.
+      }
+      throw new AgentsMcpError(expectedCode, 'sensitive upstream detail');
+    });
+    const bridge = await startAgentsMcpBridge({
+      fetchCatalog: vi.fn().mockResolvedValue({ response: Response.json(fileAgentCatalog), sessionEpoch: 1 }),
+      uploadFile,
+      invokeAgent,
+      token: `bridge-secret-stdio-upload-${expectedCode}`,
+    });
+    bridges.push(bridge);
+    const { client } = await connectStdioAdapter(`ki-buddy-agents-file-upload-${expectedCode}`, bridge);
+
+    const result = await client.callTool({
+      name: 'agents_upload_file',
+      arguments: { agentId: 'agent-file', fieldName: 'source', filePath },
+    });
+    const payload = JSON.parse((result.content[0] as { text: string }).text) as { error?: { code?: string } };
+
+    expect({
+      errorCode: payload.error?.code,
+      invokeCalls: invokeAgent.mock.calls.length,
+      isError: result.isError,
+      uploadCalls: uploadFile.mock.calls.length,
+    }).toEqual({ errorCode: expectedCode, invokeCalls: 0, isError: true, uploadCalls: 1 });
+  });
+
+  it('does not dispatch an upload after the authenticated session changes following catalog validation', async () => {
+    const directory = await createTrackedTempDirectory('ki-buddy-agents-stdio-session-change-');
+    const filePath = path.join(directory, 'feedback.txt');
+    await writeFile(filePath, 'stdio session change canary');
+    let epochReads = 0;
+    const fetchAuthenticated = vi.fn(async (requestPath: string) => {
+      if (requestPath !== '/bridge/agents/catalog') throw new Error('Upload must not be dispatched');
+      return Response.json(fileAgentCatalog);
+    });
+    const authService: RuntimeAuthService = {
+      fetchAuthenticated,
+      getSessionEpoch: () => {
+        epochReads += 1;
+        return epochReads <= 2 ? 1 : 2;
+      },
+    };
+    const bridge = await startAgentsMcpRuntimeBridge(authService, {});
+    bridges.push(bridge);
+    const { client } = await connectStdioAdapter('ki-buddy-agents-file-upload-session-change', bridge);
+
+    const result = await client.callTool({
+      name: 'agents_upload_file',
+      arguments: { agentId: 'agent-file', fieldName: 'source', filePath },
+    });
+    const payload = JSON.parse((result.content[0] as { text: string }).text) as { error?: { code?: string } };
+
+    expect({
+      errorCode: payload.error?.code,
+      isError: result.isError,
+      remoteCalls: fetchAuthenticated.mock.calls.length,
+    }).toEqual({ errorCode: 'auth', isError: true, remoteCalls: 1 });
+  });
+
   it('keeps distinct direct Adapter clients isolated while one invoke is pending', async () => {
     let finishInvoke: ((response: Response) => void) | undefined;
     let invokeClientId = '';
@@ -676,7 +844,12 @@ describe('packaged Agents MCP Adapter stdio process', () => {
     });
 
     expect(existsSync(adapterScript)).toBe(true);
-    expect(tools.tools.map(({ name }) => name)).toEqual(['agents_list', 'agents_describe', 'agents_invoke']);
+    expect(tools.tools.map(({ name }) => name)).toEqual([
+      'agents_list',
+      'agents_describe',
+      'agents_upload_file',
+      'agents_invoke',
+    ]);
     expect(result.content).toEqual([
       {
         type: 'text',

--- a/tests/unit/process/ki-buddy/agents/bridge.test.ts
+++ b/tests/unit/process/ki-buddy/agents/bridge.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { startAgentsMcpBridge, type AgentsMcpBridgeHandle } from '@/process/ki-buddy/agents/bridge';
+import {
+  AGENTS_MCP_AGENT_ID_HEADER,
+  AGENTS_MCP_FIELD_NAME_HEADER,
+  AGENTS_MCP_FILE_NAME_HEADER,
+  AGENTS_MCP_FILE_SIZE_HEADER,
+} from '@/process/ki-buddy/agents/contracts';
 
 const handles: AgentsMcpBridgeHandle[] = [];
 const catalog = {
@@ -10,7 +16,16 @@ const catalog = {
       agentId: 'agent-1',
       agentTitle: 'Agent 1',
       agentType: 'workflow',
-      defaultInputModes: [{ name: 'query', description: 'Query', type: 'text', required: true }],
+      defaultInputModes: [
+        { name: 'query', description: 'Query', type: 'text', required: true },
+        {
+          name: 'source',
+          description: 'Source file',
+          type: 'file',
+          required: false,
+          allowed_file_types: ['txt'],
+        },
+      ],
       defaultOutputModes: [],
     },
   ],
@@ -35,6 +50,28 @@ async function request(
       ...(body === undefined ? {} : { 'content-type': 'application/json' }),
     },
     ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+async function upload(
+  bridge: AgentsMcpBridgeHandle,
+  fileName = 'feedback.txt',
+  clientId = '11111111-1111-4111-8111-111111111111',
+  fieldName = 'source'
+) {
+  const form = new FormData();
+  form.append('file', new Blob(['customer feedback'], { type: 'text/plain' }), fileName);
+  return fetch(`${bridge.url}/upload`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${bridge.token}`,
+      'x-ki-buddy-agents-client-id': clientId,
+      [AGENTS_MCP_AGENT_ID_HEADER]: encodeURIComponent('agent-1'),
+      [AGENTS_MCP_FIELD_NAME_HEADER]: encodeURIComponent(fieldName),
+      [AGENTS_MCP_FILE_NAME_HEADER]: encodeURIComponent(fileName),
+      [AGENTS_MCP_FILE_SIZE_HEADER]: '17',
+    },
+    body: form,
   });
 }
 
@@ -137,6 +174,92 @@ describe('startAgentsMcpBridge', () => {
       '11111111-1111-4111-8111-111111111111',
       expect.any(AbortSignal)
     );
+  });
+
+  it('returns the remote file URL after upload validation', async () => {
+    const uploadFile = vi.fn().mockResolvedValue({
+      fileUrl: 'https://agents.example.test/files/remote-1',
+      sessionEpoch: 1,
+    });
+    const bridge = await startAgentsMcpBridge({
+      fetchCatalog: vi.fn().mockImplementation(async () => currentCatalog()),
+      uploadFile,
+      token: 'bridge-secret-file',
+    });
+    handles.push(bridge);
+
+    const uploadResponse = await upload(bridge);
+    expect(uploadResponse.status).toBe(200);
+    await expect(uploadResponse.json()).resolves.toEqual({
+      fileUrl: 'https://agents.example.test/files/remote-1',
+      fileName: 'feedback.txt',
+      size: 17,
+    });
+    expect(uploadFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringMatching(/^multipart\/form-data; boundary=/u),
+      1,
+      '11111111-1111-4111-8111-111111111111',
+      expect.any(AbortSignal)
+    );
+  });
+
+  it('accepts a Unicode file field name within the decoded schema limit', async () => {
+    const fieldName = '字段'.repeat(50);
+    const unicodeCatalog = structuredClone(catalog);
+    if (unicodeCatalog.agents[0]?.defaultInputModes[1]) {
+      unicodeCatalog.agents[0].defaultInputModes[1].name = fieldName;
+    }
+    const uploadFile = vi.fn().mockResolvedValue({
+      fileUrl: 'https://agents.example.test/files/remote-1',
+      sessionEpoch: 1,
+    });
+    const bridge = await startAgentsMcpBridge({
+      fetchCatalog: vi.fn().mockResolvedValue({ response: Response.json(unicodeCatalog), sessionEpoch: 1 }),
+      uploadFile,
+      token: 'bridge-secret-unicode-field',
+    });
+    handles.push(bridge);
+
+    const response = await upload(bridge, 'feedback.txt', '11111111-1111-4111-8111-111111111111', fieldName);
+
+    expect(response.status).toBe(200);
+    expect(uploadFile).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a file type outside allowed_file_types before remote upload', async () => {
+    const uploadFile = vi.fn();
+    const bridge = await startAgentsMcpBridge({
+      fetchCatalog: vi.fn().mockImplementation(async () => currentCatalog()),
+      uploadFile,
+      token: 'bridge-secret-file-type',
+    });
+    handles.push(bridge);
+
+    const response = await upload(bridge, 'feedback.pdf');
+
+    expect(response.status).toBe(400);
+    expect(uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('does not check file format when the Agent schema omits allowed_file_types', async () => {
+    const unrestrictedCatalog = structuredClone(catalog);
+    delete unrestrictedCatalog.agents[0]?.defaultInputModes[1]?.allowed_file_types;
+    const uploadFile = vi.fn().mockResolvedValue({
+      fileUrl: 'https://agents.example.test/files/remote-1',
+      sessionEpoch: 1,
+    });
+    const bridge = await startAgentsMcpBridge({
+      fetchCatalog: vi.fn().mockResolvedValue({ response: Response.json(unrestrictedCatalog), sessionEpoch: 1 }),
+      uploadFile,
+      token: 'bridge-secret-unrestricted-file-type',
+    });
+    handles.push(bridge);
+
+    const response = await upload(bridge, 'feedback.proprietary');
+
+    expect(response.status).toBe(200);
+    expect(uploadFile).toHaveBeenCalledOnce();
   });
 
   it('keeps concurrent clients distinct across the shared loopback bridge', async () => {

--- a/tests/unit/process/ki-buddy/agents/client.test.ts
+++ b/tests/unit/process/ki-buddy/agents/client.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createAgentsClient } from '@/process/ki-buddy/agents/client';
+
+const tempDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
 
 const validCatalog = {
   status: 'ok',
@@ -75,6 +84,95 @@ describe('createAgentsClient', () => {
     expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
       agentId: 'agent-feedback',
       inputs: { query: 'Summarize this.' },
+    });
+  });
+
+  it('streams the exact local file path as multipart file content', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'ki-buddy-agents-upload-'));
+    tempDirectories.push(directory);
+    const filePath = path.join(directory, 'feedback.txt');
+    await writeFile(filePath, 'customer feedback');
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      expect(url.pathname).toBe('/upload');
+      expect(init?.body).toBeInstanceOf(FormData);
+      if (!(init?.body instanceof FormData)) throw new Error('Expected multipart upload body');
+      const uploaded = init.body.get('file');
+      expect(uploaded).toBeInstanceOf(Blob);
+      expect(await (uploaded as Blob).text()).toBe('customer feedback');
+      return Response.json({
+        fileUrl: 'https://agents.example.test/files/remote-1',
+        fileName: 'feedback.txt',
+        size: 17,
+      });
+    });
+    const client = createClient(fetchMock as typeof fetch);
+
+    await client.upload('agent-file', 'source', filePath);
+  });
+
+  it('returns the remote file URL from the upload bridge', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'ki-buddy-agents-upload-'));
+    tempDirectories.push(directory);
+    const filePath = path.join(directory, 'feedback.txt');
+    await writeFile(filePath, 'customer feedback');
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        fileUrl: 'https://agents.example.test/files/remote-1',
+        fileName: 'feedback.txt',
+        size: 17,
+      })
+    );
+    const client = createClient(fetchMock as typeof fetch);
+
+    await expect(client.upload('agent-file', 'source', filePath)).resolves.toEqual({
+      fileUrl: 'https://agents.example.test/files/remote-1',
+      fileName: 'feedback.txt',
+      size: 17,
+    });
+  });
+
+  it('rejects a relative path before making a bridge request', async () => {
+    const fetchMock = vi.fn();
+    const client = createClient(fetchMock as typeof fetch);
+
+    await expect(client.upload('agent-file', 'source', 'feedback.txt')).rejects.toMatchObject({
+      code: 'invalid_input',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing local file before making a bridge request', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'ki-buddy-agents-upload-missing-'));
+    tempDirectories.push(directory);
+    const fetchMock = vi.fn();
+    const client = createClient(fetchMock as typeof fetch);
+
+    await expect(
+      client.upload('agent-file', 'source', path.join(directory, 'missing-agents-file.txt'))
+    ).rejects.toMatchObject({ code: 'invalid_input' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a local directory before making a bridge request', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'ki-buddy-agents-upload-directory-'));
+    tempDirectories.push(directory);
+    const fetchMock = vi.fn();
+    const client = createClient(fetchMock as typeof fetch);
+
+    await expect(client.upload('agent-file', 'source', directory)).rejects.toMatchObject({ code: 'invalid_input' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards a remote file URL directly in invoke inputs', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ status: 'completed' }));
+    const client = createClient(fetchMock as typeof fetch);
+
+    await client.invoke('agent-file', { source: 'https://agents.example.test/files/remote-1' });
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      agentId: 'agent-file',
+      inputs: { source: 'https://agents.example.test/files/remote-1' },
     });
   });
 

--- a/tests/unit/process/ki-buddy/agents/contracts.test.ts
+++ b/tests/unit/process/ki-buddy/agents/contracts.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   normalizeAgentsCatalog,
   normalizeAgentsCatalogSelection,
-  validateAgentsScalarInputs,
+  validateAgentsFileField,
+  validateAgentsInvokeInputs,
 } from '@/process/ki-buddy/agents/contracts';
 import catalogFixture from '../../../../fixtures/ki-buddy/agents/catalog.json';
 
@@ -38,7 +39,7 @@ describe('safe Agents catalog projection', () => {
           description: '脱敏后的反馈文件',
           type: 'file',
           required: true,
-          allowed_file_types: ['text/plain'],
+          allowed_file_types: ['txt'],
         },
       ],
       outputSchema: [{ name: 'summary', description: '分析摘要', type: 'text', required: true }],
@@ -146,7 +147,7 @@ describe('scalar invoke input enforcement', () => {
       outputSchema: [],
     };
 
-    expect(validateAgentsScalarInputs(description, { query: 'Summary', limit: 3, includeArchived: false })).toEqual({
+    expect(validateAgentsInvokeInputs(description, { query: 'Summary', limit: 3, includeArchived: false })).toEqual({
       query: 'Summary',
       limit: 3,
       includeArchived: false,
@@ -165,7 +166,7 @@ describe('scalar invoke input enforcement', () => {
         outputSchema: [],
       };
 
-      expect(() => validateAgentsScalarInputs(description, { [fieldName]: 'secret' })).toThrow('forbidden field');
+      expect(() => validateAgentsInvokeInputs(description, { [fieldName]: 'secret' })).toThrow('forbidden field');
     }
   );
 
@@ -181,7 +182,7 @@ describe('scalar invoke input enforcement', () => {
         outputSchema: [],
       };
 
-      expect(validateAgentsScalarInputs(description, { [fieldName]: 12 })).toEqual({ [fieldName]: 12 });
+      expect(validateAgentsInvokeInputs(description, { [fieldName]: 12 })).toEqual({ [fieldName]: 12 });
     }
   );
 
@@ -195,6 +196,68 @@ describe('scalar invoke input enforcement', () => {
       outputSchema: [],
     };
 
-    expect(() => validateAgentsScalarInputs(description, { query: ['not', 'scalar'] })).toThrow('scalar schema');
+    expect(() => validateAgentsInvokeInputs(description, { query: ['not', 'scalar'] })).toThrow('scalar schema');
+  });
+});
+
+describe('file invoke input enforcement', () => {
+  const description = {
+    agentId: 'agent-file',
+    title: 'File agent',
+    description: '',
+    agentType: 'workflow',
+    inputSchema: [
+      {
+        name: 'source',
+        description: '',
+        type: 'file',
+        required: true,
+        allowed_file_types: ['txt'],
+      },
+      { name: 'query', description: '', type: 'text', required: false },
+    ],
+    outputSchema: [],
+  };
+
+  it('accepts the remote file URL returned by the upload tool', () => {
+    expect(
+      validateAgentsInvokeInputs(description, {
+        source: 'https://agents.example.test/files/remote-1',
+        query: 'Summarize',
+      })
+    ).toEqual({ source: 'https://agents.example.test/files/remote-1', query: 'Summarize' });
+  });
+
+  it.each([[''], [{ fileUrl: 'https://agents.example.test/files/remote-1' }]])(
+    'rejects a non-string or empty file input: %j',
+    (source) => {
+      expect(() => validateAgentsInvokeInputs(description, { source })).toThrow('uploaded file URL');
+    }
+  );
+
+  it.each([
+    ['report.xlsx', 'xlsx'],
+    ['photo.png', '.png'],
+  ])('accepts an extension declared by the Agent: %s / %s', (fileName, allowedType) => {
+    expect(() =>
+      validateAgentsFileField(
+        {
+          ...description,
+          inputSchema: [{ ...description.inputSchema[0], allowed_file_types: [allowedType] }],
+        },
+        'source',
+        fileName
+      )
+    ).not.toThrow();
+  });
+
+  it('does not inspect file format when allowed_file_types is absent', () => {
+    expect(() =>
+      validateAgentsFileField(
+        { ...description, inputSchema: [{ ...description.inputSchema[0], allowed_file_types: undefined }] },
+        'source',
+        'unknown-format.proprietary'
+      )
+    ).not.toThrow();
   });
 });

--- a/tests/unit/process/ki-buddy/agents/mcpServer.test.ts
+++ b/tests/unit/process/ki-buddy/agents/mcpServer.test.ts
@@ -39,6 +39,11 @@ async function connect(overrides: Partial<AgentsClient> = {}) {
       outputSchema: [],
     }),
     invoke: async (agentId) => ({ agentId, text: 'Done.' }),
+    upload: async (_agentId, _fieldName, _filePath) => ({
+      fileUrl: 'https://agents.example.test/files/remote-1',
+      fileName: 'feedback.txt',
+      size: 12,
+    }),
     ...overrides,
   };
   const server = createAgentsMcpServer(adapter);
@@ -54,14 +59,46 @@ async function connect(overrides: Partial<AgentsClient> = {}) {
 }
 
 describe('createAgentsMcpServer', () => {
-  it('publishes the three catalog and execution tools', async () => {
+  it('publishes catalog, upload, and execution tools', async () => {
     const client = await connect();
 
     const result = await client.listTools();
 
-    expect(result.tools.map(({ name }) => name)).toEqual(['agents_list', 'agents_describe', 'agents_invoke']);
+    expect(result.tools.map(({ name }) => name)).toEqual([
+      'agents_list',
+      'agents_describe',
+      'agents_upload_file',
+      'agents_invoke',
+    ]);
     expect(result.tools[0]).toMatchObject({ annotations: { readOnlyHint: true }, inputSchema: { properties: {} } });
-    expect(result.tools[2]).toMatchObject({ annotations: { destructiveHint: true, idempotentHint: false } });
+    expect(result.tools[2]).toMatchObject({ annotations: { destructiveHint: false, idempotentHint: false } });
+    expect(result.tools[2]?.inputSchema).toMatchObject({
+      properties: { filePath: { type: 'string' } },
+      required: expect.arrayContaining(['filePath']),
+    });
+    expect(JSON.stringify(result.tools[2]?.inputSchema)).not.toContain('attachmentIndex');
+    expect(result.tools[3]).toMatchObject({ annotations: { destructiveHint: true, idempotentHint: false } });
+  });
+
+  it('uploads one absolute local path for one exact file field', async () => {
+    const upload = vi.fn().mockResolvedValue({
+      fileUrl: 'https://agents.example.test/files/remote-1',
+      fileName: 'feedback.txt',
+      size: 12,
+    });
+    const client = await connect({ upload });
+
+    const result = await client.callTool({
+      name: 'agents_upload_file',
+      arguments: {
+        agentId: 'agent-1',
+        fieldName: 'source',
+        filePath: '/tmp/feedback.txt',
+      },
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(upload).toHaveBeenCalledWith('agent-1', 'source', '/tmp/feedback.txt');
   });
 
   it('returns the current inventory and exact selected schema', async () => {

--- a/tests/unit/process/ki-buddy/agents/networkClient.test.ts
+++ b/tests/unit/process/ki-buddy/agents/networkClient.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { IncomingMessage } from 'node:http';
+import { Readable } from 'node:stream';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 type CertificateRequest = {
@@ -26,7 +28,13 @@ vi.mock('electron', () => ({
   },
 }));
 
-import { createAgentsNetworkFetch, resolveAgentsRequestUrl } from '@/process/ki-buddy/agents/networkClient';
+import {
+  createAgentsGatewayClient,
+  createAgentsNetworkFetch,
+  resolveAgentsRequestUrl,
+} from '@/process/ki-buddy/agents/networkClient';
+
+const gatewayClientId = '11111111-1111-4111-8111-111111111111';
 
 describe('Ki-Buddy Agents request routing', () => {
   it.each(['/bridge/agents/catalog', '/bridge/agents/invoke', '/bridge/agents/future-capability?requestId=123'])(
@@ -175,29 +183,37 @@ describe('Ki-Buddy Agents network client', () => {
     expect(new Headers((forwardedRequest as Request).headers).get('x-request-context')).toBe('preserved');
   });
 
-  it('uses fixed catalog and invoke sessions across many stdio clients without forwarding local identities', async () => {
+  it('uses fixed catalog, upload, and invoke sessions across many stdio clients without forwarding local identities', async () => {
     const invokeFetch = vi.fn().mockResolvedValue(Response.json({ state: 'completed' }));
+    const uploadFetch = vi
+      .fn()
+      .mockResolvedValue(
+        Response.json({ errorCode: 0, responseBody: { fileUrl: 'https://agents.example.test/files/1' } })
+      );
     const catalogFetch = vi.fn().mockResolvedValue(Response.json({ status: 'ok', agents: [] }));
     electronMock.fromPartition.mockImplementation((partition: string) => ({
-      fetch: partition.endsWith('-invoke') ? invokeFetch : catalogFetch,
+      fetch: partition.endsWith('-invoke') ? invokeFetch : partition.endsWith('-upload') ? uploadFetch : catalogFetch,
       setCertificateVerifyProc: vi.fn(),
     }));
     const agentsFetch = createAgentsNetworkFetch();
 
-    const requests = Array.from({ length: 40 }, (_, index) => {
+    const requests = Array.from({ length: 60 }, (_, index) => {
       const suffix = String(index + 1).padStart(12, '0');
       const clientId = `11111111-1111-4111-8111-${suffix}`;
-      const requestKind = index % 2 === 0 ? 'invoke' : 'catalog';
-      return agentsFetch(`https://192.168.0.8:8443/kagents_core/api/bridge/agents/${requestKind}`, {
-        method: requestKind === 'invoke' ? 'POST' : 'GET',
+      const requestKind = index % 3 === 0 ? 'invoke' : index % 3 === 1 ? 'catalog' : 'upload';
+      const requestPath =
+        requestKind === 'upload' ? '/kagent/sys/file/upload' : `/kagents_core/api/bridge/agents/${requestKind}`;
+      return agentsFetch(`https://192.168.0.8:8443${requestPath}`, {
+        method: requestKind === 'catalog' ? 'GET' : 'POST',
         headers: { 'x-ki-buddy-agents-client-id': clientId },
       });
     });
     await Promise.all(requests);
 
     expect(electronMock.fromPartition).toHaveBeenCalledWith('ki-buddy-agents-network-invoke', { cache: false });
+    expect(electronMock.fromPartition).toHaveBeenCalledWith('ki-buddy-agents-network-upload', { cache: false });
     expect(electronMock.fromPartition).toHaveBeenCalledWith('ki-buddy-agents-network-catalog', { cache: false });
-    expect(electronMock.fromPartition).toHaveBeenCalledTimes(2);
+    expect(electronMock.fromPartition).toHaveBeenCalledTimes(3);
     expect(invokeFetch.mock.calls[0]?.[1]).toMatchObject({ headers: expect.any(Headers) });
     const invokeHeaders = invokeFetch.mock.calls[0]?.[1]?.headers;
     const catalogHeaders = catalogFetch.mock.calls[0]?.[1]?.headers;
@@ -235,5 +251,92 @@ describe('Ki-Buddy Agents network client', () => {
 
     finishInvokes.forEach((finish) => finish(Response.json({ state: 'completed' })));
     await Promise.all([firstInvoke, secondInvoke]);
+  });
+});
+
+describe('Ki-Buddy Agents gateway client', () => {
+  it('streams multipart content and normalizes the remote upload response', async () => {
+    const response = Response.json({
+      errorCode: 0,
+      responseBody: { fileUrl: 'https://agents.example.test/files/remote-1' },
+    });
+    const fetchAuthenticated = vi.fn().mockResolvedValue(response);
+    const client = createAgentsGatewayClient({ fetchAuthenticated, getSessionEpoch: () => 1 });
+    const body = Readable.from(['multipart-body']) as IncomingMessage;
+    const signal = new AbortController().signal;
+
+    await expect(
+      client.uploadFile(body, 'multipart/form-data; boundary=boundary-1', 1, gatewayClientId, signal)
+    ).resolves.toEqual({ fileUrl: 'https://agents.example.test/files/remote-1', sessionEpoch: 1 });
+    expect(fetchAuthenticated).toHaveBeenCalledWith(
+      '/kagent/sys/file/upload',
+      expect.objectContaining({
+        body: expect.any(ReadableStream),
+        duplex: 'half',
+        method: 'POST',
+        signal,
+      })
+    );
+  });
+
+  it.each([
+    ['expired authentication', 401, {}, 'auth'],
+    ['remote server failure', 500, {}, 'server'],
+    ['rejected upload envelope', 200, { errorCode: 1, responseBody: {} }, 'server'],
+    ['incompatible upload envelope', 200, { errorCode: 0, responseBody: {} }, 'contract'],
+  ])('classifies %s before returning an uploaded file', async (_scenario, status, payload, expectedCode) => {
+    const client = createAgentsGatewayClient({
+      fetchAuthenticated: vi.fn().mockResolvedValue(Response.json(payload, { status })),
+      getSessionEpoch: () => 1,
+    });
+    const body = Readable.from(['multipart-body']) as IncomingMessage;
+
+    await expect(
+      client.uploadFile(
+        body,
+        'multipart/form-data; boundary=boundary-1',
+        1,
+        gatewayClientId,
+        new AbortController().signal
+      )
+    ).rejects.toMatchObject({ code: expectedCode });
+  });
+
+  it('rejects upload before remote dispatch when the catalog session is no longer current', async () => {
+    const fetchAuthenticated = vi.fn();
+    const client = createAgentsGatewayClient({ fetchAuthenticated, getSessionEpoch: () => 2 });
+    const body = Readable.from(['multipart-body']) as IncomingMessage;
+
+    await expect(
+      client.uploadFile(
+        body,
+        'multipart/form-data; boundary=boundary-1',
+        1,
+        gatewayClientId,
+        new AbortController().signal
+      )
+    ).rejects.toMatchObject({ code: 'auth' });
+    expect(fetchAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it('classifies an interrupted upload as auth when the session changes during dispatch', async () => {
+    let sessionEpoch = 1;
+    const fetchAuthenticated = vi.fn(async () => {
+      sessionEpoch = 2;
+      throw new Error('request aborted by session replacement');
+    });
+    const client = createAgentsGatewayClient({ fetchAuthenticated, getSessionEpoch: () => sessionEpoch });
+    const body = Readable.from(['multipart-body']) as IncomingMessage;
+
+    await expect(
+      client.uploadFile(
+        body,
+        'multipart/form-data; boundary=boundary-1',
+        1,
+        gatewayClientId,
+        new AbortController().signal
+      )
+    ).rejects.toMatchObject({ code: 'auth' });
+    expect(fetchAuthenticated).toHaveBeenCalledOnce();
   });
 });

--- a/tests/unit/process/ki-buddy/agents/runtime.test.ts
+++ b/tests/unit/process/ki-buddy/agents/runtime.test.ts
@@ -1,3 +1,5 @@
+import type { IncomingMessage } from 'node:http';
+import { Readable } from 'node:stream';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { startAgentsMcpRuntimeBridge } from '@/process/ki-buddy/agents';
 import type { AgentsInvokeRequest, startAgentsMcpBridge } from '@/process/ki-buddy/agents/bridge';
@@ -112,6 +114,41 @@ describe('startAgentsMcpRuntimeBridge', () => {
       body: JSON.stringify(request),
       signal,
     });
+    await handle.close();
+  });
+
+  it('streams multipart file content through the authenticated upload boundary', async () => {
+    const response = Response.json({
+      errorCode: 0,
+      responseBody: { fileUrl: 'https://agents.example.test/files/remote-1' },
+    });
+    const fetchAuthenticated = vi.fn().mockResolvedValue(response);
+    const bridge = createStartBridgeCapture();
+    const handle = await startAgentsMcpRuntimeBridge(
+      createAuthService(fetchAuthenticated),
+      process.env,
+      bridge.startBridge
+    );
+    const body = Readable.from(['multipart-body']) as IncomingMessage;
+    const signal = new AbortController().signal;
+
+    await expect(
+      bridge.options().uploadFile?.(body, 'multipart/form-data; boundary=boundary-1', 1, clientId, signal)
+    ).resolves.toEqual({ fileUrl: 'https://agents.example.test/files/remote-1', sessionEpoch: 1 });
+    expect(fetchAuthenticated).toHaveBeenCalledWith(
+      '/kagent/sys/file/upload',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'multipart/form-data; boundary=boundary-1',
+          'x-ki-buddy-agents-client-id': clientId,
+        },
+        body: expect.any(ReadableStream),
+        duplex: 'half',
+        signal,
+      })
+    );
     await handle.close();
   });
 

--- a/tests/unit/process/ki-buddy/agents/server.test.ts
+++ b/tests/unit/process/ki-buddy/agents/server.test.ts
@@ -19,6 +19,10 @@ function createAdapterHarness() {
     env: {
       KI_BUDDY_AGENTS_ADAPTER_BRIDGE_URL: 'http://127.0.0.1:43123',
       KI_BUDDY_AGENTS_ADAPTER_BRIDGE_TOKEN: 'bridge-secret',
+      AIONUI_BASE_URL: 'http://127.0.0.1:19000',
+      AIONUI_CONVERSATION_ID: 'conversation-1',
+      AIONUI_RUNTIME_TOKEN: 'runtime-secret',
+      AIONUI_USER_ID: 'user-1',
     },
     exitCode: undefined as number | undefined,
     get ppid() {

--- a/tests/unit/renderer/ki-buddy/McpServerToolsList.dom.test.tsx
+++ b/tests/unit/renderer/ki-buddy/McpServerToolsList.dom.test.tsx
@@ -13,11 +13,13 @@ const PRODUCT_DESCRIPTIONS = {
   'en-US': {
     list: 'Lists the complete Agents catalog available to the current signed-in account.',
     describe: 'Shows the exact input and output schema for one agent in the current catalog.',
+    upload: 'Uploads one local file for an exact file input field and returns its Agents file URL.',
     invoke: 'Invokes the described Agent once with complete scalar inputs.',
   },
   'zh-CN': {
     list: '列出当前登录账号可用的完整 Agents 目录。',
     describe: '显示当前目录中一个 Agent 的精确输入和输出结构。',
+    upload: '为指定的文件输入字段上传一个本地文件，并返回其 Agents 文件 URL。',
     invoke: '使用完整的标量参数调用一次已描述的 Agent。',
   },
 } as const;
@@ -35,6 +37,7 @@ const buildServer = (overrides: Partial<IMcpServer> = {}): IMcpServer => ({
   tools: [
     { name: 'agents_list', description: PROTOCOL_DESCRIPTION },
     { name: 'agents_describe', description: PROTOCOL_DESCRIPTION },
+    { name: 'agents_upload_file', description: PROTOCOL_DESCRIPTION },
     { name: 'agents_invoke', description: PROTOCOL_DESCRIPTION },
   ],
   created_at: 0,
@@ -57,6 +60,7 @@ async function createTestI18n(language: keyof typeof PRODUCT_DESCRIPTIONS): Prom
               kiBuddy: {
                 agentsListDescription: descriptions.list,
                 agentsDescribeDescription: descriptions.describe,
+                agentsUploadDescription: descriptions.upload,
                 agentsInvokeDescription: descriptions.invoke,
               },
             },
@@ -104,6 +108,7 @@ describe('Ki-Buddy Agents MCP tool presentation', () => {
 
     expect(screen.getByText(PRODUCT_DESCRIPTIONS['en-US'].list)).toBeInTheDocument();
     expect(screen.getByText(PRODUCT_DESCRIPTIONS['en-US'].describe)).toBeInTheDocument();
+    expect(screen.getByText(PRODUCT_DESCRIPTIONS['en-US'].upload)).toBeInTheDocument();
     expect(screen.getByText(PRODUCT_DESCRIPTIONS['en-US'].invoke)).toBeInTheDocument();
     expect(screen.queryByText(PROTOCOL_DESCRIPTION)).not.toBeInTheDocument();
   });
@@ -113,6 +118,7 @@ describe('Ki-Buddy Agents MCP tool presentation', () => {
 
     expect(screen.getByText(PRODUCT_DESCRIPTIONS[language].list)).toBeInTheDocument();
     expect(screen.getByText(PRODUCT_DESCRIPTIONS[language].describe)).toBeInTheDocument();
+    expect(screen.getByText(PRODUCT_DESCRIPTIONS[language].upload)).toBeInTheDocument();
     expect(screen.getByText(PRODUCT_DESCRIPTIONS[language].invoke)).toBeInTheDocument();
     expect(screen.queryByText(PROTOCOL_DESCRIPTION)).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Description

- 新增独立 MCP 工具 `agents_upload_file`，按 `agentId`、精确 `fieldName` 和本地绝对路径将文件流式上传到当前 Agents 部署。
- 上传前刷新当前 Agent schema；仅在 `allowed_file_types` 非空时检查扩展名，成功后返回 `fileUrl`、`fileName` 和 `size`。
- `agents_invoke` 的文件字段继续接收上传工具返回的 `fileUrl` 字符串，不修改 AionUi 通用 Conversation 的附件发送、展示或持久化逻辑。
- 为 `agents_upload_file` 补齐 Ki-Buddy 产品资源本地化映射，避免工具设置页回退显示英文协议描述。
- 将 stdio 集成测试的 MCP bundle 构建到 suite 独享临时目录，避免与打包测试共享 `out/` 导致的并行测试回归；默认构建输出仍为 `out/main`。

## Related Issues

- 关联 #23
- Ki-Core 中配套的 Skill/Rule 修改按当前安排暂不推送，因此本 PR 不自动关闭 Issue。

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Refactoring
- [ ] `docs` — Documentation only
- [ ] `chore` — Maintenance / tooling

## Atomic PR

- [x] This PR contains one logical change.
- [x] The PR title follows Conventional Commit format.

## Local checks

- [x] Lint（`bun run lint -- --quiet`，0 errors）
- [x] Formatting（`bun run format:check`）
- [x] TypeScript（`bunx tsc --noEmit`）
- [x] Tests（495 files passed、1 skipped；4349 tests passed、5 skipped）
- [x] i18n types（`bun run i18n:types`）
- [x] i18n validation（`node scripts/check-i18n.js`）
- [x] Product experience consistency check
- [x] 新增用户可见文案均使用 i18n key，并覆盖 13 个 locale。

## Runtime Verification

- [x] macOS：使用 packaged Ki-Buddy 与可正常执行的已发布 Agent，人工验证本地文件上传、`fileUrl` 拼接及 invoke 成功。
- [ ] Windows
- [ ] Linux

## Screenshots

不适用。工具描述本地化由 DOM 回归测试覆盖。

## Additional Context

- `package.json`、`bun.lock`、`ki-buddy-product.json` 与 `origin/product/main` 无差异。
- Adapter 不查询 Conversation、不解析 `[[AION_FILES]]`，也不管理历史附件；本地路径继续来自 AionUi 的 `[Attached files]`、用户明确路径或现有文件工具。
- 最终两轴审查：Standards 0 finding；Spec 除两项已确认不修改的既有行为外无新增 finding。
- 完整测试仅输出仓库已有的 `MaxListenersExceededWarning` 与既有 i18n warning，均未导致失败。
