### PR TITLE
docs(agents): defer result file delivery

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -202,14 +202,6 @@ _Avoid_：项目目录授权、模型提供的路径、文件系统读取权限
 Adapter 为当前 session 中已经上传的远端文件输入生成的一次性不透明 `uploadRef`；它不暴露真实 `fileUrl`。
 _Avoid_：fileUrl、本地路径、Agents 文件 ID
 
-**结果文件交付**：
-Adapter 将正式 MCP result-file contract 返回的结构化远端文件安全写入 effective workspace，并向助手返回本地文件引用和脱敏摘要。
-_Avoid_：Assistant 下载、远端 URI 消息、主进程 Agents 输出解析
-
-**部分结果交付**：
-MCP contract 已明确返回成功结果，但一个或多个结构化结果文件未能写入 effective workspace 的本地交付状态。
-_Avoid_：invoke 失败、全部成功、自动重新执行
-
-**结果交付引用**：
-Adapter 为当前 session 中尚未解决的结果文件交付保存的一次性不透明 `deliveryRef`，用于只重试未交付文件。
-_Avoid_：远端 URI、持久下载记录、invoke 重试
+**远端执行文件产物**：
+Agents 平台通过正式 execution artifact contract 与一次远端执行关联并提供获取语义的文件结果；Ki-Buddy 不根据 invoke JSON、URL 或字段名称推断这种关联。
+_Avoid_：客户端结果文件、任意输出 URL、本地 `deliveryRef`

--- a/docs/adr/agents-execution/0008-deliver-remote-result-files-inside-adapter.md
+++ b/docs/adr/agents-execution/0008-deliver-remote-result-files-inside-adapter.md
@@ -1,5 +1,5 @@
 ---
-status: accepted
+status: superseded by ADR-0013
 ---
 
 # 在 Adapter 内安全交付远端结果文件

--- a/docs/adr/agents-execution/0009-separate-platform-and-client-security-responsibilities.md
+++ b/docs/adr/agents-execution/0009-separate-platform-and-client-security-responsibilities.md
@@ -4,7 +4,7 @@ status: accepted
 
 # 分离 Agents 平台与 Ki-Buddy 的安全责任
 
-Agents 平台拥有用户、组织、角色、权限、已发布 agent、远端执行授权、内容治理和中心化审计。Ki-Buddy 拥有本地凭据边界、Core 用户隔离、Adapter 协议校验、task-scoped 文件授权、结果下载限制和本地工具授权；本地 invocation ledger 只负责防重与恢复，不是审计副本。
+Agents 平台拥有用户、组织、角色、权限、已发布 agent、远端执行授权、内容治理和中心化审计。Ki-Buddy 拥有本地凭据边界、Core 用户隔离、Adapter 协议校验、用户文件授权和本地工具授权。远端执行生命周期由 ADR 0012 修订，结果文件能力由 ADR 0013 修订；正式 execution artifact contract 出现前，Ki-Buddy 不实现结果下载限制或交付状态。
 
 首发把 catalog 描述和 invoke 返回作为普通 MCP tool 内容交给 Agents 执行助手，不增加 `trust=untrusted` 标记、启发式关键词过滤或专用 prompt-injection 边界。Agents 执行助手也沿用普通 AionCLI 的本地工具和 Ki-Buddy 现有授权策略，不创建专用受限 runtime 或额外确认层。
 
@@ -19,5 +19,5 @@ Agents 平台拥有用户、组织、角色、权限、已发布 agent、远端�
 - Ki-Buddy 不能宣称远端内容经过 prompt-injection 隔离或净化；恶意描述和结果可能影响模型后续判断。Adapter 的 schema、凭据、来源和容量校验不能被描述为内容安全防护。
 - Agents 平台不能替代 Ki-Buddy 对本地文件、shell、浏览器和其他副作用的授权判断；远端 agent 权限与本地工具权限是两个独立边界。
 - 明确执行请求当前构成一次 invoke 的同意，客户端不自行推断风险。Agents 后续发布 `sideEffect`、`riskLevel`、`requiresApproval` 等稳定 contract 时，Ki-Buddy 必须重新评估确认流程。
