### PR TITLE
fix(ci): install release validation dependencies

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Fetch mapped AionUi tag
         shell: bash
         run: |

--- a/tests/unit/assets/kiCoreWorkflowPolicy.test.ts
+++ b/tests/unit/assets/kiCoreWorkflowPolicy.test.ts
@@ -49,6 +49,19 @@ describe('Ki-Core workflow source policies', () => {
     }
   });
 
+  it('installs stable release validator dependencies before reading the mapped identity', () => {
+    const stable = workflow('build-and-release.yml');
+    const validateJob = stable.slice(stable.indexOf('  validate-release:'), stable.indexOf('\n  code-quality:'));
+    const setupBun = validateJob.indexOf('- name: Setup bun');
+    const installDependencies = validateJob.indexOf('- name: Install dependencies');
+    const fetchMappedTag = validateJob.indexOf('- name: Fetch mapped AionUi tag');
+
+    expect(setupBun).toBeGreaterThan(-1);
+    expect(installDependencies).toBeGreaterThan(setupBun);
+    expect(fetchMappedTag).toBeGreaterThan(installDependencies);
+    expect(validateJob.slice(installDependencies, fetchMappedTag)).toContain('bun install --frozen-lockfile');
+  });
+
   it('creates only an approved Ki-Buddy Draft Release from a product tag', () => {
     const stable = workflow('build-and-release.yml');
     expect(stable).toContain("- 'ki-buddy-v*'");


### PR DESCRIPTION
# Pull Request

## 说明

修复 Ki-Buddy 正式发布校验在安装依赖前执行 kiBuddyRelease.js 的问题。

ki-buddy-v0.1.2 触发的正式发布 run 32731140971 在 Validate Ki-Buddy release job 失败。脚本自 PR #42 起会加载 js-yaml，但 validate-release job 只设置 Node.js，没有安装 package.json 中声明的依赖，因此干净 runner 报 Cannot find module js-yaml。

本 PR：

- 在 validate-release job 中设置 Bun。
- 在首次执行 kiBuddyRelease.js 前运行 bun install --frozen-lockfile。
- 增加 workflow 顺序回归测试，要求依赖安装早于 Fetch mapped AionUi tag。

## 关联 Issue

- 无
- 失败 run：https://github.com/xlihub/Ki-Buddy/actions/runs/32731140971

## 变更类型

- [x] fix — CI 发布流程修复

## 原子 PR 检查

- [x] 本 PR 仅修复正式发布校验的依赖安装顺序
- [x] PR 标题符合 Conventional Commit 格式

## 本地检查

- [x] focused test：7/7 通过
- [x] lint：0 error；仍有仓库现存的 884 条 warning
- [x] 格式检查通过
- [x] TypeScript 检查通过
- [x] 发布映射验证通过
- [x] Ki-Buddy 产品体验一致性检查通过
- [x] 完整 Vitest：495 个测试文件通过，1 个跳过；4351 个测试通过，5 个跳过
- [x] just push 全部检查通过

一次较早的本地完整测试因临时构建目录中的 aionext-goose.zip 短暂缺失而失败；对应测试单独重跑 16/16 通过，随后完整测试及 just push 完整测试均通过。

## 运行时验证

- [ ] 已在 macOS 验证
- [ ] 已在 Windows 验证
- [ ] 已在 Linux 验证
- [x] 已完成变更自查

## 截图

不适用，本 PR 仅修改 GitHub Actions workflow 和自动化测试。

## 补充信息

远端 ki-buddy-v0.1.2 tag 保持不变，且没有创建 Release。该 tag 不会移动、删除或复用。本修复合并后，发布版本将更新为 Ki-Buddy 0.1.3，AionUi、Ki-Core 和 AionCore 映射保持不变。
