### PR TITLE
fix(installer): validate branded Windows executable

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -641,6 +641,20 @@ jobs:
           echo ""
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
+      - name: Silent install smoke test (Windows x64)
+        if: matrix.platform == 'windows-x64'
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem -Path out -Filter "Ki-Buddy-*-win-*.exe" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $installer) {
+            throw "No Windows installer found in out/"
+          }
+
+          $process = Start-Process -FilePath $installer.FullName -ArgumentList '/S' -Wait -NoNewWindow -PassThru
+          if ($process.ExitCode -ne 0) {
+            throw "Windows installer exited with code $($process.ExitCode)"
+          }
+
       - name: List build artifacts
         if: success() || failure()
         shell: bash

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -511,7 +511,10 @@ jobs:
           }
 
           Write-Host "Using installer: $($installer.FullName)"
-          Start-Process -FilePath $installer.FullName -ArgumentList '/S' -Wait -NoNewWindow
+          $process = Start-Process -FilePath $installer.FullName -ArgumentList '/S' -Wait -NoNewWindow -PassThru
+          if ($process.ExitCode -ne 0) {
+            throw "Windows installer exited with code $($process.ExitCode)"
+          }
 
           $candidates = @(
             "$env:LOCALAPPDATA\\Programs\\Ki-Buddy\\Ki-Buddy.exe",

--- a/resources/windows/installer-observability.nsh
+++ b/resources/windows/installer-observability.nsh
@@ -106,16 +106,16 @@ Var /GLOBAL AionUiSessionLogPath
 !macroend
 
 !macro AIONUI_LOG_EXTRACT_RESULT _METHOD
-  ${IfNot} ${FileExists} "$INSTDIR\AionUi.exe"
+  ${IfNot} ${FileExists} "$INSTDIR\${AIONUI_APP_EXECUTABLE_FILENAME}"
     !insertmacro AIONUI_FAIL_UX \
       "${AIONUI_E_EXTRACT_FAILED}" \
-      "event=extract result=fail method=${_METHOD} missing=AionUi.exe" \
+      "event=extract result=fail method=${_METHOD} missing=${AIONUI_APP_EXECUTABLE_FILENAME}" \
       "${AIONUI_MSG_EXTRACT_FAILED_ZH}" \
       "${AIONUI_MSG_EXTRACT_FAILED_EN}" \
       "${AIONUI_MSG_EXTRACT_FAILED_ACTION_ZH}" \
       "${AIONUI_MSG_EXTRACT_FAILED_ACTION_EN}" \
-      "extract result=fail method=${_METHOD} missing=AionUi.exe instDir=$INSTDIR" \
-      "extract result=fail method=${_METHOD} missing=AionUi.exe instDir=$INSTDIR"
+      "extract result=fail method=${_METHOD} missing=${AIONUI_APP_EXECUTABLE_FILENAME} instDir=$INSTDIR" \
+      "extract result=fail method=${_METHOD} missing=${AIONUI_APP_EXECUTABLE_FILENAME} instDir=$INSTDIR"
   ${Else}
     !insertmacro AIONUI_SLOG "event=extract result=ok method=${_METHOD} detail=customFiles_${AIONUI_TARGET_ARCH}"
   ${EndIf}

--- a/resources/windows/installer-process-control.nsh
+++ b/resources/windows/installer-process-control.nsh
@@ -176,7 +176,7 @@ Var /GLOBAL AionUiCurrentOutDir
 !macro AIONUI_QUERY_LOCKERS _TARGET_PATH _RETURN
   InitPluginsDir
   File /oname=$PLUGINSDIR\aionui-query-lockers.ps1 "${PROJECT_DIR}\resources\windows\support\query-lockers.ps1"
-  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\aionui-query-lockers.ps1" -LogPath "$AionUiSessionLogPath" -InstDir "$INSTDIR" -TargetPath "${_TARGET_PATH}" -LockerListPath "$PLUGINSDIR\aionui-rm-lockers.txt" -Session "$AionUiSessionId" -Version "${VERSION}" -Arch "${AIONUI_TARGET_ARCH}" -Updated "$AionUiIsUpdated" -CurrentOutDir "$AionUiCurrentOutDir"`
+  nsExec::Exec `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\aionui-query-lockers.ps1" -LogPath "$AionUiSessionLogPath" -InstDir "$INSTDIR" -TargetPath "${_TARGET_PATH}" -LockerListPath "$PLUGINSDIR\aionui-rm-lockers.txt" -Session "$AionUiSessionId" -Version "${VERSION}" -Arch "${AIONUI_TARGET_ARCH}" -Updated "$AionUiIsUpdated" -CurrentOutDir "$AionUiCurrentOutDir" -AppExecutableFilename "${AIONUI_APP_EXECUTABLE_FILENAME}" -UninstallFilename "${UNINSTALL_FILENAME}"`
   Pop ${_RETURN}
 !macroend
 

--- a/resources/windows/installer-update-verify.nsh
+++ b/resources/windows/installer-update-verify.nsh
@@ -170,7 +170,7 @@ Var /GLOBAL AionUiActiveMarkerResult
 
 !macro AIONUI_VERIFY_CORE_APP_FILES
   !insertmacro AIONUI_LOG_EVENT "verify-install start instDir=$INSTDIR"
-  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\AionUi.exe" "AionUi.exe"
+  !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\${AIONUI_APP_EXECUTABLE_FILENAME}" "${AIONUI_APP_EXECUTABLE_FILENAME}"
   !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\ffmpeg.dll" "ffmpeg.dll"
   !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\libEGL.dll" "libEGL.dll"
   !insertmacro AIONUI_VERIFY_REQUIRED_FILE "$INSTDIR\libGLESv2.dll" "libGLESv2.dll"

--- a/resources/windows/support/query-lockers.ps1
+++ b/resources/windows/support/query-lockers.ps1
@@ -7,7 +7,9 @@ param(
   [string]$Version,
   [string]$Arch,
   [string]$Updated,
-  [string]$CurrentOutDir
+  [string]$CurrentOutDir,
+  [string]$AppExecutableFilename,
+  [string]$UninstallFilename
 )
 
 $ErrorActionPreference = 'SilentlyContinue'
@@ -78,8 +80,8 @@ try {
   } elseif ($targetPathFull -and (Test-Path -LiteralPath $targetPathFull -PathType Container)) {
     $topLevel = @(Get-ChildItem -LiteralPath $targetPathFull -Force -File -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName })
     $knownRelative = @(
-      'AionUi.exe',
-      'Uninstall AionUi.exe',
+      $AppExecutableFilename,
+      $UninstallFilename,
       'resources\app.asar',
       'resources\app-update.yml',
       'resources\bundled-aioncore\win32-x64\aioncore.exe'

--- a/tests/unit/bootstrap/buildWithBuilder.test.ts
+++ b/tests/unit/bootstrap/buildWithBuilder.test.ts
@@ -51,8 +51,8 @@ function resolveAppBuilderInstallUtil(): string {
 describe('build-with-builder', () => {
   it('rejects skip-vite when renderer output is only a source html shell', () => {
     const outDir = resolve(repoRoot, 'out');
-    const backupOutDir = resolve(repoRoot, `.tmp-out-backup-${process.pid}-${Date.now()}`);
     const tempDir = mkdtempSync(join(tmpdir(), 'aionui-build-skip-vite-test-'));
+    const backupOutDir = join(tempDir, 'out-backup');
     const hookPath = join(tempDir, 'hook.cjs');
 
     writeFileSync(
@@ -273,7 +273,7 @@ childProcess.execSync = function mockedExecSync(command) {
     const hookPath = join(tempDir, 'hook.cjs');
     const callsPath = join(tempDir, 'prepare-calls.json');
     const outDir = resolve(repoRoot, 'out');
-    const backupOutDir = resolve(repoRoot, `.tmp-out-backup-${process.pid}-${Date.now()}-${expectedArch}`);
+    const backupOutDir = join(tempDir, 'out-backup');
 
     writeFileSync(
       hookPath,

--- a/tests/unit/releasePackagingConfig.test.ts
+++ b/tests/unit/releasePackagingConfig.test.ts
@@ -21,6 +21,16 @@ function yamlBlock(content: string, key: string): string {
   return nextTopLevelKey === -1 ? rest : rest.slice(0, nextTopLevelKey);
 }
 
+function workflowStep(content: string, name: string): string {
+  const marker = `      - name: ${name}`;
+  const start = content.indexOf(marker);
+  if (start === -1) return '';
+
+  const rest = content.slice(start + marker.length);
+  const nextStep = rest.indexOf('\n      - name: ');
+  return nextStep === -1 ? rest : rest.slice(0, nextStep);
+}
+
 describe('release packaging configuration', () => {
   it('keeps mac zip artifacts enabled', () => {
     const config = readProjectFile('packages/desktop/electron-builder.yml');
@@ -37,6 +47,43 @@ describe('release packaging configuration', () => {
     expect(winBlock).toContain('    - nsis');
     expect(winBlock).not.toContain('    - zip');
   });
+
+  it('validates the packaged executable from the product identity at every installation phase', () => {
+    const productConfig = JSON.parse(readProjectFile('ki-buddy-product.json')) as {
+      electronBuilder: { executableName: string };
+    };
+    const installerChecks = [
+      readProjectFile('resources/windows/installer-observability.nsh'),
+      readProjectFile('resources/windows/installer-update-verify.nsh'),
+    ];
+
+    expect(productConfig.electronBuilder.executableName).toBe('Ki-Buddy');
+    for (const installerCheck of installerChecks) {
+      expect(installerCheck).toContain('"$INSTDIR\\${AIONUI_APP_EXECUTABLE_FILENAME}"');
+      expect(installerCheck).not.toContain('$INSTDIR\\AionUi.exe');
+    }
+  });
+
+  it('passes branded executable names to external Windows locker diagnostics', () => {
+    const processControl = readProjectFile('resources/windows/installer-process-control.nsh');
+    const queryLockers = readProjectFile('resources/windows/support/query-lockers.ps1');
+
+    expect(processControl).toContain('-AppExecutableFilename "${AIONUI_APP_EXECUTABLE_FILENAME}"');
+    expect(processControl).toContain('-UninstallFilename "${UNINSTALL_FILENAME}"');
+    expect(queryLockers).not.toMatch(/['"](?:Uninstall )?AionUi\.exe['"]/);
+  });
+
+  it.each(['_build-reusable.yml', 'pr-checks.yml'])(
+    'fails %s Windows installation smoke tests on a non-zero installer exit code',
+    (workflowName) => {
+      const workflow = readProjectFile(`.github/workflows/${workflowName}`);
+      const smokeStep = workflowStep(workflow, 'Silent install smoke test (Windows x64)');
+
+      expect(smokeStep).toContain('-PassThru');
+      expect(smokeStep).toContain('$process.ExitCode -ne 0');
+      expect(smokeStep).toContain('throw "Windows installer exited with code $($process.ExitCode)"');
+    }
+  );
 
   it('includes and unpacks the native keytar credential module', () => {
     const config = readProjectFile('packages/desktop/electron-builder.yml');


### PR DESCRIPTION
# Pull Request

## Description

Ki-Buddy v0.1.4 的 Windows 安装器在解压完成后仍固定检查 `AionUi.exe`，但产品实际生成的主程序是 `Ki-Buddy.exe`，因此安装器会错误报告 `E1010` 并以退出码 2 结束。后续完整性校验也存在相同硬编码，会在通过解压检查后触发 `E1031`。

本 PR：

- 使用 electron-builder 提供的 `APP_EXECUTABLE_FILENAME` 校验解压结果和最终安装结果，并在诊断日志中记录相同文件名。
- 将外部占用进程查询使用的主程序与卸载程序文件名改为产品变量。
- 让 PR Windows 安装测试检查静默安装器退出码，避免残留的已解压文件掩盖安装失败。
- 在正式发布构建中增加 Windows x64 静默安装测试，安装失败时阻止上传产物。
- 将构建测试的 `out` 备份放入用例独立临时目录，避免并行测试期间被 build evidence 当作 untracked source 扫描。

## Related Issues

- 无

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 4356 passed, 5 skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys — 本次没有新增应用内用户文案

附加验证：

- `bun run test:coverage` 通过；仓库当前总体覆盖率为 54.3% statements / 55.11% lines。
- 默认并行模式完整测试通过，验证了临时目录隔离修复。
- `just push --force-with-lease origin fix/windows-installer-executable-check` 全部检查通过。

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

没有在本地 Windows 实机生成并安装完整安装包；PR CI 和正式发布 workflow 会执行 Windows x64 静默安装测试。

## Screenshots

不适用。

## Additional Context

`resources/windows` 中剩余的 `AionUi-fixed-uninstaller.exe` 是 `$PLUGINSDIR` 内的安装器私有临时文件，最终复制目标仍使用 `${UNINSTALL_FILENAME}`，不影响 Ki-Buddy 安装目录中的品牌文件名。

`ki-buddy-v0.1.1` 至 `ki-buddy-v0.1.4` 的源码均存在产品可执行文件名与安装后校验文件名不一致的问题。本 PR 不修改、移动或覆盖任何已有 tag 和 Release 资产，修复应通过新的 Ki-Buddy patch 版本发布。