-- 中心化审计完整性由 Agents 验证。Ki-Buddy 只保存脱敏关联 ID、执行状态和本地结果引用，不保存完整请求响应，也不建设管理员审计 UI。
+- 中心化审计完整性由 Agents 验证。Ki-Buddy 不保存远端执行状态副本或本地结果引用，也不建设管理员审计 UI。
 - 扩大自动授权范围、支持一次请求多次 invoke，或平台内容治理无法满足要求时，必须同时重新评估远端内容信任和本地工具权限。

--- a/docs/adr/agents-execution/0012-integrate-agents-execution-lifecycle-through-mcp.md
+++ b/docs/adr/agents-execution/0012-integrate-agents-execution-lifecycle-through-mcp.md
@@ -8,14 +8,14 @@ Ki-Buddy 是运行在用户电脑上的 MCP 客户端。它通过官方 Assistan
 
 Agents 拥有 task identity、服务端幂等、status、cancel、resume、retry 和中心化审计。以上能力必须通过正式 MCP contract 提供；Ki-Buddy 只接入并呈现该 contract，不根据任意 JSON 字段、HTTP 等待窗口或本地进程状态建立 Agents 专用状态机。异常后新的执行由用户发起。
 
-Ki-Buddy 继续负责客户端安全边界，包括本地凭据、Core 用户隔离、Adapter protocol 与 schema 校验、用户文件授权、结果下载限制和本地工具授权。这些能力可以维护本地短期 grant 或 delivery 引用，但不得赋予它们远端 task identity、执行恢复或取消语义。
+Ki-Buddy 继续负责客户端安全边界，包括本地凭据、Core 用户隔离、Adapter protocol 与 schema 校验、用户文件授权和本地工具授权。Agents 提供正式 execution artifact contract 后，结果下载限制也属于客户端安全边界；在此之前 Ki-Buddy 不建立结果交付能力或 delivery 引用。
 
 ## 对既有决策的修订
 
 - 取代 ADR 0006。客户端不实现本地幂等登记、结果未知持久化、跨进程 dispatch qualification 或 active invocation 恢复。
 - 修订 ADR 0005。Assistant session 继续使用现有队列，不在 Adapter 内增加队列；远端 task identity 与执行状态只使用 MCP contract 提供的值。
 - 修订 ADR 0007。file grant 和 `uploadRef` 属于客户端文件授权，绑定 deployment、账号、conversation、Adapter session、agent 和输入字段；不绑定 Ki-Buddy 自建 taskId，也不表示远端执行状态。上传能力必须依据正式 MCP file-input contract。
-- 修订 ADR 0008。结果文件只按正式 MCP result-file contract 识别；本地 delivery 状态不构成远端执行状态副本，下载失败不能触发新的 invoke。
+- ADR 0008 已由 ADR 0013 取代。Ki-Buddy 等待 Agents 正式提供远端执行文件产物 contract，不从 invoke JSON 推断文件产物，也不建立本地 delivery 状态。
 - 修订 ADR 0009。Agents 平台同时拥有远端执行生命周期；Ki-Buddy 不保存脱敏执行状态副本或提供管理员审计查询。
 
 ## Considered Options
@@ -30,5 +30,5 @@ Ki-Buddy 继续负责客户端安全边界，包括本地凭据、Core 用户隔
 - #67 的 direct invoke contract 保持不变：Adapter 不增加 describe grant 或请求级本地防重，合法成功 JSON 继续完整透传。
 - 用户 Stop 只结束本地会话等待；没有 MCP cancel contract 时不能宣称远端已取消。
 - MCP 调用断开或超时时，Ki-Buddy 只报告本地调用结果。用户后续发起的新请求按新的 MCP 交互处理。
