### PR TITLE
fix(ci): install draft release dependencies

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -165,6 +165,19 @@ jobs:
       - name: Checkout release tag
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Download build artifacts
         uses: actions/download-artifact@v7
         with:

--- a/tests/unit/assets/kiCoreWorkflowPolicy.test.ts
+++ b/tests/unit/assets/kiCoreWorkflowPolicy.test.ts
@@ -1,9 +1,53 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { load as loadYaml } from 'js-yaml';
+
+type WorkflowStep = Readonly<{
+  name?: string;
+  run?: string;
+  with?: Readonly<Record<string, unknown>>;
+}>;
+
+type WorkflowJob = Readonly<{
+  steps?: readonly WorkflowStep[];
+}>;
+
+type WorkflowDefinition = Readonly<{
+  jobs?: Readonly<Record<string, WorkflowJob>>;
+}>;
+
+const DEPENDENCY_BOUND_SCRIPT_PATHS = [
+  'packages/shared-scripts/src/kiBuddyProductExperienceConsistency.ts',
+  'packages/shared-scripts/src/kiBuddyRelease.js',
+  'packages/shared-scripts/src/kiBuddyUnpacked.js',
+  'packages/shared-scripts/src/prepare-aioncore.js',
+  'scripts/build-with-builder.js',
+  'scripts/pack-web-cli.js',
+  'scripts/prepareAioncore.js',
+];
 
 function workflow(name: string) {
   return readFileSync(resolve(process.cwd(), '.github/workflows', name), 'utf8');
+}
+
+function workflowNames(): readonly string[] {
+  return readdirSync(resolve(process.cwd(), '.github/workflows'))
+    .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+    .toSorted();
+}
+
+function invokesDependencyBoundScript(command: string): boolean {
+  return command.split('\n').some((line) => {
+    const trimmed = line.trim();
+    return DEPENDENCY_BOUND_SCRIPT_PATHS.some(
+      (scriptPath) =>
+        trimmed.startsWith(`node ${scriptPath}`) ||
+        trimmed.startsWith(`bun ${scriptPath}`) ||
+        trimmed.includes(`$(node ${scriptPath}`) ||
+        trimmed.includes(`$(bun ${scriptPath}`)
+    );
+  });
 }
 
 describe('Ki-Core workflow source policies', () => {
@@ -60,6 +104,36 @@ describe('Ki-Core workflow source policies', () => {
     expect(installDependencies).toBeGreaterThan(setupBun);
     expect(fetchMappedTag).toBeGreaterThan(installDependencies);
     expect(validateJob.slice(installDependencies, fetchMappedTag)).toContain('bun install --frozen-lockfile');
+  });
+
+  it('installs workspace dependencies before every dependency-bound repository script invocation', () => {
+    const invocations: string[] = [];
+
+    for (const name of workflowNames()) {
+      const definition = loadYaml(workflow(name)) as WorkflowDefinition;
+      for (const [jobName, job] of Object.entries(definition.jobs ?? {})) {
+        const steps = job.steps ?? [];
+        for (const [stepIndex, step] of steps.entries()) {
+          const command = step.run;
+          if (!command || !invokesDependencyBoundScript(command)) continue;
+
+          const invocation = `${name}:${jobName}:${step.name ?? stepIndex + 1}`;
+          invocations.push(invocation);
+          const priorCommands = steps
+            .slice(0, stepIndex)
+            .flatMap((priorStep) => {
+              const retryCommand = priorStep.with?.command;
+              return [priorStep.run, typeof retryCommand === 'string' ? retryCommand : undefined].filter(
+                (value): value is string => Boolean(value)
+              );
+            })
+            .join('\n');
+          expect(priorCommands, invocation).toContain('bun install --frozen-lockfile');
+        }
+      }
+    }
+
+    expect(invocations.length).toBeGreaterThan(0);
   });
 
   it('creates only an approved Ki-Buddy Draft Release from a product tag', () => {


### PR DESCRIPTION
# Pull Request

## Description

修复 Ki-Buddy 正式发布在创建 Draft Release 时未安装 workspace 依赖的问题。`Generate Ki-Buddy release notes` 会加载 `kiBuddyRelease.js`，该脚本依赖 `js-yaml`；此前 `create-draft-release` job 直接调用脚本，导致干净 runner 报 `Cannot find module js-yaml`。

本 PR：

- 在 `create-draft-release` checkout 后设置 Node.js 22 和 Bun，并执行 `bun install --frozen-lockfile`。
- 审计当前所有相关 GitHub Actions 中依赖 workspace 包的仓库脚本调用。
- 增加 workflow 策略测试，解析全部 workflow，并要求每个相关 job 在实际调用脚本前安装依赖；同时识别 `nick-fields/retry` 的 `with.command` 安装方式，避免误报。

## Related Issues

- 无

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — 884 条仓库既有 warning，0 error
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 495 个测试文件通过，1 个跳过；4352 项测试通过，5 项跳过
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — 通过，仅有仓库既有 warning
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — 本 PR 没有用户可见文本

额外验证：

- `bunx vitest run tests/unit/assets/kiCoreWorkflowPolicy.test.ts`：8/8 通过
- `bun run test:coverage`：命令通过；项目总体 Statements 54.29%，当前仓库未设置失败阈值
- `node packages/shared-scripts/src/kiBuddyRelease.js verify --tag ki-buddy-v0.1.3 --commit 95124f259534421e9c5e47ad04d48c7abd1550ce`：通过
- `bun packages/shared-scripts/src/kiBuddyProductExperienceConsistency.ts`：通过
- `just push -u origin fix/release-notes-install-deps`：通过
- `prek`：本机未安装，未执行

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

不适用。本 PR 仅修改 GitHub Actions 与策略测试。

## Additional Context

失败 run：[Ki-Buddy Stable Release 32741100343](https://github.com/xlihub/Ki-Buddy/actions/runs/32741100343)。该 run 的六类桌面构建、五类 Web CLI、安装冒烟测试以及 Release 资产校验均通过，最终仅在 Release Notes 生成步骤失败，因此没有创建 0.1.3 GitHub Release。

`ki-buddy-v0.1.3` 保留并继续指向 `95124f259534421e9c5e47ad04d48c7abd1550ce`，不会移动或复用。修复合并后应使用新的 Ki-Buddy patch 版本和 tag 恢复发布。