-- #23–#26 的本地文件授权和交付能力不依赖 #21；涉及上传、远端结果或执行生命周期的部分必须基于正式 MCP contract。
+- #23 的本地文件输入能力继续依据正式 file-input contract；#25、#26 在 Agents 提供 execution artifact contract 前不实施。
 - 本决策不要求修改 Ki-Core，也不增加 Team runtime。

--- a/docs/adr/agents-execution/0013-defer-result-file-delivery-until-agents-contract.md
+++ b/docs/adr/agents-execution/0013-defer-result-file-delivery-until-agents-contract.md
@@ -1,0 +1,22 @@
+---
+status: accepted
+---
+
+# 等待 Agents 提供远端执行文件产物 contract
+
+Ki-Buddy 暂不实现远端执行文件产物的识别、下载、部分交付或重试。文件与某次远端执行的关联、可用状态、授权和获取方式属于 Agents execution lifecycle；当前 Agents 没有提供正式 execution artifact contract，客户端根据 invoke JSON、URL 或字段名称推断这些语义会形成一套未经平台定义的协议。
+
+`agents_invoke` 保持 #67 的 direct invoke contract，合法成功 JSON 继续完整透传。Adapter 不默认下载疑似文件、不创建 `deliveryRef`，也不把本地下载结果建模为远端执行状态。任意 URL 或 file-like JSON 只是普通远端结果内容，不被 Ki-Buddy 认定为远端执行文件产物。
+
+## Considered Options
+
+- 根据 `result.outputs` 或常见 URL 字段推断并自动下载：客户端无法证明文件属于哪次执行、是否已经可用或应使用什么授权，且会改变 `agents_invoke` 的成功与失败语义。
+- 在 Adapter 内先设计 `deliveryRef` 和部分交付状态：会让 Ki-Buddy 提前定义 Agents 尚未提供的文件产物生命周期。
+- 由 Assistant 使用普通下载工具处理远端 URL：无法形成 Agents 文件产物的可信关联，也不属于 Agents Adapter 的协议适配。
+
+## Consequences
+
+- ADR 0008 被本决策取代；#25、#26 当前不实施。
+- Ki-Buddy 目前不提供 Agents 远端执行文件产物的专用本地交付体验，也不宣称普通结果中的 URL 是可下载产物。
+- Agents 后续提供正式 contract 时，应先确认执行与文件的关联、产物状态、授权获取方式、元数据以及错误语义，再由 Adapter 映射该 contract。
+- 接入正式 contract 后，effective workspace、origin、redirect、凭据、容量、临时文件、路径和覆盖策略仍由 Ki-Buddy 的客户端安全边界负责，并通过新的 issue 明确验收范围。

--- a/docs/architecture/research/ki-buddy-account-cache-classification.md
+++ b/docs/architecture/research/ki-buddy-account-cache-classification.md
@@ -274,12 +274,12 @@ conversation、Team、task、mailbox 已由 Core user scope 隔离，但 rendere
 
 ADR 0006 的产品 SQLite ledger 方案已被 ADR 0012 取代。Ki-Buddy 不生成远端 taskId，不维护 invocation ledger 或 active invocation lifecycle，也不在 logout、账号切换、App 重启或异常恢复时推断 Agents 执行状态。status、cancel、resume、retry 与服务端幂等必须由 Agents 通过正式 MCP contract 提供。证据：`/Users/xli/AionUi/docs/adr/agents-execution/0006-guard-remote-invocations-with-local-ledger.md`、`/Users/xli/AionUi/docs/adr/agents-execution/0012-integrate-agents-execution-lifecycle-through-mcp.md`。
 
-ADR 0007 的 `uploadRef` 与 ADR 0008 的 `deliveryRef` 仍属于计划中的客户端临时引用。它们只承担本地文件授权或交付职责，不表示远端 task identity、执行状态、恢复或取消。证据：`/Users/xli/AionUi/docs/adr/agents-execution/0007-upload-authorized-local-files-inside-adapter.md`、`/Users/xli/AionUi/docs/adr/agents-execution/0008-deliver-remote-result-files-inside-adapter.md`、ADR 0012。
+ADR 0007 的 `uploadRef` 属于计划中的客户端临时引用，只承担本地文件授权职责，不表示远端 task identity、执行状态、恢复或取消。ADR 0013 已取代 ADR 0008；Agents 尚未提供正式 execution artifact contract，因此 Ki-Buddy 不设计或保存 `deliveryRef`。证据：`/Users/xli/AionUi/docs/adr/agents-execution/0007-upload-authorized-local-files-inside-adapter.md`、`/Users/xli/AionUi/docs/adr/agents-execution/0012-integrate-agents-execution-lifecycle-through-mcp.md`、`/Users/xli/AionUi/docs/adr/agents-execution/0013-defer-result-file-delivery-until-agents-contract.md`。
 
-当前 `packages/desktop/src/process/ki-buddy/` 中没有 `uploadRef` 或 `deliveryRef` 的业务实现。因此它们应标为“计划中”：
+当前 `packages/desktop/src/process/ki-buddy/` 中没有 `uploadRef` 的业务实现，因此它应标为“计划中”：
 
-- `uploadRef` 和 `deliveryRef` 属于账号绑定的临时客户端状态，切换时必须失效；
-- 这些引用不能被用于恢复、重试或取消远端执行，相关能力只能来自 MCP contract；
+- `uploadRef` 属于账号绑定的临时客户端状态，切换时必须失效；
+- `uploadRef` 不能被用于恢复、重试或取消远端执行，相关能力只能来自 MCP contract；
 - 现有 Core `ChatFileRef::Upload` 与计划中的 Agents Adapter `uploadRef` 不是同一个对象，不能混为一类。
 
 ## 8. AionUi v2.1.54 生产 OAuth 账号切换对照
@@ -373,7 +373,7 @@ Core user bridge 的 auth listener 在退出时以 `void handleSignedOut(...)` �
 - Agents credential、Core session/defaultSession auth Cookie、旧请求 AbortController 与验证循环；
 - conversation/Team/task/cron/assistant/project 的运行中请求、响应和订阅；
 - SWR 账号数据及所有模块级账号内存 store；
-- 旧 Agents 请求的 abort，以及未来 `uploadRef`、`deliveryRef` 等客户端临时引用失效；Ki-Buddy 不维护 idempotency ledger 或 active invocation lifecycle。
+- 旧 Agents 请求的 abort，以及未来 `uploadRef` 等客户端临时引用失效；Ki-Buddy 不维护 idempotency ledger、active invocation lifecycle 或远端执行文件产物引用。
 
 ### 必须保持不变
 


### PR DESCRIPTION
# Pull Request

## Description

本 PR 记录 Agents 远端执行文件产物的最新职责边界：

- Ki-Buddy 暂不根据 invoke JSON、URL 或字段名推断远端执行文件产物。
- `agents_invoke` 保持 #67 的 direct invoke contract，合法成功 JSON 继续完整透传。
- 等待 Agents 提供正式 execution artifact contract 后，再由 Agents MCP Adapter 进行映射和适配。
- 新增 ADR 0013，并将 ADR 0008 标记为被取代；同步更新领域术语、相关 ADR 和账号状态研究文档。

本 PR 不包含 runtime、UI 或测试代码修改。

## Related Issues

- Related to #25
- Related to #26
- Related to #67

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [x] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format:check` — formatting passes through `just push`
- [x] `bun run lint -- --quiet` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 495 test files passed, 1 skipped; 4349 tests passed, 5 skipped
- [x] i18n validation passed through `just push`（本次变更不涉及 i18n 路径）
- [x] New/changed user-facing text uses i18n keys（本次没有 runtime 用户文案）

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

不适用，本 PR 仅修改领域文档与 ADR。

## Additional Context

- #25、#26 已按同一决策更新，并以 `NOT_PLANNED` / `wontfix` 关闭。
- `just push` 由维护者在宿主机执行完成。
- 检查过程仍会报告仓库既有 i18n warning 和 Node `MaxListenersExceededWarning`，没有 error，质量门禁通过。
